### PR TITLE
fix(i18n): translate pre-existing __MISSING__ keys for combo.sort and credential health (#12272)

### DIFF
--- a/changelog.d/fixes/12272-missing-i18n.md
+++ b/changelog.d/fixes/12272-missing-i18n.md
@@ -1,0 +1,1 @@
+- **fix(i18n):** translate pre-existing `__MISSING__:` keys for `combo.sort`, `requestLogger.detail` expand/collapse, `common.profile`, and `settings.resilienceCredentialHealth*` across 39 locales ([#12272](https://github.com/diegosouzapw/OmniRoute/issues/12272))

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "حذف كافة الدفعات المكتملة",
     "batchListBatchesTable": "دفعات",
     "changelogViewerLoading": "جارٍ تحميل سجل التغيير من GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "الملف الشخصي",
     "profileLoading": "جارٍ تحميل الملف الشخصي...",
     "profileHowToEarn": "كيف تكسب",
     "bootstrapBannerDismiss": "استبعاد",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "عند التمكين، يتم تتبع المزودين الفاشلين عالمياً وتخطيهم لفترة تهدئة.",
     "resilienceProviderCooldownMin": "الحد الأدنى لفترة التهدئة",
     "resilienceProviderCooldownMax": "الحد الأقصى لفترة التهدئة",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "فحص صحة بيانات الاعتماد",
+    "resilienceCredentialHealthScope": "جميع اتصالات مفتاح API وOAuth النشطة",
+    "resilienceCredentialHealthTrigger": "دورياً، وفق إيقاع ثابت",
+    "resilienceCredentialHealthEffect": "يفحص بيانات اعتماد كل اتصال ويعلّمه نشطاً/خطأ؛ الاتصالات الفاشلة تتراجع أسياً",
+    "resilienceCredentialHealthDesc": "مسح خلفي يتحقق من بيانات اعتماد كل اتصال نشط باستدعاء مزوّده. عيّن 0 لتعطيل المسح بالكامل. قيم فحص الصحة لكل اتصال (في حوار تعديل الاتصال) تتجاوز دائماً هذا الإعداد العام.",
+    "resilienceCredentialHealthInterval": "فاصل الفحص العام",
+    "resilienceCredentialHealthEveryMinutes": "كل {minutes} دقائق",
+    "resilienceCredentialHealthHint": "0 يعطّل المسح الخلفي (الحد الأقصى 1440 دقيقة = 24 ساعة). الاتصالات ذات قيمة فحص صحة خاصة تتجاهل هذا الإعداد العام؛ القيمة 0 لاتصال معيّن تستثنيه حتى مع تشغيل المسح العام.",
     "forcedFingerprintTitle": "مُمكّن دائمًا لـ {provider} — مطلوب لسلامة حساب OAuth؛ لا يمكن إيقاف تشغيله.",
     "forcedFingerprintBadge": "مطلوب",
     "sessionAffinityTitle": "ترابط الجلسة",
@@ -11331,11 +11331,11 @@
       "copy": "نسخ",
       "autoscrollOn": "التمرير التلقائي: تشغيل",
       "autoscrollOff": "التScroll التلقائي: إيقاف",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "طي الكل",
+      "collapseOneLevel": "طي مستوى واحد",
+      "currentExpandLevel": "مستوى التوسيع الحالي",
+      "expandOneLevel": "توسيع مستوى واحد",
+      "expandAllLevels": "توسيع الكل",
       "payload": {
         "clientRawRequest": "طلب العميل الخام",
         "clientRequest": "طلب العميل",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "ترتيب حسب",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "يدوي",
+        "provider": "المزوّد",
+        "score": "النقاط (النماذج المجانية)",
+        "name": "الاسم"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "ترتيب النقاط ينطبق على المزوّدين المجانيين فقط؛ البقية تبقى في مكانها."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Bütün tamamlanmış partiyaları silin",
     "batchListBatchesTable": "Partiyalar",
     "changelogViewerLoading": "GitHub-dan dəyişiklik jurnalı yüklənir...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Profil yüklənir...",
     "profileHowToEarn": "Necə qazanmaq olar",
     "bootstrapBannerDismiss": "Rədd et",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Aktivləşdirildikdə, uğursuz provayderlər qlobal olaraq izlənilir və soyuma müddəti ərzində ötürülür.",
     "resilienceProviderCooldownMin": "Minimum soyuma müddəti",
     "resilienceProviderCooldownMax": "Maksimum soyuma müddəti",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Etibarnamə sağlamlıq yoxlaması",
+    "resilienceCredentialHealthScope": "Bütün aktiv API-açar və OAuth bağlantıları",
+    "resilienceCredentialHealthTrigger": "Dövri, sabit ritmlə",
+    "resilienceCredentialHealthEffect": "Hər bağlantının etibarnaməsini yoxlayır və aktiv/xəta kimi işarələyir; uğursuz bağlantılar eksponensial geriləyir",
+    "resilienceCredentialHealthDesc": "Hər aktiv bağlantının etibarnaməsini provayderə zəng edərək yoxlayan fon tarama. Tamamilə söndürmək üçün 0 təyin edin. Hər bağlantının öz Sağlamlıq Yoxlaması dəyəri (redaktə dialoqunda) həmişə bu qlobal standartı üstələyir.",
+    "resilienceCredentialHealthInterval": "Qlobal yoxlama intervalı",
+    "resilienceCredentialHealthEveryMinutes": "Hər {minutes} dəq",
+    "resilienceCredentialHealthHint": "0 fon taramasını söndürür (maks. 1440 dəq = 24 saat). Öz Sağlamlıq Yoxlaması dəyəri olan bağlantılar bu qlobal standartı nəzərə almır; bir bağlantıda 0 onu qlobal tarama açıq olsa belə çıxarır.",
     "forcedFingerprintTitle": "{provider} üçün həmişə aktivdir — OAuth hesabının təhlükəsizliyi üçün tələb olunur; söndürülə bilməz.",
     "forcedFingerprintBadge": "Tələb olunur",
     "sessionAffinityTitle": "Sessiya yaxınlığı (affinity)",
@@ -11331,11 +11331,11 @@
       "copy": "Kopyala",
       "autoscrollOn": "Avtomatik Sürüş: açıq",
       "autoscrollOff": "Avtomatik Sürüş: söndürüldü",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Hamısını yığ",
+      "collapseOneLevel": "Bir səviyyə yığ",
+      "currentExpandLevel": "Cari açılma səviyyəsi",
+      "expandOneLevel": "Bir səviyyə aç",
+      "expandAllLevels": "Hamısını aç",
       "payload": {
         "clientRawRequest": "Müştəri Xam Sorğu",
         "clientRequest": "Müştəri Tələbi",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sırala",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Əl ilə",
+        "provider": "Provayder",
+        "score": "Bal (pulsuz modellər)",
+        "name": "Ad"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Bal sıralaması yalnız pulsuz provayderlərə aiddir; qalanlar yerində qalır."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Изтрийте всички завършени партиди",
     "batchListBatchesTable": "Партиди",
     "changelogViewerLoading": "Регистърът на промените се зарежда от GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Профил",
     "profileLoading": "Профилът се зарежда...",
     "profileHowToEarn": "Как да печелите",
     "bootstrapBannerDismiss": "Отхвърляне",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Когато е активирано, неуспешните доставчици се проследяват глобално и се пропускат за cooldown период.",
     "resilienceProviderCooldownMin": "Минимален cooldown",
     "resilienceProviderCooldownMax": "Максимален cooldown",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Проверка на здравето на идентификационните данни",
+    "resilienceCredentialHealthScope": "Всички активни API-ключ и OAuth връзки",
+    "resilienceCredentialHealthTrigger": "Периодично, с фиксиран ритъм",
+    "resilienceCredentialHealthEffect": "Проверява идентификационните данни на всяка връзка и я маркира активна/грешка; неуспешните връзки се отлагат експоненциално",
+    "resilienceCredentialHealthDesc": "Фоново сканиране, което валидира идентификационните данни на всяка активна връзка, като извиква доставчика ѝ. Задайте 0, за да го изключите напълно. Стойностите за проверка на здравето на отделна връзка (в диалога за редактиране) винаги заменят този глобален по подразбиране.",
+    "resilienceCredentialHealthInterval": "Глобален интервал на проверка",
+    "resilienceCredentialHealthEveryMinutes": "На всеки {minutes} мин",
+    "resilienceCredentialHealthHint": "0 изключва фоновото сканиране (макс. 1440 мин = 24 ч). Връзки със собствена стойност за проверка на здравето игнорират този глобален по подразбиране; 0 за дадена връзка я изключва дори когато глобалното сканиране е включено.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Сесиен афинитет",
@@ -11331,11 +11331,11 @@
       "copy": "Копирай",
       "autoscrollOn": "Автоскрол: включен",
       "autoscrollOff": "Автоскрол: изключен",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Свий всички",
+      "collapseOneLevel": "Свий едно ниво",
+      "currentExpandLevel": "Текущо ниво на разгъване",
+      "expandOneLevel": "Разгъни едно ниво",
+      "expandAllLevels": "Разгъни всички",
       "payload": {
         "clientRawRequest": "Клиентска Сурова Заявка",
         "clientRequest": "Заявка от клиента",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Сортирай по",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Ръчно",
+        "provider": "Доставчик",
+        "score": "Резултат (безплатни модели)",
+        "name": "Име"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Класирането по резултат важи само за безплатни доставчици; останалите остават на място."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "সমস্ত সমাপ্ত ব্যাচ মুছুন",
     "batchListBatchesTable": "ব্যাচ",
     "changelogViewerLoading": "GitHub থেকে চেঞ্জলগ লোড হচ্ছে...",
-    "profile": "__MISSING__:Profile",
+    "profile": "প্রোফাইল",
     "profileLoading": "প্রোফাইল লোড হচ্ছে...",
     "profileHowToEarn": "কিভাবে আয় করা যায়",
     "bootstrapBannerDismiss": "খারিজ",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "সক্ষম করা হলে, ব্যর্থ প্রোভাইডারগুলিকে বিশ্বব্যাপী ট্র্যাক করা হয় এবং একটি কুলডাউন সময়ের জন্য এড়িয়ে যাওয়া হয়।",
     "resilienceProviderCooldownMin": "সর্বনিম্ন কুলডাউন",
     "resilienceProviderCooldownMax": "সর্বোচ্চ কুলডাউন",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "ক্রেডেনশিয়াল স্বাস্থ্য পরীক্ষা",
+    "resilienceCredentialHealthScope": "সব সক্রিয় API-কি এবং OAuth সংযোগ",
+    "resilienceCredentialHealthTrigger": "নির্দিষ্ট ছন্দে পর্যায়ক্রমে",
+    "resilienceCredentialHealthEffect": "প্রতিটি সংযোগের ক্রেডেনশিয়াল পরীক্ষা করে সক্রিয়/ত্রুটি চিহ্নিত করে; ব্যর্থ সংযোগ সূচকীয় ব্যাকঅফ নেয়",
+    "resilienceCredentialHealthDesc": "পটভূমি স্ক্যান যা প্রতিটি সক্রিয় সংযোগের ক্রেডেনশিয়াল তার প্রদানকারীকে কল করে যাচাই করে। সম্পূর্ণ বন্ধ করতে 0 সেট করুন। প্রতি-সংযোগ স্বাস্থ্য পরীক্ষার মান (সম্পাদনা ডায়ালগে) সবসময় এই বৈশ্বিক ডিফল্টকে ওভাররাইড করে।",
+    "resilienceCredentialHealthInterval": "বৈশ্বিক পরীক্ষার ব্যবধান",
+    "resilienceCredentialHealthEveryMinutes": "প্রতি {minutes} মিনিট",
+    "resilienceCredentialHealthHint": "0 পটভূমি স্ক্যান বন্ধ করে (সর্বোচ্চ 1440 মিনিট = 24 ঘণ্টা)। নিজস্ব স্বাস্থ্য পরীক্ষা মানযুক্ত সংযোগ এই বৈশ্বিক ডিফল্ট উপেক্ষা করে; কোনো সংযোগে 0 সেট করলে বৈশ্বিক স্ক্যান চালু থাকলেও সেটি বাদ পড়ে।",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "সেশন অ্যাফিনিটি",
@@ -11331,11 +11331,11 @@
       "copy": "কপি করুন",
       "autoscrollOn": "অটোস্ক্রল: চালু",
       "autoscrollOff": "অটোস্ক্রোল: বন্ধ",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "সব গুটিয়ে ফেলুন",
+      "collapseOneLevel": "এক স্তর গুটিয়ে ফেলুন",
+      "currentExpandLevel": "বর্তমান প্রসারণ স্তর",
+      "expandOneLevel": "এক স্তর প্রসারিত করুন",
+      "expandAllLevels": "সব প্রসারিত করুন",
       "payload": {
         "clientRawRequest": "ক্লায়েন্ট কাঁচা অনুরোধ",
         "clientRequest": "ক্লায়েন্টের অনুরোধ",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "সাজান",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "ম্যানুয়াল",
+        "provider": "প্রদানকারী",
+        "score": "স্কোর (বিনামূল্যের মডেল)",
+        "name": "নাম"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "স্কোর অনুসারে সাজানো শুধু বিনামূল্যের প্রদানকারীদের জন্য; বাকিরা জায়গায় থাকে।"
     }
   },
   "comboControl": {

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Odstraňte všechny dokončené dávky",
     "batchListBatchesTable": "Dávky",
     "changelogViewerLoading": "Načítání protokolu změn z GitHubu...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Načítání profilu...",
     "profileHowToEarn": "Jak vydělat",
     "bootstrapBannerDismiss": "Odmítnout",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Pokud je povoleno, selhaní poskytovatelé jsou sledováni globálně a po dobu cooldownu jsou přeskakováni.",
     "resilienceProviderCooldownMin": "Minimální cooldown",
     "resilienceProviderCooldownMax": "Maximální cooldown",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Kontrola zdraví přihlašovacích údajů",
+    "resilienceCredentialHealthScope": "Všechna aktivní API-klíč a OAuth připojení",
+    "resilienceCredentialHealthTrigger": "Pravidelně, pevným rytmem",
+    "resilienceCredentialHealthEffect": "Ověří přihlašovací údaje každého připojení a označí ho aktivní/chyba; neúspěšná připojení se exponenciálně odkládají",
+    "resilienceCredentialHealthDesc": "Prohledávání na pozadí, které ověřuje přihlašovací údaje každého aktivního připojení voláním jeho poskytovatele. Nastavte 0 pro úplné vypnutí. Hodnoty kontroly zdraví u jednotlivého připojení (v dialogu úprav) vždy přepíší toto globální výchozí nastavení.",
+    "resilienceCredentialHealthInterval": "Globální interval kontroly",
+    "resilienceCredentialHealthEveryMinutes": "Každých {minutes} min",
+    "resilienceCredentialHealthHint": "0 vypne prohledávání na pozadí (max. 1440 min = 24 h). Připojení s vlastní hodnotou kontroly zdraví toto globální výchozí nastavení ignorují; 0 u konkrétního připojení ho vyřadí, i když je globální prohledávání zapnuté.",
     "forcedFingerprintTitle": "Vždy aktivní pro {provider} — vyžadováno pro bezpečnost OAuth účtu; nelze vypnout.",
     "forcedFingerprintBadge": "Vyžadováno",
     "sessionAffinityTitle": "Afinita relací",
@@ -11331,11 +11331,11 @@
       "copy": "Kopírovat",
       "autoscrollOn": "Automatické posouvání: zapnuto",
       "autoscrollOff": "Automatické posouvání: vypnuto",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Sbalit vše",
+      "collapseOneLevel": "Sbalit o úroveň",
+      "currentExpandLevel": "Aktuální úroveň rozbalení",
+      "expandOneLevel": "Rozbalit o úroveň",
+      "expandAllLevels": "Rozbalit vše",
       "payload": {
         "clientRawRequest": "Klientský Raw Request",
         "clientRequest": "Žádost klienta",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Řadit podle",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Ručně",
+        "provider": "Poskytovatel",
+        "score": "Skóre (bezplatné modely)",
+        "name": "Název"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Řazení podle skóre platí jen pro bezplatné poskytovatele; ostatní zůstanou na místě."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Slet alle afsluttede batches",
     "batchListBatchesTable": "Batcher",
     "changelogViewerLoading": "Indlæser ændringslog fra GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Indlæser profil...",
     "profileHowToEarn": "Hvordan man tjener",
     "bootstrapBannerDismiss": "Afvis",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Når den er aktiveret, spores fejlende udbydere globalt og springes over i en afkølingsperiode.",
     "resilienceProviderCooldownMin": "Minimumsafkøling",
     "resilienceProviderCooldownMax": "Maksimumsafkøling",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Sundhedstjek af legitimationsoplysninger",
+    "resilienceCredentialHealthScope": "Alle aktive API-nøgle- og OAuth-forbindelser",
+    "resilienceCredentialHealthTrigger": "Periodisk, i fast rytme",
+    "resilienceCredentialHealthEffect": "Tjekker hver forbindelses legitimationsoplysninger og markerer den aktiv/fejl; fejlslagne forbindelser bakker eksponentielt",
+    "resilienceCredentialHealthDesc": "Baggrundsscanning, der validerer hver aktiv forbindelses legitimationsoplysninger ved at kalde dens udbyder. Sæt 0 for at slå scanningen helt fra. Sundhedstjek-værdier pr. forbindelse (i redigeringsdialogen) tilsidesætter altid denne globale standard.",
+    "resilienceCredentialHealthInterval": "Globalt kontrolinterval",
+    "resilienceCredentialHealthEveryMinutes": "Hver {minutes} min",
+    "resilienceCredentialHealthHint": "0 slår baggrundsscanningen fra (maks. 1440 min = 24 t). Forbindelser med egen sundhedstjek-værdi ignorerer denne globale standard; 0 på en forbindelse udelader den, selv når den globale scanning kører.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Sessionsaffinitet",
@@ -11331,11 +11331,11 @@
       "copy": "Kopier",
       "autoscrollOn": "Autoscroll: til",
       "autoscrollOff": "Autoscroll: fra",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Skjul alle",
+      "collapseOneLevel": "Skjul ét niveau",
+      "currentExpandLevel": "Aktuelt udfoldningsniveau",
+      "expandOneLevel": "Udvid ét niveau",
+      "expandAllLevels": "Udvid alle",
       "payload": {
         "clientRawRequest": "Klient Rå Anmodning",
         "clientRequest": "Klientanmodning",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sortér efter",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manuel",
+        "provider": "Udbyder",
+        "score": "Score (gratis modeller)",
+        "name": "Navn"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Score-rangering gælder kun gratis udbydere; de øvrige bliver stående."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Löschen Sie alle abgeschlossenen Chargen",
     "batchListBatchesTable": "Chargen",
     "changelogViewerLoading": "Änderungsprotokoll von GitHub wird geladen...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Profil wird geladen...",
     "profileHowToEarn": "So verdienen Sie",
     "bootstrapBannerDismiss": "Entlassen",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Wenn diese Option aktiviert ist, werden fehlgeschlagene Anbieter global nachverfolgt und für eine Cooldown-Phase übersprungen.",
     "resilienceProviderCooldownMin": "Minimaler Cooldown",
     "resilienceProviderCooldownMax": "Maximaler Cooldown",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Anmeldedaten-Gesundheitsprüfung",
+    "resilienceCredentialHealthScope": "Alle aktiven API-Schlüssel- und OAuth-Verbindungen",
+    "resilienceCredentialHealthTrigger": "Periodisch, in festem Takt",
+    "resilienceCredentialHealthEffect": "Prüft die Anmeldedaten jeder Verbindung und markiert sie aktiv/Fehler; fehlgeschlagene Verbindungen gehen in exponentielles Backoff",
+    "resilienceCredentialHealthDesc": "Hintergrundscan, der die Anmeldedaten jeder aktiven Verbindung durch einen Aufruf beim Anbieter prüft. 0 schaltet den Scan vollständig ab. Gesundheitsprüfwerte pro Verbindung (im Bearbeitungsdialog) überschreiben immer diese globale Vorgabe.",
+    "resilienceCredentialHealthInterval": "Globales Prüfintervall",
+    "resilienceCredentialHealthEveryMinutes": "Alle {minutes} Min",
+    "resilienceCredentialHealthHint": "0 deaktiviert den Hintergrundscan (max. 1440 Min = 24 h). Verbindungen mit eigenem Gesundheitsprüfwert ignorieren diese globale Vorgabe; 0 bei einer Verbindung nimmt sie auch bei laufendem globalem Scan aus.",
     "forcedFingerprintTitle": "Für {provider} immer aktiviert — erforderlich für die Sicherheit von OAuth-Konten; kann nicht deaktiviert werden.",
     "forcedFingerprintBadge": "Erforderlich",
     "sessionAffinityTitle": "Sitzungsaffinität",
@@ -11338,11 +11338,11 @@
       "copy": "Kopieren",
       "autoscrollOn": "Autoscroll: ein",
       "autoscrollOff": "Autoscroll: aus",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Alle einklappen",
+      "collapseOneLevel": "Eine Ebene einklappen",
+      "currentExpandLevel": "Aktuelle Ausklappebene",
+      "expandOneLevel": "Eine Ebene ausklappen",
+      "expandAllLevels": "Alle ausklappen",
       "payload": {
         "clientRawRequest": "Client Rohanfrage",
         "clientRequest": "Kundenanfrage",
@@ -13008,14 +13008,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sortieren nach",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manuell",
+        "provider": "Anbieter",
+        "score": "Punktzahl (kostenlose Modelle)",
+        "name": "Name"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Die Punktzahl-Reihenfolge gilt nur für kostenlose Anbieter; alle anderen bleiben an Ort und Stelle."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Eliminar todos los lotes completados",
     "batchListBatchesTable": "Lotes",
     "changelogViewerLoading": "Cargando registro de cambios desde GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Perfil",
     "profileLoading": "Cargando perfil...",
     "profileHowToEarn": "como ganar",
     "bootstrapBannerDismiss": "Descartar",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "When enabled, failed providers are tracked globally and skipped for a cooldown period.",
     "resilienceProviderCooldownMin": "Minimum cooldown",
     "resilienceProviderCooldownMax": "Maximum cooldown",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Comprobación de salud de credenciales",
+    "resilienceCredentialHealthScope": "Todas las conexiones activas de clave API y OAuth",
+    "resilienceCredentialHealthTrigger": "Periódicamente, con cadencia fija",
+    "resilienceCredentialHealthEffect": "Comprueba la credencial de cada conexión y la marca activa/error; las conexiones fallidas entran en backoff exponencial",
+    "resilienceCredentialHealthDesc": "Barrido en segundo plano que valida la credencial de cada conexión activa llamando a su proveedor. Pon 0 para desactivarlo por completo. Los valores de comprobación de salud por conexión (en el diálogo de edición) siempre anulan este valor global.",
+    "resilienceCredentialHealthInterval": "Intervalo global de comprobación",
+    "resilienceCredentialHealthEveryMinutes": "Cada {minutes} min",
+    "resilienceCredentialHealthHint": "0 desactiva el barrido en segundo plano (máx. 1440 min = 24 h). Las conexiones con su propio valor de comprobación de salud ignoran este valor global; un 0 en una conexión la excluye aunque el barrido global esté activo.",
     "forcedFingerprintTitle": "Siempre activado para {provider}; necesario para la seguridad de las cuentas OAuth y no se puede desactivar.",
     "forcedFingerprintBadge": "Obligatorio",
     "sessionAffinityTitle": "Session affinity",
@@ -11331,11 +11331,11 @@
       "copy": "Copiar",
       "autoscrollOn": "Desplazamiento automático: activado",
       "autoscrollOff": "Desplazamiento automático: desactivado",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Contraer todo",
+      "collapseOneLevel": "Contraer un nivel",
+      "currentExpandLevel": "Nivel de expansión actual",
+      "expandOneLevel": "Expandir un nivel",
+      "expandAllLevels": "Expandir todo",
       "payload": {
         "clientRawRequest": "Solicitud Cruda del Cliente",
         "clientRequest": "Solicitud del Cliente",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Ordenar por",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manual",
+        "provider": "Proveedor",
+        "score": "Puntuación (modelos gratuitos)",
+        "name": "Nombre"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "La clasificación por puntuación solo aplica a proveedores gratuitos; el resto se queda en su sitio."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "تمام دسته های تکمیل شده را حذف کنید",
     "batchListBatchesTable": "دسته ها",
     "changelogViewerLoading": "در حال بارگیری تغییرات از GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "نمایه",
     "profileLoading": "در حال بارگیری نمایه...",
     "profileHowToEarn": "نحوه کسب درآمد",
     "bootstrapBannerDismiss": "رد کردن",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "در صورت فعال بودن، ارائه‌دهندگان ناموفق به صورت سراسری ردیابی شده و برای یک دوره کول‌داون نادیده گرفته می‌شوند.",
     "resilienceProviderCooldownMin": "حداقل کول‌داون",
     "resilienceProviderCooldownMax": "حداکثر کول‌داون",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "بررسی سلامت اعتبارنامه",
+    "resilienceCredentialHealthScope": "همه اتصال‌های فعال کلید API و OAuth",
+    "resilienceCredentialHealthTrigger": "دوره‌ای، با آهنگ ثابت",
+    "resilienceCredentialHealthEffect": "اعتبارنامه هر اتصال را می‌سنجد و آن را فعال/خطا علامت می‌زند؛ اتصال‌های ناموفق عقب‌نشینی نمایی می‌گیرند",
+    "resilienceCredentialHealthDesc": "پویش پس‌زمینه که اعتبارنامه هر اتصال فعال را با فراخوانی ارائه‌دهنده‌اش تأیید می‌کند. برای خاموش کردن کامل، 0 بگذارید. مقدار بررسی سلامت هر اتصال (در گفتگوی ویرایش) همیشه این پیش‌فرض سراسری را لغو می‌کند.",
+    "resilienceCredentialHealthInterval": "بازه بررسی سراسری",
+    "resilienceCredentialHealthEveryMinutes": "هر {minutes} دقیقه",
+    "resilienceCredentialHealthHint": "0 پویش پس‌زمینه را خاموش می‌کند (حداکثر 1440 دقیقه = 24 ساعت). اتصال‌هایی با مقدار بررسی سلامت خودشان این پیش‌فرض سراسری را نادیده می‌گیرند؛ 0 برای یک اتصال آن را حتی با پویش سراسری روشن کنار می‌گذارد.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "وابستگی نشست",
@@ -11331,11 +11331,11 @@
       "copy": "کپی",
       "autoscrollOn": "اسکرول خودکار: روشن",
       "autoscrollOff": "حرکت خودکار: خاموش",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "بستن همه",
+      "collapseOneLevel": "بستن یک سطح",
+      "currentExpandLevel": "سطح گسترش فعلی",
+      "expandOneLevel": "گسترش یک سطح",
+      "expandAllLevels": "گسترش همه",
       "payload": {
         "clientRawRequest": "درخواست خام کلاینت",
         "clientRequest": "درخواست مشتری",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "مرتب‌سازی بر اساس",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "دستی",
+        "provider": "ارائه‌دهنده",
+        "score": "امتیاز (مدل‌های رایگان)",
+        "name": "نام"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "رتبه‌بندی امتیازی فقط برای ارائه‌دهندگان رایگان است؛ بقیه سر جای خود می‌مانند."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Poista kaikki valmiit erät",
     "batchListBatchesTable": "Erät",
     "changelogViewerLoading": "Ladataan muutoslokia GitHubista...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profiili",
     "profileLoading": "Ladataan profiilia...",
     "profileHowToEarn": "Kuinka ansaita",
     "bootstrapBannerDismiss": "Hylkää",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Kun tämä on käytössä, epäonnistuneita palveluntarjoajia seurataan globaalisti ja ne ohitetaan jäähdytysajan ajaksi.",
     "resilienceProviderCooldownMin": "Vähimmäisjäähdytysaika",
     "resilienceProviderCooldownMax": "Enimmäisjäähdytysaika",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Tunnusten terveystarkistus",
+    "resilienceCredentialHealthScope": "Kaikki aktiiviset API-avain- ja OAuth-yhteydet",
+    "resilienceCredentialHealthTrigger": "Säännöllisesti, kiinteällä tahdilla",
+    "resilienceCredentialHealthEffect": "Tarkistaa kunkin yhteyden tunnukset ja merkitsee sen aktiiviseksi/virheeksi; epäonnistuneet yhteydet siirtyvät eksponentiaaliseen odotukseen",
+    "resilienceCredentialHealthDesc": "Taustaskannaus, joka vahvistaa jokaisen aktiivisen yhteyden tunnukset kutsumalla sen palveluntarjoajaa. Aseta 0 poistaaksesi skannauksen kokonaan käytöstä. Yhteyskohtaiset terveystarkistusarvot (muokkausikkunassa) ohittavat aina tämän yleisen oletuksen.",
+    "resilienceCredentialHealthInterval": "Yleinen tarkistusväli",
+    "resilienceCredentialHealthEveryMinutes": "Joka {minutes} min",
+    "resilienceCredentialHealthHint": "0 poistaa taustaskannauksen käytöstä (enint. 1440 min = 24 h). Yhteydet, joilla on oma terveystarkistusarvo, ohittavat tämän yleisen oletuksen; 0 yhdellä yhteydellä jättää sen pois, vaikka yleinen skannaus olisi päällä.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Istuntoaffiniteetti",
@@ -11331,11 +11331,11 @@
       "copy": "Kopioi",
       "autoscrollOn": "Autoskrollaus: päällä",
       "autoscrollOff": "Autoskrollaus: pois",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Tiivistä kaikki",
+      "collapseOneLevel": "Tiivistä yksi taso",
+      "currentExpandLevel": "Nykyinen laajennustaso",
+      "expandOneLevel": "Laajenna yksi taso",
+      "expandAllLevels": "Laajenna kaikki",
       "payload": {
         "clientRawRequest": "Asiakkaan Raaka Pyyntö",
         "clientRequest": "Asiakaspyyntö",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Lajittele",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manuaalinen",
+        "provider": "Palveluntarjoaja",
+        "score": "Pisteet (ilmaiset mallit)",
+        "name": "Nimi"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Pistejärjestys koskee vain ilmaisia palveluntarjoajia; muut pysyvät paikoillaan."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Supprimer tous les lots terminés",
     "batchListBatchesTable": "Lots",
     "changelogViewerLoading": "Chargement du journal des modifications depuis GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Chargement du profil...",
     "profileHowToEarn": "Comment gagner",
     "bootstrapBannerDismiss": "Rejeter",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Lorsque cette option est activée, les fournisseurs défaillants sont suivis globalement et ignorés pendant une période de cooldown.",
     "resilienceProviderCooldownMin": "Cooldown minimum",
     "resilienceProviderCooldownMax": "Cooldown maximum",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Contrôle de santé des identifiants",
+    "resilienceCredentialHealthScope": "Toutes les connexions actives par clé API et OAuth",
+    "resilienceCredentialHealthTrigger": "Périodiquement, à cadence fixe",
+    "resilienceCredentialHealthEffect": "Vérifie l’identifiant de chaque connexion et la marque active/erreur ; les connexions en échec passent en backoff exponentiel",
+    "resilienceCredentialHealthDesc": "Balayage en arrière-plan qui valide l’identifiant de chaque connexion active en appelant son fournisseur. Mettez 0 pour le désactiver entièrement. Les valeurs de contrôle de santé par connexion (dans la boîte d’édition) remplacent toujours cette valeur globale.",
+    "resilienceCredentialHealthInterval": "Intervalle de contrôle global",
+    "resilienceCredentialHealthEveryMinutes": "Toutes les {minutes} min",
+    "resilienceCredentialHealthHint": "0 désactive le balayage en arrière-plan (max. 1440 min = 24 h). Les connexions avec leur propre valeur de contrôle de santé ignorent cette valeur globale ; un 0 sur une connexion l’exclut même si le balayage global est actif.",
     "forcedFingerprintTitle": "Toujours activé pour {provider} — requis pour la sécurité des comptes OAuth ; ne peut pas être désactivé.",
     "forcedFingerprintBadge": "Obligatoire",
     "sessionAffinityTitle": "Affinité de session",
@@ -11331,11 +11331,11 @@
       "copy": "Copier",
       "autoscrollOn": "Défilement automatique : activé",
       "autoscrollOff": "Défilement automatique : désactivé",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Tout replier",
+      "collapseOneLevel": "Replier un niveau",
+      "currentExpandLevel": "Niveau d’expansion actuel",
+      "expandOneLevel": "Déplier un niveau",
+      "expandAllLevels": "Tout déplier",
       "payload": {
         "clientRawRequest": "Requête brute du client",
         "clientRequest": "Requête du client",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Trier par",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manuel",
+        "provider": "Fournisseur",
+        "score": "Score (modèles gratuits)",
+        "name": "Nom"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Le classement par score ne s’applique qu’aux fournisseurs gratuits ; les autres restent en place."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "બધા પૂર્ણ થયેલ બેચ કાઢી નાખો",
     "batchListBatchesTable": "બેચ",
     "changelogViewerLoading": "GitHub માંથી ચેન્જલોગ લોડ કરી રહ્યું છે...",
-    "profile": "__MISSING__:Profile",
+    "profile": "પ્રોફાઇલ",
     "profileLoading": "પ્રોફાઇલ લોડ કરી રહ્યું છે...",
     "profileHowToEarn": "કેવી રીતે કમાવું",
     "bootstrapBannerDismiss": "કાઢી નાખો",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "જ્યારે સક્ષમ હોય, ત્યારે નિષ્ફળ પ્રદાતાઓને વૈશ્વિક સ્તરે ટ્રૅક કરવામાં આવે છે અને કૂલડાઉન સમયગાળા માટે છોડી દેવામાં આવે છે.",
     "resilienceProviderCooldownMin": "ન્યૂનતમ કૂલડાઉન",
     "resilienceProviderCooldownMax": "મહત્તમ કૂલડાઉન",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "ક્રેડેન્શિયલ આરોગ્ય તપાસ",
+    "resilienceCredentialHealthScope": "બધા સક્રિય API-કી અને OAuth કનેક્શન",
+    "resilienceCredentialHealthTrigger": "નિયત તાલે સામયિક",
+    "resilienceCredentialHealthEffect": "દરેક કનેક્શનની ક્રેડેન્શિયલ તપાસે છે અને સક્રિય/ભૂલ ચિહ્નિત કરે છે; નિષ્ફળ કનેક્શન ઘાતાંકીય બેકઓફ લે છે",
+    "resilienceCredentialHealthDesc": "પૃષ્ઠભૂમિ સ્કેન જે દરેક સક્રિય કનેક્શનની ક્રેડેન્શિયલ તેના પ્રદાતાને કૉલ કરીને ચકાસે છે. સંપૂર્ણ બંધ કરવા 0 સેટ કરો. પ્રતિ-કનેક્શન આરોગ્ય તપાસ મૂલ્યો (સંપાદન સંવાદમાં) હંમેશા આ વૈશ્વિક ડિફોલ્ટને ઓવરરાઇડ કરે છે.",
+    "resilienceCredentialHealthInterval": "વૈશ્વિક તપાસ અંતરાલ",
+    "resilienceCredentialHealthEveryMinutes": "દર {minutes} મિનિટ",
+    "resilienceCredentialHealthHint": "0 પૃષ્ઠભૂમિ સ્કેન બંધ કરે છે (મહત્તમ 1440 મિનિટ = 24 કલાક). પોતાના આરોગ્ય તપાસ મૂલ્યવાળા કનેક્શન આ વૈશ્વિક ડિફોલ્ટ અવગણે છે; કોઈ કનેક્શન પર 0 તેને વૈશ્વિક સ્કેન ચાલુ હોય ત્યારે પણ બાકાત રાખે છે.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "સત્ર અફિનિટી",
@@ -11331,11 +11331,11 @@
       "copy": "કોપી",
       "autoscrollOn": "ઓટોસ્ક્રોલ: ચાલુ",
       "autoscrollOff": "ઑટોસ્ક્રોલ: બંધ",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "બધું સંકુચિત કરો",
+      "collapseOneLevel": "એક સ્તર સંકુચિત કરો",
+      "currentExpandLevel": "વર્તમાન વિસ્તરણ સ્તર",
+      "expandOneLevel": "એક સ્તર વિસ્તારો",
+      "expandAllLevels": "બધું વિસ્તારો",
       "payload": {
         "clientRawRequest": "ક્લાયન્ટ કાચી વિનંતી",
         "clientRequest": "ક્લાયન્ટ વિનંતી",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "આના પ્રમાણે ગોઠવો",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "મેન્યુઅલ",
+        "provider": "પ્રદાતા",
+        "score": "સ્કોર (મફત મોડલ)",
+        "name": "નામ"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "સ્કોર ક્રમ માત્ર મફત પ્રદાતાઓને લાગુ પડે છે; બાકીના જગ્યાએ રહે છે."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "מחק את כל האצוות שהושלמו",
     "batchListBatchesTable": "אצוות",
     "changelogViewerLoading": "טוען יומן שינויים מ-GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "פרופיל",
     "profileLoading": "טוען פרופיל...",
     "profileHowToEarn": "איך להרוויח",
     "bootstrapBannerDismiss": "לבטל",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "כאשר מופעל, ספקים שנכשלו מנוטרים באופן גלובלי ומדולגים למשך תקופת צינון.",
     "resilienceProviderCooldownMin": "תקופת צינון מינימלית",
     "resilienceProviderCooldownMax": "תקופת צינון מרבית",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "בדיקת תקינות אישורים",
+    "resilienceCredentialHealthScope": "כל חיבורי מפתח API ו-OAuth הפעילים",
+    "resilienceCredentialHealthTrigger": "מעת לעת, בקצב קבוע",
+    "resilienceCredentialHealthEffect": "בודק את האישור של כל חיבור ומסמן אותו פעיל/שגיאה; חיבורים שנכשלו נכנסים להמתנה מעריכית",
+    "resilienceCredentialHealthDesc": "סריקת רקע שמוודאת את האישור של כל חיבור פעיל בקריאה לספק שלו. הגדר 0 כדי לכבות לגמרי. ערכי בדיקת תקינות לכל חיבור (בחלון העריכה) תמיד גוברים על ברירת המחדל הגלובלית הזו.",
+    "resilienceCredentialHealthInterval": "מרווח בדיקה גלובלי",
+    "resilienceCredentialHealthEveryMinutes": "כל {minutes} דק׳",
+    "resilienceCredentialHealthHint": "0 מכבה את סריקת הרקע (מקסימום 1440 דק׳ = 24 שע׳). חיבורים עם ערך בדיקת תקינות משלהם מתעלמים מברירת המחדל הגלובלית; 0 בחיבור מסוים מוציא אותו גם כשהסריקה הגלובלית פועלת.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "שיוך הפעלה (Session affinity)",
@@ -11331,11 +11331,11 @@
       "copy": "העתק",
       "autoscrollOn": "גלילה אוטומטית: מופעלת",
       "autoscrollOff": "גלילה אוטומטית: כבוי",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "כווץ הכול",
+      "collapseOneLevel": "כווץ רמה אחת",
+      "currentExpandLevel": "רמת ההרחבה הנוכחית",
+      "expandOneLevel": "הרחב רמה אחת",
+      "expandAllLevels": "הרחב הכול",
       "payload": {
         "clientRawRequest": "בקשת גולש גולמית",
         "clientRequest": "בקשת לקוח",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "מיין לפי",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "ידני",
+        "provider": "ספק",
+        "score": "ציון (מודלים חינמיים)",
+        "name": "שם"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "דירוג לפי ציון חל רק על ספקים חינמיים; האחרים נשארים במקומם."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "सभी पूर्ण बैच हटाएँ",
     "batchListBatchesTable": "बैच",
     "changelogViewerLoading": "GitHub से चेंजलॉग लोड हो रहा है...",
-    "profile": "__MISSING__:Profile",
+    "profile": "प्रोफ़ाइल",
     "profileLoading": "प्रोफ़ाइल लोड हो रही है...",
     "profileHowToEarn": "कैसे कमाए",
     "bootstrapBannerDismiss": "ख़ारिज करें",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "सक्षम होने पर, विफल प्रदाताओं को विश्व स्तर पर ट्रैक किया जाता है और कूलडाउन अवधि के लिए छोड़ दिया जाता है।",
     "resilienceProviderCooldownMin": "न्यूनतम कूलडाउन",
     "resilienceProviderCooldownMax": "अधिकतम कूलडाउन",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "क्रेडेंशियल स्वास्थ्य जाँच",
+    "resilienceCredentialHealthScope": "सभी सक्रिय API-की और OAuth कनेक्शन",
+    "resilienceCredentialHealthTrigger": "निश्चित लय पर समय-समय पर",
+    "resilienceCredentialHealthEffect": "हर कनेक्शन की क्रेडेंशियल जाँचता है और सक्रिय/त्रुटि चिह्नित करता है; विफल कनेक्शन घातांकीय बैकऑफ़ लेते हैं",
+    "resilienceCredentialHealthDesc": "पृष्ठभूमि स्कैन जो हर सक्रिय कनेक्शन की क्रेडेंशियल उसके प्रदाता को कॉल करके सत्यापित करता है। पूरी तरह बंद करने के लिए 0 सेट करें। प्रति-कनेक्शन स्वास्थ्य जाँच मान (संपादन संवाद में) हमेशा इस वैश्विक डिफ़ॉल्ट को ओवरराइड करते हैं।",
+    "resilienceCredentialHealthInterval": "वैश्विक जाँच अंतराल",
+    "resilienceCredentialHealthEveryMinutes": "हर {minutes} मिनट",
+    "resilienceCredentialHealthHint": "0 पृष्ठभूमि स्कैन बंद करता है (अधिकतम 1440 मिनट = 24 घंटे)। अपनी स्वास्थ्य जाँच मान वाले कनेक्शन इस वैश्विक डिफ़ॉल्ट को अनदेखा करते हैं; किसी कनेक्शन पर 0 उसे वैश्विक स्कैन चालू होने पर भी बाहर रखता है।",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "सेशन एफिनिटी",
@@ -11331,11 +11331,11 @@
       "copy": "कॉपी",
       "autoscrollOn": "ऑटोस्क्रॉल: चालू",
       "autoscrollOff": "ऑटोस्क्रॉल: बंद",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "सब समेटें",
+      "collapseOneLevel": "एक स्तर समेटें",
+      "currentExpandLevel": "वर्तमान विस्तार स्तर",
+      "expandOneLevel": "एक स्तर फैलाएँ",
+      "expandAllLevels": "सब फैलाएँ",
       "payload": {
         "clientRawRequest": "क्लाइंट कच्चा अनुरोध",
         "clientRequest": "क्लाइंट अनुरोध",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "इससे छाँटें",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "मैन्युअल",
+        "provider": "प्रदाता",
+        "score": "स्कोर (मुफ़्त मॉडल)",
+        "name": "नाम"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "स्कोर क्रम केवल मुफ़्त प्रदाताओं पर लागू होता है; बाकी अपनी जगह रहते हैं।"
     }
   },
   "comboControl": {

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Törölje az összes befejezett köteget",
     "batchListBatchesTable": "Batches",
     "changelogViewerLoading": "Változásnapló betöltése a GitHubról...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Loading profile...",
     "profileHowToEarn": "How to earn",
     "bootstrapBannerDismiss": "Elvetés",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Ha engedélyezve van, a hibás szolgáltatókat a rendszer globálisan követi, és egy lehűlési időszakra kihagyja őket.",
     "resilienceProviderCooldownMin": "Minimális lehűlési idő",
     "resilienceProviderCooldownMax": "Maximális lehűlési idő",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Hitelesítőadat-egészségellenőrzés",
+    "resilienceCredentialHealthScope": "Minden aktív API-kulcsos és OAuth kapcsolat",
+    "resilienceCredentialHealthTrigger": "Időszakosan, rögzített ütemben",
+    "resilienceCredentialHealthEffect": "Ellenőrzi minden kapcsolat hitelesítő adatát, és aktív/hiba jelzést ad; a sikertelen kapcsolatok exponenciális várakozásba lépnek",
+    "resilienceCredentialHealthDesc": "Háttérvizsgálat, amely minden aktív kapcsolat hitelesítő adatát a szolgáltatójának hívásával ellenőrzi. Állítsa 0-ra a teljes kikapcsoláshoz. A kapcsolatonkénti egészségellenőrzési értékek (a szerkesztőablakban) mindig felülírják ezt a globális alapértéket.",
+    "resilienceCredentialHealthInterval": "Globális ellenőrzési időköz",
+    "resilienceCredentialHealthEveryMinutes": "Minden {minutes} percben",
+    "resilienceCredentialHealthHint": "0 kikapcsolja a háttérvizsgálatot (max. 1440 perc = 24 óra). Saját egészségellenőrzési értékkel rendelkező kapcsolatok figyelmen kívül hagyják ezt a globális alapértéket; egy kapcsolaton a 0 akkor is kiveszi, ha a globális vizsgálat be van kapcsolva.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Munkamenet-affinitás",
@@ -11331,11 +11331,11 @@
       "copy": "Másolás",
       "autoscrollOn": "Automatikus görgetés: be",
       "autoscrollOff": "Automatikus Görgetés: ki",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Összes összecsukása",
+      "collapseOneLevel": "Egy szint összecsukása",
+      "currentExpandLevel": "Jelenlegi kinyitási szint",
+      "expandOneLevel": "Egy szint kinyitása",
+      "expandAllLevels": "Összes kinyitása",
       "payload": {
         "clientRawRequest": "Kliens Nyers Kérés",
         "clientRequest": "Ügyfél Kérés",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Rendezés",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Kézi",
+        "provider": "Szolgáltató",
+        "score": "Pontszám (ingyenes modellek)",
+        "name": "Név"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "A pontszám szerinti sorrend csak az ingyenes szolgáltatókra vonatkozik; a többiek a helyükön maradnak."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Hapus semua batch yang sudah selesai",
     "batchListBatchesTable": "kumpulan",
     "changelogViewerLoading": "Memuat log perubahan dari GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Memuat profil...",
     "profileHowToEarn": "Bagaimana cara mendapatkan penghasilan",
     "bootstrapBannerDismiss": "Singkirkan",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Jika diaktifkan, penyedia yang gagal akan dilacak secara global dan dilewati selama periode jeda.",
     "resilienceProviderCooldownMin": "Jeda minimum",
     "resilienceProviderCooldownMax": "Jeda maksimum",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Pemeriksaan kesehatan kredensial",
+    "resilienceCredentialHealthScope": "Semua koneksi API-key dan OAuth yang aktif",
+    "resilienceCredentialHealthTrigger": "Berkala, dengan irama tetap",
+    "resilienceCredentialHealthEffect": "Memeriksa kredensial setiap koneksi dan menandainya aktif/galat; koneksi gagal masuk backoff eksponensial",
+    "resilienceCredentialHealthDesc": "Pemindaian latar belakang yang memvalidasi kredensial setiap koneksi aktif dengan memanggil penyedianya. Setel 0 untuk menonaktifkannya sepenuhnya. Nilai Pemeriksaan Kesehatan per koneksi (di dialog sunting) selalu menimpa bawaan global ini.",
+    "resilienceCredentialHealthInterval": "Interval pemeriksaan global",
+    "resilienceCredentialHealthEveryMinutes": "Setiap {minutes} mnt",
+    "resilienceCredentialHealthHint": "0 menonaktifkan pemindaian latar belakang (maks. 1440 mnt = 24 jam). Koneksi dengan nilai Pemeriksaan Kesehatan sendiri mengabaikan bawaan global ini; 0 pada suatu koneksi mengeluarkannya meski pemindaian global menyala.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Afinitas sesi",
@@ -11331,11 +11331,11 @@
       "copy": "Salin",
       "autoscrollOn": "Autoscroll: aktif",
       "autoscrollOff": "Autoscroll: mati",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Ciutkan semua",
+      "collapseOneLevel": "Ciutkan satu tingkat",
+      "currentExpandLevel": "Tingkat perluasan saat ini",
+      "expandOneLevel": "Perluas satu tingkat",
+      "expandAllLevels": "Perluas semua",
       "payload": {
         "clientRawRequest": "Permintaan Mentah Klien",
         "clientRequest": "Permintaan Klien",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Urutkan berdasarkan",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manual",
+        "provider": "Penyedia",
+        "score": "Skor (model gratis)",
+        "name": "Nama"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Peringkat skor hanya berlaku untuk penyedia gratis; yang lain tetap di tempatnya."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Elimina tutti i batch completati",
     "batchListBatchesTable": "Lotti",
     "changelogViewerLoading": "Caricamento del registro delle modifiche da GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profilo",
     "profileLoading": "Caricamento profilo...",
     "profileHowToEarn": "Come guadagnare",
     "bootstrapBannerDismiss": "Congedare",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Se abilitato, i provider falliti vengono tracciati a livello globale e saltati per un periodo di cooldown.",
     "resilienceProviderCooldownMin": "Cooldown minimo",
     "resilienceProviderCooldownMax": "Cooldown massimo",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Controllo di salute delle credenziali",
+    "resilienceCredentialHealthScope": "Tutte le connessioni attive con chiave API e OAuth",
+    "resilienceCredentialHealthTrigger": "Periodicamente, a cadenza fissa",
+    "resilienceCredentialHealthEffect": "Verifica le credenziali di ogni connessione e la contrassegna attiva/errore; le connessioni in errore passano in backoff esponenziale",
+    "resilienceCredentialHealthDesc": "Scansione in background che convalida le credenziali di ogni connessione attiva chiamando il suo fornitore. Imposta 0 per disattivarla del tutto. I valori di controllo salute per connessione (nella finestra di modifica) sovrascrivono sempre questo valore globale.",
+    "resilienceCredentialHealthInterval": "Intervallo di controllo globale",
+    "resilienceCredentialHealthEveryMinutes": "Ogni {minutes} min",
+    "resilienceCredentialHealthHint": "0 disattiva la scansione in background (max 1440 min = 24 h). Le connessioni con un proprio valore di controllo salute ignorano questo valore globale; uno 0 su una connessione la esclude anche se la scansione globale è attiva.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Affinità di sessione",
@@ -11331,11 +11331,11 @@
       "copy": "Copia",
       "autoscrollOn": "Scorrimento automatico: attivo",
       "autoscrollOff": "Scorrimento automatico: disattivato",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Comprimi tutto",
+      "collapseOneLevel": "Comprimi un livello",
+      "currentExpandLevel": "Livello di espansione attuale",
+      "expandOneLevel": "Espandi un livello",
+      "expandAllLevels": "Espandi tutto",
       "payload": {
         "clientRawRequest": "Richiesta Grezza del Client",
         "clientRequest": "Richiesta del Cliente",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Ordina per",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manuale",
+        "provider": "Fornitore",
+        "score": "Punteggio (modelli gratuiti)",
+        "name": "Nome"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "L’ordinamento per punteggio vale solo per i fornitori gratuiti; gli altri restano al loro posto."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "完了したバッチをすべて削除する",
     "batchListBatchesTable": "バッチ",
     "changelogViewerLoading": "GitHub から変更ログを読み込んでいます...",
-    "profile": "__MISSING__:Profile",
+    "profile": "プロフィール",
     "profileLoading": "プロファイルを読み込んでいます...",
     "profileHowToEarn": "稼ぎ方",
     "bootstrapBannerDismiss": "解雇する",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "有効にすると、失敗したプロバイダーがグローバルに追跡され、クールダウン期間中スキップされます。",
     "resilienceProviderCooldownMin": "最小クールダウン",
     "resilienceProviderCooldownMax": "最大クールダウン",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "資格情報のヘルスチェック",
+    "resilienceCredentialHealthScope": "すべての有効な API キーおよび OAuth 接続",
+    "resilienceCredentialHealthTrigger": "一定の間隔で定期的に",
+    "resilienceCredentialHealthEffect": "各接続の資格情報を調べ、有効/エラーと記録します。失敗した接続は指数バックオフします",
+    "resilienceCredentialHealthDesc": "各有効接続の資格情報をプロバイダー呼び出しで検証するバックグラウンド掃引です。完全に無効にするには 0 を設定します。接続ごとのヘルスチェック値（編集ダイアログ）は常にこのグローバル既定値より優先されます。",
+    "resilienceCredentialHealthInterval": "グローバル検査間隔",
+    "resilienceCredentialHealthEveryMinutes": "{minutes} 分ごと",
+    "resilienceCredentialHealthHint": "0 はバックグラウンド掃引を無効にします（最大 1440 分 = 24 時間）。独自のヘルスチェック値を持つ接続はこのグローバル既定を無視します。ある接続を 0 にすると、グローバル掃引がオンでも対象外になります。",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "セッションアフィニティ",
@@ -11331,11 +11331,11 @@
       "copy": "コピー",
       "autoscrollOn": "自動スクロール: オン",
       "autoscrollOff": "自動スクロール: オフ",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "すべて折りたたむ",
+      "collapseOneLevel": "1レベル折りたたむ",
+      "currentExpandLevel": "現在の展開レベル",
+      "expandOneLevel": "1レベル展開",
+      "expandAllLevels": "すべて展開",
       "payload": {
         "clientRawRequest": "クライアント生リクエスト",
         "clientRequest": "クライアントリクエスト",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "並べ替え",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "手動",
+        "provider": "プロバイダー",
+        "score": "スコア（無料モデル）",
+        "name": "名前"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "スコア順は無料プロバイダーにのみ適用されます。それ以外はそのままです。"
     }
   },
   "comboControl": {

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "완료된 모든 배치 삭제",
     "batchListBatchesTable": "배치",
     "changelogViewerLoading": "GitHub에서 변경 로그를 로드하는 중...",
-    "profile": "__MISSING__:Profile",
+    "profile": "프로필",
     "profileLoading": "프로필 로드 중...",
     "profileHowToEarn": "적립 방법",
     "bootstrapBannerDismiss": "닫기",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "활성화하면 실패한 제공자를 전역적으로 추적하고 쿨다운 기간 동안 건너뜁니다.",
     "resilienceProviderCooldownMin": "최소 쿨다운",
     "resilienceProviderCooldownMax": "최대 쿨다운",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "자격 증명 상태 검사",
+    "resilienceCredentialHealthScope": "모든 활성 API 키 및 OAuth 연결",
+    "resilienceCredentialHealthTrigger": "고정 주기로 정기적으로",
+    "resilienceCredentialHealthEffect": "각 연결의 자격 증명을 검사하고 활성/오류로 표시합니다. 실패한 연결은 지수 백오프합니다",
+    "resilienceCredentialHealthDesc": "각 활성 연결의 자격 증명을 제공자를 호출해 검증하는 백그라운드 스윕입니다. 완전히 끄려면 0으로 설정하세요. 연결별 상태 검사 값(편집 대화상자)은 항상 이 전역 기본값을 덮어씁니다.",
+    "resilienceCredentialHealthInterval": "전역 검사 간격",
+    "resilienceCredentialHealthEveryMinutes": "{minutes}분마다",
+    "resilienceCredentialHealthHint": "0은 백그라운드 스윕을 끕니다(최대 1440분 = 24시간). 자체 상태 검사 값이 있는 연결은 이 전역 기본값을 무시합니다. 연결을 0으로 두면 전역 스윕이 켜져 있어도 제외됩니다.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "세션 어피니티",
@@ -11331,11 +11331,11 @@
       "copy": "복사",
       "autoscrollOn": "자동 스크롤: 켜짐",
       "autoscrollOff": "자동 스크롤: 꺼짐",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "모두 접기",
+      "collapseOneLevel": "한 단계 접기",
+      "currentExpandLevel": "현재 펼침 단계",
+      "expandOneLevel": "한 단계 펼치기",
+      "expandAllLevels": "모두 펼치기",
       "payload": {
         "clientRawRequest": "클라이언트 원시 요청",
         "clientRequest": "클라이언트 요청",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "정렬 기준",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "수동",
+        "provider": "제공자",
+        "score": "점수(무료 모델)",
+        "name": "이름"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "점수 순위는 무료 제공자에만 적용됩니다. 나머지는 그대로 둡니다."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "पूर्ण झालेल्या सर्व बॅचेस हटवा",
     "batchListBatchesTable": "बॅचेस",
     "changelogViewerLoading": "GitHub वरून चेंजलॉग लोड करत आहे...",
-    "profile": "__MISSING__:Profile",
+    "profile": "प्रोफाइल",
     "profileLoading": "प्रोफाइल लोड करत आहे...",
     "profileHowToEarn": "कसे कमवायचे",
     "bootstrapBannerDismiss": "डिसमिस करा",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "सक्षम केल्यावर, अयशस्वी प्रदात्यांचा जागतिक स्तरावर मागोवा घेतला जातो आणि कूलडाउन कालावधीसाठी ते वगळले जातात.",
     "resilienceProviderCooldownMin": "किमान कूलडाउन",
     "resilienceProviderCooldownMax": "कमाल कूलडाउन",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "क्रेडेन्शियल आरोग्य तपासणी",
+    "resilienceCredentialHealthScope": "सर्व सक्रिय API-की आणि OAuth कनेक्शन",
+    "resilienceCredentialHealthTrigger": "ठराविक लयाने नियतकालिक",
+    "resilienceCredentialHealthEffect": "प्रत्येक कनेक्शनची क्रेडेन्शियल तपासते आणि सक्रिय/त्रुटी चिन्हांकित करते; अयशस्वी कनेक्शन घातांकीय बॅकऑफ घेतात",
+    "resilienceCredentialHealthDesc": "पार्श्वभूमी स्कॅन जे प्रत्येक सक्रिय कनेक्शनची क्रेडेन्शियल त्याच्या प्रदात्याला कॉल करून सत्यापित करते. पूर्ण बंद करण्यासाठी 0 सेट करा. प्रति-कनेक्शन आरोग्य तपासणी मूल्ये (संपादन संवादात) नेहमी या जागतिक डीफॉल्टला ओव्हरराइड करतात.",
+    "resilienceCredentialHealthInterval": "जागतिक तपासणी अंतराल",
+    "resilienceCredentialHealthEveryMinutes": "दर {minutes} मिनिटे",
+    "resilienceCredentialHealthHint": "0 पार्श्वभूमी स्कॅन बंद करतो (कमाल 1440 मिनिटे = 24 तास). स्वतःचे आरोग्य तपासणी मूल्य असलेली कनेक्शन हे जागतिक डीफॉल्ट दुर्लक्षित करतात; एखाद्या कनेक्शनवर 0 ते जागतिक स्कॅन चालू असतानाही वगळते.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "सत्र एफिनिटी",
@@ -11331,11 +11331,11 @@
       "copy": "कॉपी",
       "autoscrollOn": "ऑटोस्क्रोल: चालू",
       "autoscrollOff": "ऑटोस्क्रोल: बंद",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "सर्व संकुचित करा",
+      "collapseOneLevel": "एक स्तर संकुचित करा",
+      "currentExpandLevel": "सध्याचा विस्तार स्तर",
+      "expandOneLevel": "एक स्तर विस्तारा",
+      "expandAllLevels": "सर्व विस्तारा",
       "payload": {
         "clientRawRequest": "क्लायंट कच्चा विनंती",
         "clientRequest": "ग्राहक विनंती",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "यानुसार क्रम लावा",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "मॅन्युअल",
+        "provider": "प्रदाता",
+        "score": "स्कोर (मोफत मॉडेल)",
+        "name": "नाव"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "स्कोर क्रम फक्त मोफत प्रदात्यांना लागू होतो; इतर जागीच राहतात."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Padamkan semua kumpulan yang lengkap",
     "batchListBatchesTable": "kelompok",
     "changelogViewerLoading": "Memuatkan changelog daripada GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Memuatkan profil...",
     "profileHowToEarn": "Bagaimana untuk mendapatkan",
     "bootstrapBannerDismiss": "Tolak",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Apabila didayakan, penyedia yang gagal dijejaki secara global dan dilangkau untuk tempoh bertenang.",
     "resilienceProviderCooldownMin": "Tempoh bertenang minimum",
     "resilienceProviderCooldownMax": "Tempoh bertenang maksimum",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Pemeriksaan kesihatan kelayakan",
+    "resilienceCredentialHealthScope": "Semua sambungan API-key dan OAuth yang aktif",
+    "resilienceCredentialHealthTrigger": "Berkala, dengan irama tetap",
+    "resilienceCredentialHealthEffect": "Memeriksa kelayakan setiap sambungan dan menandainya aktif/ralat; sambungan gagal masuk backoff eksponen",
+    "resilienceCredentialHealthDesc": "Imbasan latar yang mengesahkan kelayakan setiap sambungan aktif dengan memanggil penyedianya. Tetapkan 0 untuk mematikannya sepenuhnya. Nilai Pemeriksaan Kesihatan setiap sambungan (dalam dialog sunting) sentiasa menindih lalai global ini.",
+    "resilienceCredentialHealthInterval": "Selang pemeriksaan global",
+    "resilienceCredentialHealthEveryMinutes": "Setiap {minutes} min",
+    "resilienceCredentialHealthHint": "0 mematikan imbasan latar (maks. 1440 min = 24 jam). Sambungan dengan nilai Pemeriksaan Kesihatan sendiri mengabaikan lalai global ini; 0 pada sesuatu sambungan mengeluarkannya walaupun imbasan global dihidupkan.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Afiniti sesi",
@@ -11331,11 +11331,11 @@
       "copy": "Salin",
       "autoscrollOn": "Autoscroll: hidup",
       "autoscrollOff": "Autoscroll: mati",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Kuncupkan semua",
+      "collapseOneLevel": "Kuncupkan satu aras",
+      "currentExpandLevel": "Aras kembang semasa",
+      "expandOneLevel": "Kembangkan satu aras",
+      "expandAllLevels": "Kembangkan semua",
       "payload": {
         "clientRawRequest": "Permintaan Mentah Klien",
         "clientRequest": "Permintaan Klien",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Isih mengikut",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manual",
+        "provider": "Penyedia",
+        "score": "Skor (model percuma)",
+        "name": "Nama"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Kedudukan skor hanya untuk penyedia percuma; yang lain kekal di tempatnya."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Verwijder alle voltooide batches",
     "batchListBatchesTable": "Batches",
     "changelogViewerLoading": "Wijzigingslogboek laden vanuit GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profiel",
     "profileLoading": "Profiel laden...",
     "profileHowToEarn": "Hoe te verdienen",
     "bootstrapBannerDismiss": "Negeren",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Indien ingeschakeld, worden mislukte providers globaal bijgehouden en overgeslagen gedurende een afkoelperiode.",
     "resilienceProviderCooldownMin": "Minimale afkoelperiode",
     "resilienceProviderCooldownMax": "Maximale afkoelperiode",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Gezondheidscontrole van inloggegevens",
+    "resilienceCredentialHealthScope": "Alle actieve API-sleutel- en OAuth-verbindingen",
+    "resilienceCredentialHealthTrigger": "Periodiek, in vast ritme",
+    "resilienceCredentialHealthEffect": "Controleert de inloggegevens van elke verbinding en markeert die actief/fout; mislukte verbindingen gaan in exponentiële backoff",
+    "resilienceCredentialHealthDesc": "Achtergrondscan die de inloggegevens van elke actieve verbinding valideert door de aanbieder aan te roepen. Zet 0 om de scan volledig uit te schakelen. Gezondheidscontrolewaarden per verbinding (in het bewerkingsvenster) overschrijven altijd deze globale standaard.",
+    "resilienceCredentialHealthInterval": "Globaal controle-interval",
+    "resilienceCredentialHealthEveryMinutes": "Elke {minutes} min",
+    "resilienceCredentialHealthHint": "0 schakelt de achtergrondscan uit (max. 1440 min = 24 u). Verbindingen met een eigen gezondheidscontrolewaarde negeren deze globale standaard; 0 op een verbinding sluit die uit, ook als de globale scan aanstaat.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Sessie-affiniteit",
@@ -11331,11 +11331,11 @@
       "copy": "Kopieer",
       "autoscrollOn": "Autoscroll: aan",
       "autoscrollOff": "Autoscroll: uit",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Alles samenvouwen",
+      "collapseOneLevel": "Eén niveau samenvouwen",
+      "currentExpandLevel": "Huidig uitklapniveau",
+      "expandOneLevel": "Eén niveau uitklappen",
+      "expandAllLevels": "Alles uitklappen",
       "payload": {
         "clientRawRequest": "Client Rauwe Verzoek",
         "clientRequest": "Klantverzoek",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sorteren op",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Handmatig",
+        "provider": "Aanbieder",
+        "score": "Score (gratis modellen)",
+        "name": "Naam"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Scorevolgorde geldt alleen voor gratis aanbieders; de rest blijft staan."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Slett alle fullførte batcher",
     "batchListBatchesTable": "Batcher",
     "changelogViewerLoading": "Laster inn endringslogg fra GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Laster profil...",
     "profileHowToEarn": "Hvordan tjene",
     "bootstrapBannerDismiss": "Avvis",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Når aktivert, spores feilede leverandører globalt og hoppes over i en nedkjølingsperiode.",
     "resilienceProviderCooldownMin": "Minimum nedkjøling",
     "resilienceProviderCooldownMax": "Maksimum nedkjøling",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Helsessjekk av påloggingsinformasjon",
+    "resilienceCredentialHealthScope": "Alle aktive API-nøkkel- og OAuth-tilkoblinger",
+    "resilienceCredentialHealthTrigger": "Periodisk, i fast rytme",
+    "resilienceCredentialHealthEffect": "Sjekker påloggingsinformasjonen til hver tilkobling og merker den aktiv/feil; mislykkede tilkoblinger går i eksponentiell backoff",
+    "resilienceCredentialHealthDesc": "Bakgrunnsskanning som validerer påloggingsinformasjonen til hver aktiv tilkobling ved å kalle leverandøren. Sett 0 for å slå den helt av. Helsessjekkverdier per tilkobling (i redigeringsdialogen) overstyrer alltid denne globale standarden.",
+    "resilienceCredentialHealthInterval": "Globalt sjekkintervall",
+    "resilienceCredentialHealthEveryMinutes": "Hver {minutes} min",
+    "resilienceCredentialHealthHint": "0 slår av bakgrunnsskanningen (maks. 1440 min = 24 t). Tilkoblinger med egen helsessjekkverdi ignorerer denne globale standarden; 0 på en tilkobling utelater den selv når den globale skanningen er på.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Sesjonsaffinitet",
@@ -11331,11 +11331,11 @@
       "copy": "Kopier",
       "autoscrollOn": "Autoscroll: på",
       "autoscrollOff": "Autoscroll: av",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Skjul alle",
+      "collapseOneLevel": "Skjul ett nivå",
+      "currentExpandLevel": "Gjeldende utvidelsesnivå",
+      "expandOneLevel": "Utvid ett nivå",
+      "expandAllLevels": "Utvid alle",
       "payload": {
         "clientRawRequest": "Klient Rå Forespørsel",
         "clientRequest": "Klientforespørsel",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sorter etter",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manuell",
+        "provider": "Leverandør",
+        "score": "Poeng (gratis modeller)",
+        "name": "Navn"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Poengrekkefølge gjelder bare gratis leverandører; de andre blir stående."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Tanggalin ang lahat ng nakumpletong batch",
     "batchListBatchesTable": "Mga batch",
     "changelogViewerLoading": "Nilo-load ang changelog mula sa GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profile",
     "profileLoading": "Nilo-load ang profile...",
     "profileHowToEarn": "Paano kumita",
     "bootstrapBannerDismiss": "I-dismiss",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Kapag pinagana, ang mga nabigong provider ay sinusubaybayan nang global at nilalaktawan para sa isang panahon ng cooldown.",
     "resilienceProviderCooldownMin": "Minimum na cooldown",
     "resilienceProviderCooldownMax": "Maximum na cooldown",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Pagsusuri sa kalusugan ng kredensyal",
+    "resilienceCredentialHealthScope": "Lahat ng aktibong API-key at OAuth na koneksyon",
+    "resilienceCredentialHealthTrigger": "Pana-panahon, sa nakatakdang bilis",
+    "resilienceCredentialHealthEffect": "Sinusuri ang kredensyal ng bawat koneksyon at minamarkahan itong aktibo/error; ang nabigong koneksyon ay pumapasok sa exponential backoff",
+    "resilienceCredentialHealthDesc": "Background sweep na nagpapatunay sa kredensyal ng bawat aktibong koneksyon sa pamamagitan ng pagtawag sa provider nito. Itakda sa 0 para i-disable nang buo. Ang mga Health Check value sa bawat koneksyon (sa edit dialog) ay palaging nangingibabaw sa global default na ito.",
+    "resilienceCredentialHealthInterval": "Pandaigdigang agwat ng pagsusuri",
+    "resilienceCredentialHealthEveryMinutes": "Bawat {minutes} min",
+    "resilienceCredentialHealthHint": "Ang 0 ay nagdi-disable ng background sweep (max 1440 min = 24 oras). Ang mga koneksyong may sariling Health Check value ay hindi tumitingin sa global default na ito; ang 0 sa isang koneksyon ay inaalis ito kahit naka-on ang global sweep.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Session affinity",
@@ -11331,11 +11331,11 @@
       "copy": "Kopyahin",
       "autoscrollOn": "Autoscroll: naka-on",
       "autoscrollOff": "Autoscroll: patay",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "I-collapse lahat",
+      "collapseOneLevel": "I-collapse ang isang antas",
+      "currentExpandLevel": "Kasalukuyang antas ng pagpapalawak",
+      "expandOneLevel": "I-expand ang isang antas",
+      "expandAllLevels": "I-expand lahat",
       "payload": {
         "clientRawRequest": "Kliyentong Hilaw na Kahilingan",
         "clientRequest": "Hiling ng Kliyente",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Ayusin ayon sa",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manual",
+        "provider": "Provider",
+        "score": "Iskor (libreng modelo)",
+        "name": "Pangalan"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Ang pagkakasunod ayon sa iskor ay para lang sa libreng provider; ang iba ay nananatili sa lugar."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Usuń wszystkie ukończone zadania wsadowe",
     "batchListBatchesTable": "Zadania wsadowe",
     "changelogViewerLoading": "Ładowanie changelogu z GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Ładowanie profilu...",
     "profileHowToEarn": "Jak zarabiać",
     "bootstrapBannerDismiss": "Odrzuć",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Po włączeniu awarie providers są śledzone globalnie i pomijane na czas cooldownu.",
     "resilienceProviderCooldownMin": "Minimalny cooldown",
     "resilienceProviderCooldownMax": "Maksymalny cooldown",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Kontrola stanu poświadczeń",
+    "resilienceCredentialHealthScope": "Wszystkie aktywne połączenia z kluczem API i OAuth",
+    "resilienceCredentialHealthTrigger": "Okresowo, w stałym rytmie",
+    "resilienceCredentialHealthEffect": "Sprawdza poświadczenia każdego połączenia i oznacza je jako aktywne/błąd; nieudane połączenia wchodzą w wykładniczy backoff",
+    "resilienceCredentialHealthDesc": "Skan w tle, który weryfikuje poświadczenia każdego aktywnego połączenia, wywołując jego dostawcę. Ustaw 0, aby wyłączyć go całkowicie. Wartości kontroli stanu per połączenie (w oknie edycji) zawsze nadpisują to globalne ustawienie.",
+    "resilienceCredentialHealthInterval": "Globalny interwał kontroli",
+    "resilienceCredentialHealthEveryMinutes": "Co {minutes} min",
+    "resilienceCredentialHealthHint": "0 wyłącza skan w tle (maks. 1440 min = 24 h). Połączenia z własną wartością kontroli stanu ignorują to globalne ustawienie; 0 na danym połączeniu wyłącza je nawet przy włączonym skanie globalnym.",
     "forcedFingerprintTitle": "Zawsze włączone dla {provider} — wymagane dla bezpieczeństwa konta OAuth; nie można wyłączyć.",
     "forcedFingerprintBadge": "Wymagane",
     "sessionAffinityTitle": "Powinowactwo sesji (session affinity)",
@@ -11331,11 +11331,11 @@
       "copy": "Kopiuj",
       "autoscrollOn": "Autoscroll: włączone",
       "autoscrollOff": "Autoscroll: wyłączone",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Zwiń wszystko",
+      "collapseOneLevel": "Zwiń jeden poziom",
+      "currentExpandLevel": "Bieżący poziom rozwinięcia",
+      "expandOneLevel": "Rozwiń jeden poziom",
+      "expandAllLevels": "Rozwiń wszystko",
       "payload": {
         "clientRawRequest": "Surowe Żądanie Klienta",
         "clientRequest": "Żądanie Klienta",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sortuj według",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Ręcznie",
+        "provider": "Dostawca",
+        "score": "Wynik (darmowe modele)",
+        "name": "Nazwa"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Sortowanie według wyniku dotyczy tylko darmowych dostawców; pozostali zostają na miejscu."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Excluir todos os lotes concluídos",
     "batchListBatchesTable": "Lotes",
     "changelogViewerLoading": "Carregando changelog do GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Perfil",
     "profileLoading": "Carregando perfil...",
     "profileHowToEarn": "Como ganhar",
     "bootstrapBannerDismiss": "Dispensar",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Quando ativado, os fornecedores com falhas são monitorizados globalmente e ignorados durante um período de cooldown.",
     "resilienceProviderCooldownMin": "Cooldown mínimo",
     "resilienceProviderCooldownMax": "Cooldown máximo",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Verificação de saúde da credencial",
+    "resilienceCredentialHealthScope": "Todas as ligações ativas de chave API e OAuth",
+    "resilienceCredentialHealthTrigger": "Periodicamente, com cadência fixa",
+    "resilienceCredentialHealthEffect": "Testa a credencial de cada ligação e marca-a ativa/erro; as ligações com falha entram em backoff exponencial",
+    "resilienceCredentialHealthDesc": "Varredura em segundo plano que valida a credencial de cada ligação ativa ao chamar o respetivo fornecedor. Defina 0 para a desativar por completo. Os valores de verificação de saúde por ligação (no diálogo de edição) substituem sempre este valor global.",
+    "resilienceCredentialHealthInterval": "Intervalo global de verificação",
+    "resilienceCredentialHealthEveryMinutes": "A cada {minutes} min",
+    "resilienceCredentialHealthHint": "0 desativa a varredura em segundo plano (máx. 1440 min = 24 h). As ligações com o próprio valor de verificação de saúde ignoram este valor global; um 0 numa ligação exclui-a mesmo com a varredura global ligada.",
     "forcedFingerprintTitle": "Sempre ativado para {provider} — obrigatório para a segurança da conta OAuth; não pode ser desligado.",
     "forcedFingerprintBadge": "Obrigatório",
     "sessionAffinityTitle": "Afinidade de sessão",
@@ -11331,11 +11331,11 @@
       "copy": "Copiar",
       "autoscrollOn": "Deslocação Automática: ativada",
       "autoscrollOff": "Deslocação Automática: desligada",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Recolher tudo",
+      "collapseOneLevel": "Recolher um nível",
+      "currentExpandLevel": "Nível de expansão atual",
+      "expandOneLevel": "Expandir um nível",
+      "expandAllLevels": "Expandir tudo",
       "payload": {
         "clientRawRequest": "Pedido Bruto do Cliente",
         "clientRequest": "Pedido do Cliente",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Ordenar por",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manual",
+        "provider": "Fornecedor",
+        "score": "Pontuação (modelos gratuitos)",
+        "name": "Nome"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "A ordenação por pontuação aplica-se só a fornecedores gratuitos; os restantes ficam no sítio."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Ștergeți toate loturile finalizate",
     "batchListBatchesTable": "Loturi",
     "changelogViewerLoading": "Se încarcă jurnalul de modificări din GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Se încarcă profilul...",
     "profileHowToEarn": "Cum să câștigi",
     "bootstrapBannerDismiss": "Respingeți",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Când este activat, furnizorii eșuați sunt urmăriți la nivel global și omiși pentru o perioadă de cooldown.",
     "resilienceProviderCooldownMin": "Cooldown minim",
     "resilienceProviderCooldownMax": "Cooldown maxim",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Verificare a stării acreditărilor",
+    "resilienceCredentialHealthScope": "Toate conexiunile active cu cheie API și OAuth",
+    "resilienceCredentialHealthTrigger": "Periodic, la un ritm fix",
+    "resilienceCredentialHealthEffect": "Verifică acreditarea fiecărei conexiuni și o marchează activă/eroare; conexiunile eșuate intră în backoff exponențial",
+    "resilienceCredentialHealthDesc": "Scanare în fundal care validează acreditarea fiecărei conexiuni active apelând furnizorul. Setați 0 pentru a o dezactiva complet. Valorile de verificare a stării per conexiune (în dialogul de editare) înlocuiesc întotdeauna această valoare globală.",
+    "resilienceCredentialHealthInterval": "Interval global de verificare",
+    "resilienceCredentialHealthEveryMinutes": "La fiecare {minutes} min",
+    "resilienceCredentialHealthHint": "0 dezactivează scanarea în fundal (max. 1440 min = 24 h). Conexiunile cu propria valoare de verificare a stării ignoră această valoare globală; 0 pe o conexiune o exclude chiar dacă scanarea globală e pornită.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Afinitate de sesiune",
@@ -11331,11 +11331,11 @@
       "copy": "Copiază",
       "autoscrollOn": "Derulare automată: activată",
       "autoscrollOff": "Derulare automată: oprită",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Restrânge tot",
+      "collapseOneLevel": "Restrânge un nivel",
+      "currentExpandLevel": "Nivelul actual de extindere",
+      "expandOneLevel": "Extinde un nivel",
+      "expandAllLevels": "Extinde tot",
       "payload": {
         "clientRawRequest": "Cerere Brută Client",
         "clientRequest": "Cerere Client",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sortează după",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manual",
+        "provider": "Furnizor",
+        "score": "Scor (modele gratuite)",
+        "name": "Nume"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Clasarea după scor se aplică doar furnizorilor gratuți; restul rămân pe loc."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Удалить все завершенные пакеты",
     "batchListBatchesTable": "Пакеты",
     "changelogViewerLoading": "Загрузка журнала изменений с GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Профиль",
     "profileLoading": "Загрузка профиля...",
     "profileHowToEarn": "Как заработать",
     "bootstrapBannerDismiss": "Уволить",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Если включено, сбои провайдеров отслеживаются глобально, и они пропускаются на время кулдауна.",
     "resilienceProviderCooldownMin": "Минимальный кулдаун",
     "resilienceProviderCooldownMax": "Максимальный кулдаун",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Проверка состояния учётных данных",
+    "resilienceCredentialHealthScope": "Все активные подключения с API-ключом и OAuth",
+    "resilienceCredentialHealthTrigger": "Периодически, с фиксированным ритмом",
+    "resilienceCredentialHealthEffect": "Проверяет учётные данные каждого подключения и помечает его активным/ошибкой; неудачные подключения уходят в экспоненциальный backoff",
+    "resilienceCredentialHealthDesc": "Фоновое сканирование, которое проверяет учётные данные каждого активного подключения, вызывая его провайдера. Установите 0, чтобы полностью отключить. Значения проверки состояния для отдельного подключения (в диалоге правки) всегда перекрывают этот глобальный параметр.",
+    "resilienceCredentialHealthInterval": "Глобальный интервал проверки",
+    "resilienceCredentialHealthEveryMinutes": "Каждые {minutes} мин",
+    "resilienceCredentialHealthHint": "0 отключает фоновое сканирование (макс. 1440 мин = 24 ч). Подключения со своим значением проверки состояния игнорируют этот глобальный параметр; 0 у конкретного подключения исключает его даже при включённом глобальном сканировании.",
     "forcedFingerprintTitle": "Всегда включено для {provider} — требуется для безопасности OAuth-аккаунта; отключить нельзя.",
     "forcedFingerprintBadge": "Обязательно",
     "sessionAffinityTitle": "Привязка сессии",
@@ -11331,11 +11331,11 @@
       "copy": "Копировать",
       "autoscrollOn": "Автопрокрутка: включена",
       "autoscrollOff": "Автопрокрутка: выключена",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Свернуть всё",
+      "collapseOneLevel": "Свернуть на уровень",
+      "currentExpandLevel": "Текущий уровень развёртывания",
+      "expandOneLevel": "Развернуть на уровень",
+      "expandAllLevels": "Развернуть всё",
       "payload": {
         "clientRawRequest": "Сырой запрос клиента",
         "clientRequest": "Запрос клиента",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Сортировать по",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Вручную",
+        "provider": "Провайдер",
+        "score": "Оценка (бесплатные модели)",
+        "name": "Имя"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Сортировка по оценке действует только для бесплатных провайдеров; остальные остаются на месте."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Odstráňte všetky dokončené dávky",
     "batchListBatchesTable": "Dávky",
     "changelogViewerLoading": "Načítava sa protokol zmien z GitHubu...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Načítava sa profil...",
     "profileHowToEarn": "Ako zarobiť",
     "bootstrapBannerDismiss": "Odmietnuť",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Keď je táto možnosť povolená, zlyhaní poskytovatelia sú sledovaní globálne a preskočení na dobu cooldownu.",
     "resilienceProviderCooldownMin": "Minimálny cooldown",
     "resilienceProviderCooldownMax": "Maximálny cooldown",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Kontrola zdravia prihlasovacích údajov",
+    "resilienceCredentialHealthScope": "Všetky aktívne API-kľúč a OAuth pripojenia",
+    "resilienceCredentialHealthTrigger": "Pravidelne, pevným rytmom",
+    "resilienceCredentialHealthEffect": "Overí prihlasovacie údaje každého pripojenia a označí ho aktívne/chyba; neúspešné pripojenia idú do exponenciálneho backoffu",
+    "resilienceCredentialHealthDesc": "Skenovanie na pozadí, ktoré overuje prihlasovacie údaje každého aktívneho pripojenia volaním jeho poskytovateľa. Nastavte 0 na úplné vypnutie. Hodnoty kontroly zdravia na pripojenie (v dialógu úprav) vždy prepíšu toto globálne predvolené nastavenie.",
+    "resilienceCredentialHealthInterval": "Globálny interval kontroly",
+    "resilienceCredentialHealthEveryMinutes": "Každých {minutes} min",
+    "resilienceCredentialHealthHint": "0 vypne skenovanie na pozadí (max. 1440 min = 24 h). Pripojenia s vlastnou hodnotou kontroly zdravia ignorujú toto globálne predvolené nastavenie; 0 pri konkrétnom pripojení ho vyradí, aj keď je globálne skenovanie zapnuté.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Afinita relácie",
@@ -11331,11 +11331,11 @@
       "copy": "Kopírovať",
       "autoscrollOn": "Automatické posúvanie: zapnuté",
       "autoscrollOff": "Automatické posúvanie: vypnuté",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Zbaliť všetko",
+      "collapseOneLevel": "Zbaliť o úroveň",
+      "currentExpandLevel": "Aktuálna úroveň rozbalenia",
+      "expandOneLevel": "Rozbaliť o úroveň",
+      "expandAllLevels": "Rozbaliť všetko",
       "payload": {
         "clientRawRequest": "Klientský surový požiadavok",
         "clientRequest": "Žiadosť klienta",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Zoradiť podľa",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Ručne",
+        "provider": "Poskytovateľ",
+        "score": "Skóre (bezplatné modely)",
+        "name": "Názov"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Zoradenie podľa skóre platí len pre bezplatných poskytovateľov; ostatní ostanú na mieste."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Ta bort alla slutförda batcher",
     "batchListBatchesTable": "Partier",
     "changelogViewerLoading": "Laddar ändringslogg från GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Laddar profil...",
     "profileHowToEarn": "Hur man tjänar",
     "bootstrapBannerDismiss": "Avvisa",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "När detta är aktiverat spåras misslyckade leverantörer globalt och hoppas över under en avkylningsperiod.",
     "resilienceProviderCooldownMin": "Minsta avkylning",
     "resilienceProviderCooldownMax": "Maximal avkylning",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Hälsokontroll av inloggningsuppgifter",
+    "resilienceCredentialHealthScope": "Alla aktiva API-nyckel- och OAuth-anslutningar",
+    "resilienceCredentialHealthTrigger": "Periodiskt, i fast takt",
+    "resilienceCredentialHealthEffect": "Kontrollerar varje anslutnings inloggningsuppgifter och markerar den aktiv/fel; misslyckade anslutningar går i exponentiell backoff",
+    "resilienceCredentialHealthDesc": "Bakgrundsskanning som validerar inloggningsuppgifterna för varje aktiv anslutning genom att anropa dess leverantör. Sätt 0 för att stänga av den helt. Hälsokontrollvärden per anslutning (i redigeringsdialogrutan) åsidosätter alltid denna globala standard.",
+    "resilienceCredentialHealthInterval": "Globalt kontrollintervall",
+    "resilienceCredentialHealthEveryMinutes": "Var {minutes} min",
+    "resilienceCredentialHealthHint": "0 stänger av bakgrundsskanningen (max 1440 min = 24 h). Anslutningar med eget hälsokontrollvärde ignorerar denna globala standard; 0 på en anslutning utesluter den även när den globala skanningen är på.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Sessionsaffinitet",
@@ -11331,11 +11331,11 @@
       "copy": "Kopiera",
       "autoscrollOn": "Autoscroll: på",
       "autoscrollOff": "Autoscroll: av",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Fäll ihop alla",
+      "collapseOneLevel": "Fäll ihop en nivå",
+      "currentExpandLevel": "Aktuell utfällningsnivå",
+      "expandOneLevel": "Fäll ut en nivå",
+      "expandAllLevels": "Fäll ut alla",
       "payload": {
         "clientRawRequest": "Klientens Rå Begäran",
         "clientRequest": "Klientförfrågan",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Sortera efter",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Manuell",
+        "provider": "Leverantör",
+        "score": "Poäng (gratis modeller)",
+        "name": "Namn"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Poängordning gäller bara gratisleverantörer; övriga står kvar."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Futa makundi yote yaliyokamilishwa",
     "batchListBatchesTable": "Makundi",
     "changelogViewerLoading": "Inapakia logi ya mabadiliko kutoka kwa GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Wasifu",
     "profileLoading": "Inapakia wasifu...",
     "profileHowToEarn": "Jinsi ya kupata",
     "bootstrapBannerDismiss": "Ondoa",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Ikiwashwa, watoa huduma walioshindwa hufuatiliwa kwa jumla na kupitwa kwa kipindi cha cooldown.",
     "resilienceProviderCooldownMin": "Cooldown ya chini zaidi",
     "resilienceProviderCooldownMax": "Cooldown ya juu zaidi",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Ukaguzi wa afya ya kitambulisho",
+    "resilienceCredentialHealthScope": "Miunganisho yote hai ya ufunguo wa API na OAuth",
+    "resilienceCredentialHealthTrigger": "Kila mara, kwa mdundo thabiti",
+    "resilienceCredentialHealthEffect": "Hukagua kitambulisho cha kila muunganisho na kukitia hai/kosa; miunganisho iliyoshindwa huingia backoff ya kielelezo",
+    "resilienceCredentialHealthDesc": "Uchunguzi wa nyuma unaothibitisha kitambulisho cha kila muunganisho hai kwa kumpigia mtoa huduma wake. Weka 0 ili kuzima kabisa. Thamani za Ukaguzi wa Afya kwa kila muunganisho (katika kidirisha cha kuhariri) daima zinabatilisha chaguo-msingi hili la kimataifa.",
+    "resilienceCredentialHealthInterval": "Muda wa ukaguzi wa kimataifa",
+    "resilienceCredentialHealthEveryMinutes": "Kila dakika {minutes}",
+    "resilienceCredentialHealthHint": "0 inazima uchunguzi wa nyuma (kiwango cha juu dakika 1440 = saa 24). Miunganisho yenye thamani yake ya Ukaguzi wa Afya hupuuzia chaguo-msingi hili la kimataifa; 0 kwenye muunganisho inautoa hata uchunguzi wa kimataifa ukiwa umewashwa.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Session affinity",
@@ -11331,11 +11331,11 @@
       "copy": "Nakili",
       "autoscrollOn": "Autoscroll: on",
       "autoscrollOff": "Autoscroll: off",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Kunja zote",
+      "collapseOneLevel": "Kunja kiwango kimoja",
+      "currentExpandLevel": "Kiwango cha sasa cha kupanua",
+      "expandOneLevel": "Panua kiwango kimoja",
+      "expandAllLevels": "Panua zote",
       "payload": {
         "clientRawRequest": "Omba Mbichi ya Mteja",
         "clientRequest": "Omba Mteja",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Panga kwa",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Mkono",
+        "provider": "Mtoa huduma",
+        "score": "Alama (modeli za bure)",
+        "name": "Jina"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Mpangilio wa alama unahusu watoa huduma wa bure tu; wengine wanabaki mahali pao."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "முடிக்கப்பட்ட அனைத்து தொகுதிகளையும் நீக்கவும்",
     "batchListBatchesTable": "தொகுதிகள்",
     "changelogViewerLoading": "GitHub இலிருந்து சேஞ்ச்லாக்கை ஏற்றுகிறது...",
-    "profile": "__MISSING__:Profile",
+    "profile": "சுயவிவரம்",
     "profileLoading": "சுயவிவரத்தை ஏற்றுகிறது...",
     "profileHowToEarn": "எப்படி சம்பாதிப்பது",
     "bootstrapBannerDismiss": "நிராகரி",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "இயக்கப்பட்டால், தோல்வியடைந்த வழங்குநர்கள் உலகளவில் கண்காணிக்கப்பட்டு, ஒரு கூல்டவுன் காலத்திற்குத் தவிர்க்கப்படுவார்கள்.",
     "resilienceProviderCooldownMin": "குறைந்தபட்ச கூல்டவுன்",
     "resilienceProviderCooldownMax": "அதிகபட்ச கூல்டவுன்",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "அங்கீகாரத் தகவல் உடல்நலச் சோதனை",
+    "resilienceCredentialHealthScope": "அனைத்து செயலில் உள்ள API-விசை மற்றும் OAuth இணைப்புகள்",
+    "resilienceCredentialHealthTrigger": "நிலையான தாளத்தில் கால இடைவெளியில்",
+    "resilienceCredentialHealthEffect": "ஒவ்வொரு இணைப்பின் அங்கீகாரத் தகவலையும் சோதித்து செயலில்/பிழை எனக் குறிக்கிறது; தோல்வியுற்ற இணைப்புகள் அடுக்குக் காத்திருப்புக்குச் செல்கின்றன",
+    "resilienceCredentialHealthDesc": "ஒவ்வொரு செயலில் உள்ள இணைப்பின் அங்கீகாரத் தகவலையும் அதன் வழங்குநரை அழைத்து சரிபார்க்கும் பின்னணி ஸ்கேன். முழுவதும் அணைக்க 0 அமைக்கவும். இணைப்பு வாரிய உடல்நலச் சோதனை மதிப்புகள் (திருத்த உரையாடலில்) எப்போதும் இந்த உலகளாவிய இயல்புநிலையை மீறுகின்றன.",
+    "resilienceCredentialHealthInterval": "உலகளாவிய சோதனை இடைவெளி",
+    "resilienceCredentialHealthEveryMinutes": "ஒவ்வொரு {minutes} நிமிடமும்",
+    "resilienceCredentialHealthHint": "0 பின்னணி ஸ்கேனை அணைக்கிறது (அதிகபட்சம் 1440 நிமிடம் = 24 மணி). சொந்த உடல்நலச் சோதனை மதிப்புள்ள இணைப்புகள் இந்த உலகளாவிய இயல்புநிலையைப் புறக்கணிக்கின்றன; ஒரு இணைப்பில் 0 உலகளாவிய ஸ்கேன் இயங்கினாலும் அதை விலக்குகிறது.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "அமர்வு அஃபினிட்டி",
@@ -11331,11 +11331,11 @@
       "copy": "பதிப்பேற்றவும்",
       "autoscrollOn": "ஆட்டோஸ்கிரோல்: இயக்கம்",
       "autoscrollOff": "ஆட்டோஸ்க்ரோல்: அணைப்பு",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "அனைத்தையும் சுருக்கு",
+      "collapseOneLevel": "ஒரு நிலையைச் சுருக்கு",
+      "currentExpandLevel": "தற்போதைய விரிவாக்க நிலை",
+      "expandOneLevel": "ஒரு நிலையை விரிவாக்கு",
+      "expandAllLevels": "அனைத்தையும் விரிவாக்கு",
       "payload": {
         "clientRawRequest": "கிளையனின் கச்சா கோரிக்கை",
         "clientRequest": "கிளையனின் கோரிக்கை",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "இதன்படி வரிசைப்படுத்து",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "கைமுறை",
+        "provider": "வழங்குநர்",
+        "score": "மதிப்பெண் (இலவச மாதிரிகள்)",
+        "name": "பெயர்"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "மதிப்பெண் வரிசை இலவச வழங்குநர்களுக்கு மட்டுமே; மற்றவை இடத்திலேயே இருக்கும்."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "పూర్తయిన అన్ని బ్యాచ్‌లను తొలగించండి",
     "batchListBatchesTable": "బ్యాచ్‌లు",
     "changelogViewerLoading": "GitHub నుండి చేంజ్లాగ్ లోడ్ అవుతోంది...",
-    "profile": "__MISSING__:Profile",
+    "profile": "ప్రొఫైల్",
     "profileLoading": "ప్రొఫైల్ లోడ్ అవుతోంది...",
     "profileHowToEarn": "ఎలా సంపాదించాలి",
     "bootstrapBannerDismiss": "తొలగించు",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "ప్రారంభించినప్పుడు, విఫలమైన ప్రొవైడర్‌లు ప్రపంచవ్యాప్తంగా ట్రాక్ చేయబడతాయి మరియు కూల్‌డౌన్ వ్యవధి కోసం దాటవేయబడతాయి.",
     "resilienceProviderCooldownMin": "కనీస కూల్‌డౌన్",
     "resilienceProviderCooldownMax": "గరిష్ట కూల్‌డౌన్",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "క్రెడెన్షియల్ ఆరోగ్య తనిఖీ",
+    "resilienceCredentialHealthScope": "అన్ని క్రియాశీల API-కీ మరియు OAuth కనెక్షన్లు",
+    "resilienceCredentialHealthTrigger": "నిర్ణీత లయలో కాలానుగుణంగా",
+    "resilienceCredentialHealthEffect": "ప్రతి కనెక్షన్ క్రెడెన్షియల్‌ను పరిశీలించి క్రియాశీల/లోపం అని గుర్తిస్తుంది; విఫలమైన కనెక్షన్లు ఘాతాంక బ్యాకాఫ్‌లోకి వెళ్తాయి",
+    "resilienceCredentialHealthDesc": "ప్రతి క్రియాశీల కనెక్షన్ క్రెడెన్షియల్‌ను దాని ప్రొవైడర్‌ను పిలిచి ధృవీకరించే నేపథ్య స్కాన్. పూర్తిగా ఆపడానికి 0 సెట్ చేయండి. కనెక్షన్ వారీ ఆరోగ్య తనిఖీ విలువలు (సవరణ డైలాగ్‌లో) ఎల్లప్పుడూ ఈ గ్లోబల్ డిఫాల్ట్‌ను ఓవర్‌రైడ్ చేస్తాయి.",
+    "resilienceCredentialHealthInterval": "గ్లోబల్ తనిఖీ విరామం",
+    "resilienceCredentialHealthEveryMinutes": "ప్రతి {minutes} నిమి",
+    "resilienceCredentialHealthHint": "0 నేపథ్య స్కాన్‌ను ఆపుతుంది (గరిష్ఠం 1440 నిమి = 24 గం). స్వంత ఆరోగ్య తనిఖీ విలువ ఉన్న కనెక్షన్లు ఈ గ్లోబల్ డిఫాల్ట్‌ను విస్మరిస్తాయి; ఒక కనెక్షన్‌పై 0 గ్లోబల్ స్కాన్ ఆన్‌లో ఉన్నా దాన్ని మినహాయిస్తుంది.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "సెషన్ అఫినిటీ",
@@ -11331,11 +11331,11 @@
       "copy": "కాపీ",
       "autoscrollOn": "ఆటోస్క్రోల్: ఆన్",
       "autoscrollOff": "ఆటోస్క్రోల్: ఆఫ్",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "అన్నీ కుదించు",
+      "collapseOneLevel": "ఒక స్థాయి కుదించు",
+      "currentExpandLevel": "ప్రస్తుత విస్తరణ స్థాయి",
+      "expandOneLevel": "ఒక స్థాయి విస్తరించు",
+      "expandAllLevels": "అన్నీ విస్తరించు",
       "payload": {
         "clientRawRequest": "క్లయింట్ రా అభ్యర్థన",
         "clientRequest": "క్లయింట్ అభ్యర్థన",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "దీని ప్రకారం క్రమం",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "మాన్యువల్",
+        "provider": "ప్రొవైడర్",
+        "score": "స్కోరు (ఉచిత మోడళ్లు)",
+        "name": "పేరు"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "స్కోరు క్రమం ఉచిత ప్రొవైడర్లకు మాత్రమే; మిగతావి చోటులోనే ఉంటాయి."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "ลบแบทช์ที่เสร็จสมบูรณ์ทั้งหมด",
     "batchListBatchesTable": "แบตช์",
     "changelogViewerLoading": "กำลังโหลดบันทึกการเปลี่ยนแปลงจาก GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "โปรไฟล์",
     "profileLoading": "กำลังโหลดโปรไฟล์...",
     "profileHowToEarn": "วิธีการได้รับ",
     "bootstrapBannerDismiss": "ยกเลิก",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "เมื่อเปิดใช้งาน ผู้ให้บริการที่ล้มเหลวจะถูกติดตามทั่วทั้งระบบและถูกข้ามเป็นระยะเวลาคูลดาวน์",
     "resilienceProviderCooldownMin": "คูลดาวน์ขั้นต่ำ",
     "resilienceProviderCooldownMax": "คูลดาวน์สูงสุด",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "การตรวจสุขภาพข้อมูลรับรอง",
+    "resilienceCredentialHealthScope": "การเชื่อมต่อ API-key และ OAuth ที่ใช้งานทั้งหมด",
+    "resilienceCredentialHealthTrigger": "เป็นระยะ ตามจังหวะคงที่",
+    "resilienceCredentialHealthEffect": "ตรวจข้อมูลรับรองของการเชื่อมต่อแต่ละรายการแล้วทำเครื่องหมายว่าใช้งาน/ข้อผิดพลาด การเชื่อมต่อที่ล้มเหลวเข้าสู่การถอยแบบเอ็กซ์โพเนนเชียล",
+    "resilienceCredentialHealthDesc": "การกวาดพื้นหลังที่ตรวจสอบข้อมูลรับรองของการเชื่อมต่อที่ใช้งานแต่ละรายการโดยเรียกผู้ให้บริการ ตั้งเป็น 0 เพื่อปิดทั้งหมด ค่าการตรวจสุขภาพต่อรายการเชื่อมต่อ (ในกล่องแก้ไข) จะทับค่าเริ่มต้นส่วนกลางนี้เสมอ",
+    "resilienceCredentialHealthInterval": "ช่วงตรวจส่วนกลาง",
+    "resilienceCredentialHealthEveryMinutes": "ทุก {minutes} นาที",
+    "resilienceCredentialHealthHint": "0 ปิดการกวาดพื้นหลัง (สูงสุด 1440 นาที = 24 ชม.) การเชื่อมต่อที่มีค่าการตรวจสุขภาพของตัวเองจะไม่ใช้ค่าเริ่มต้นส่วนกลางนี้ ค่า 0 บนการเชื่อมต่อหนึ่งรายการจะตัดออกแม้การกวาดส่วนกลางเปิดอยู่",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Session affinity",
@@ -11331,11 +11331,11 @@
       "copy": "คัดลอก",
       "autoscrollOn": "เลื่อนอัตโนมัติ: เปิดใช้งาน",
       "autoscrollOff": "เลื่อนอัตโนมัติ: ปิด",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "ยุบทั้งหมด",
+      "collapseOneLevel": "ยุบหนึ่งระดับ",
+      "currentExpandLevel": "ระดับการขยายปัจจุบัน",
+      "expandOneLevel": "ขยายหนึ่งระดับ",
+      "expandAllLevels": "ขยายทั้งหมด",
       "payload": {
         "clientRawRequest": "คำขอดิบของลูกค้า",
         "clientRequest": "คำขอของลูกค้า",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "เรียงตาม",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "ด้วยตนเอง",
+        "provider": "ผู้ให้บริการ",
+        "score": "คะแนน (โมเดลฟรี)",
+        "name": "ชื่อ"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "การเรียงตามคะแนนใช้กับผู้ให้บริการฟรีเท่านั้น ที่เหลืออยู่ที่เดิม"
     }
   },
   "comboControl": {

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Tamamlanan tüm grupları sil",
     "batchListBatchesTable": "Gruplar",
     "changelogViewerLoading": "GitHub'dan değişiklik günlüğü yükleniyor...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Profil",
     "profileLoading": "Profil yükleniyor...",
     "profileHowToEarn": "Nasıl kazanılır",
     "bootstrapBannerDismiss": "Reddet",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Etkinleştirildiğinde, başarısız sağlayıcılar küresel olarak izlenir ve bir bekleme süresi boyunca atlanır.",
     "resilienceProviderCooldownMin": "Minimum bekleme süresi",
     "resilienceProviderCooldownMax": "Maksimum bekleme süresi",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Kimlik bilgisi sağlık denetimi",
+    "resilienceCredentialHealthScope": "Tüm etkin API anahtarı ve OAuth bağlantıları",
+    "resilienceCredentialHealthTrigger": "Düzenli aralıklarla, sabit ritimde",
+    "resilienceCredentialHealthEffect": "Her bağlantının kimlik bilgisini denetler ve etkin/hata olarak işaretler; başarısız bağlantılar üstel geri çekilmeye girer",
+    "resilienceCredentialHealthDesc": "Her etkin bağlantının kimlik bilgisini sağlayıcısını çağırarak doğrulayan arka plan taraması. Tamamen kapatmak için 0 yapın. Bağlantı başına sağlık denetimi değerleri (düzenleme iletişim kutusunda) her zaman bu genel varsayılanı geçersiz kılar.",
+    "resilienceCredentialHealthInterval": "Genel denetim aralığı",
+    "resilienceCredentialHealthEveryMinutes": "Her {minutes} dk",
+    "resilienceCredentialHealthHint": "0 arka plan taramasını kapatır (en fazla 1440 dk = 24 sa). Kendi sağlık denetimi değeri olan bağlantılar bu genel varsayılanı yok sayar; bir bağlantıda 0, genel tarama açıkken bile onu dışarıda bırakır.",
     "forcedFingerprintTitle": "{provider} için her zaman etkin — OAuth hesap güvenliği için gerekli; kapatılamaz.",
     "forcedFingerprintBadge": "Zorunlu",
     "sessionAffinityTitle": "Oturum bağlılığı",
@@ -11331,11 +11331,11 @@
       "copy": "Kopyala",
       "autoscrollOn": "Otomatik Kaydırma: açık",
       "autoscrollOff": "Otomatik Kaydırma: kapalı",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Tümünü daralt",
+      "collapseOneLevel": "Bir düzey daralt",
+      "currentExpandLevel": "Geçerli genişletme düzeyi",
+      "expandOneLevel": "Bir düzey genişlet",
+      "expandAllLevels": "Tümünü genişlet",
       "payload": {
         "clientRawRequest": "İstemci Ham İsteği",
         "clientRequest": "Müşteri Talebi",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Şuna göre sırala",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Elle",
+        "provider": "Sağlayıcı",
+        "score": "Puan (ücretsiz modeller)",
+        "name": "Ad"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Puan sıralaması yalnızca ücretsiz sağlayıcılar içindir; diğerleri yerinde kalır."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "Видалити всі завершені пакети",
     "batchListBatchesTable": "Партії",
     "changelogViewerLoading": "Завантаження журналу змін із GitHub...",
-    "profile": "__MISSING__:Profile",
+    "profile": "Профіль",
     "profileLoading": "Завантаження профілю...",
     "profileHowToEarn": "Як заробити",
     "bootstrapBannerDismiss": "Відхилити",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "Якщо ввімкнено, провайдери зі збоями відстежуються глобально та пропускаються на період кулдауну.",
     "resilienceProviderCooldownMin": "Мінімальний кулдаун",
     "resilienceProviderCooldownMax": "Максимальний кулдаун",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "Перевірка стану облікових даних",
+    "resilienceCredentialHealthScope": "Усі активні підключення з API-ключем і OAuth",
+    "resilienceCredentialHealthTrigger": "Періодично, з фіксованим ритмом",
+    "resilienceCredentialHealthEffect": "Перевіряє облікові дані кожного підключення й позначає його активним/помилкою; невдалі підключення йдуть у експоненційний backoff",
+    "resilienceCredentialHealthDesc": "Фонове сканування, яке перевіряє облікові дані кожного активного підключення, викликаючи його провайдера. Встановіть 0, щоб повністю вимкнути. Значення перевірки стану для окремого підключення (у діалозі редагування) завжди перекривають цей глобальний параметр.",
+    "resilienceCredentialHealthInterval": "Глобальний інтервал перевірки",
+    "resilienceCredentialHealthEveryMinutes": "Кожні {minutes} хв",
+    "resilienceCredentialHealthHint": "0 вимикає фонове сканування (макс. 1440 хв = 24 год). Підключення з власним значенням перевірки стану ігнорують цей глобальний параметр; 0 у конкретного підключення виключає його навіть коли глобальне сканування увімкнено.",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "Прив'язка сесії",
@@ -11331,11 +11331,11 @@
       "copy": "Копіювати",
       "autoscrollOn": "Автопрокрутка: увімкнено",
       "autoscrollOff": "Автопрокрутка: вимкнено",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "Згорнути все",
+      "collapseOneLevel": "Згорнути на рівень",
+      "currentExpandLevel": "Поточний рівень розгортання",
+      "expandOneLevel": "Розгорнути на рівень",
+      "expandAllLevels": "Розгорнути все",
       "payload": {
         "clientRawRequest": "Сирий запит клієнта",
         "clientRequest": "Запит клієнта",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "Сортувати за",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "Вручну",
+        "provider": "Провайдер",
+        "score": "Оцінка (безкоштовні моделі)",
+        "name": "Назва"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "Сортування за оцінкою діє лише для безкоштовних провайдерів; решта лишаються на місці."
     }
   },
   "comboControl": {

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "تمام مکمل شدہ بیچز کو حذف کریں۔",
     "batchListBatchesTable": "بیچز",
     "changelogViewerLoading": "GitHub سے چینج لاگ لوڈ ہو رہا ہے...",
-    "profile": "__MISSING__:Profile",
+    "profile": "پروفائل",
     "profileLoading": "پروفائل لوڈ ہو رہا ہے...",
     "profileHowToEarn": "کیسے کمایا جائے۔",
     "bootstrapBannerDismiss": "برطرف کرنا",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "فعال ہونے پر، ناکام پرووائیڈرز کو عالمی سطح پر ٹریک کیا جاتا ہے اور کول ڈاؤن کی مدت کے لیے چھوڑ دیا جاتا ہے۔",
     "resilienceProviderCooldownMin": "کم از کم کول ڈاؤن",
     "resilienceProviderCooldownMax": "زیادہ سے زیادہ کول ڈاؤن",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "کریڈینشل صحت کی جانچ",
+    "resilienceCredentialHealthScope": "تمام فعال API-کی اور OAuth کنکشن",
+    "resilienceCredentialHealthTrigger": "مقررہ تال پر وقفے وقفے سے",
+    "resilienceCredentialHealthEffect": "ہر کنکشن کی کریڈینشل جانچتا ہے اور اسے فعال/خرابی نشان زد کرتا ہے؛ ناکام کنکشن نمایی بیک آف میں جاتے ہیں",
+    "resilienceCredentialHealthDesc": "پس منظر اسکین جو ہر فعال کنکشن کی کریڈینشل اس کے فراہم کنندہ کو کال کر کے تصدیق کرتا ہے۔ مکمل بند کرنے کے لیے 0 سیٹ کریں۔ فی کنکشن صحت کی جانچ کی قدریں (ترمیم مکالمے میں) ہمیشہ اس عالمی ڈیفالٹ کو اوور رائیڈ کرتی ہیں۔",
+    "resilienceCredentialHealthInterval": "عالمی جانچ وقفہ",
+    "resilienceCredentialHealthEveryMinutes": "ہر {minutes} منٹ",
+    "resilienceCredentialHealthHint": "0 پس منظر اسکین بند کرتا ہے (زیادہ سے زیادہ 1440 منٹ = 24 گھنٹے)۔ اپنی صحت کی جانچ کی قدر والے کنکشن اس عالمی ڈیفالٹ کو نظر انداز کرتے ہیں؛ کسی کنکشن پر 0 اسے عالمی اسکین چالو ہونے پر بھی باہر رکھتا ہے۔",
     "forcedFingerprintTitle": "Always enabled for {provider} — required for OAuth account safety; cannot be turned off.",
     "forcedFingerprintBadge": "Required",
     "sessionAffinityTitle": "سیشن افینیٹی",
@@ -11331,11 +11331,11 @@
       "copy": "نقل کریں",
       "autoscrollOn": "خودکار اسکرول: آن",
       "autoscrollOff": "آٹو اسکرول: بند",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "سب سکیڑیں",
+      "collapseOneLevel": "ایک سطح سکیڑیں",
+      "currentExpandLevel": "موجودہ پھیلاؤ کی سطح",
+      "expandOneLevel": "ایک سطح پھیلائیں",
+      "expandAllLevels": "سب پھیلائیں",
       "payload": {
         "clientRawRequest": "کلائنٹ خام درخواست",
         "clientRequest": "کلائنٹ کی درخواست",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "ترتیب دیں",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "دستی",
+        "provider": "فراہم کنندہ",
+        "score": "اسکور (مفت ماڈل)",
+        "name": "نام"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "اسکور کی ترتیب صرف مفت فراہم کنندگان پر لاگو ہوتی ہے؛ باقی اپنی جگہ رہتے ہیں۔"
     }
   },
   "comboControl": {

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "删除所有已完成的批次",
     "batchListBatchesTable": "批次",
     "changelogViewerLoading": "正在从 GitHub 加载变更日志...",
-    "profile": "__MISSING__:Profile",
+    "profile": "个人资料",
     "profileLoading": "正在加载个人资料...",
     "profileHowToEarn": "如何赚取",
     "bootstrapBannerDismiss": "解雇",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "启用后，将在全局范围内跟踪失败的服务商，并在冷却期间跳过它们。",
     "resilienceProviderCooldownMin": "最小冷却时间",
     "resilienceProviderCooldownMax": "最大冷却时间",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "凭证健康检查",
+    "resilienceCredentialHealthScope": "所有启用的 API 密钥和 OAuth 连接",
+    "resilienceCredentialHealthTrigger": "按固定节奏定期执行",
+    "resilienceCredentialHealthEffect": "探测每条连接的凭证并标为正常/错误；失败的连接按指数退避",
+    "resilienceCredentialHealthDesc": "后台扫描：调用供应商以校验每条启用连接的凭证。设为 0 则完全关闭。各连接编辑对话框里的健康检查值始终覆盖此全局默认。",
+    "resilienceCredentialHealthInterval": "全局检查间隔",
+    "resilienceCredentialHealthEveryMinutes": "每 {minutes} 分钟",
+    "resilienceCredentialHealthHint": "0 关闭后台扫描（最长 1440 分钟 = 24 小时）。带有自身健康检查值的连接忽略此全局默认；某连接设为 0 时即使全局扫描开启也会跳过它。",
     "forcedFingerprintTitle": "{provider} 始终启用 — OAuth 账户安全所必需；无法关闭。",
     "forcedFingerprintBadge": "必需",
     "sessionAffinityTitle": "会话亲和性",
@@ -11331,11 +11331,11 @@
       "copy": "复制",
       "autoscrollOn": "自动滚动：开启",
       "autoscrollOff": "自动滚动：关闭",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "全部折叠",
+      "collapseOneLevel": "折叠一层",
+      "currentExpandLevel": "当前展开层级",
+      "expandOneLevel": "展开一层",
+      "expandAllLevels": "全部展开",
       "payload": {
         "clientRawRequest": "客户端原始请求",
         "clientRequest": "客户端请求",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "排序方式",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "手动",
+        "provider": "供应商",
+        "score": "评分（免费模型）",
+        "name": "名称"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "按评分排序只对免费供应商生效，其余保持原位。"
     }
   },
   "comboControl": {

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -771,7 +771,7 @@
     "batchListDeleteAllCompletedTitle": "刪除所有已完成的批次",
     "batchListBatchesTable": "批次",
     "changelogViewerLoading": "正在從 GitHub 載入變更日誌...",
-    "profile": "__MISSING__:Profile",
+    "profile": "個人資料",
     "profileLoading": "正在載入個人資料...",
     "profileHowToEarn": "如何賺取",
     "bootstrapBannerDismiss": "解僱",
@@ -8114,14 +8114,14 @@
     "resilienceProviderCooldownEnabledDesc": "啟用後，失敗的提供者會在全域範圍內被追蹤並在冷卻期間內被跳過。",
     "resilienceProviderCooldownMin": "最小冷卻",
     "resilienceProviderCooldownMax": "最大冷卻",
-    "resilienceCredentialHealthTitle": "__MISSING__:Credential Health Check",
-    "resilienceCredentialHealthScope": "__MISSING__:All active API-key and OAuth connections",
-    "resilienceCredentialHealthTrigger": "__MISSING__:Periodically, on a fixed cadence",
-    "resilienceCredentialHealthEffect": "__MISSING__:Probes each connection's credential and marks it active/error; failed connections back off exponentially",
-    "resilienceCredentialHealthDesc": "__MISSING__:Background sweep that validates every active connection's credential by calling its provider. Set 0 to disable the sweep entirely. Per-connection Health Check values (on each connection's edit dialog) always override this global default.",
-    "resilienceCredentialHealthInterval": "__MISSING__:Global check interval",
-    "resilienceCredentialHealthEveryMinutes": "__MISSING__:Every {minutes} min",
-    "resilienceCredentialHealthHint": "__MISSING__:0 disables the background sweep (max 1440 min = 24 h). Connections with their own Health Check value ignore this global default; a per-connection 0 opts that connection out even when the global sweep is on.",
+    "resilienceCredentialHealthTitle": "憑證健康檢查",
+    "resilienceCredentialHealthScope": "所有啟用的 API 金鑰與 OAuth 連線",
+    "resilienceCredentialHealthTrigger": "依固定節奏定期執行",
+    "resilienceCredentialHealthEffect": "探測每條連線的憑證並標為正常/錯誤；失敗的連線採指數退避",
+    "resilienceCredentialHealthDesc": "背景掃描：呼叫供應商以驗證每條啟用連線的憑證。設為 0 則完全關閉。各連線編輯對話框裡的健康檢查值一律覆寫此全域預設。",
+    "resilienceCredentialHealthInterval": "全域檢查間隔",
+    "resilienceCredentialHealthEveryMinutes": "每 {minutes} 分鐘",
+    "resilienceCredentialHealthHint": "0 關閉背景掃描（最長 1440 分鐘 = 24 小時）。帶有自身健康檢查值的連線忽略此全域預設；某連線設為 0 時即使全域掃描開啟也會略過它。",
     "forcedFingerprintTitle": "{provider} 始終啟用 — OAuth 帳戶安全所必需；無法關閉。",
     "forcedFingerprintBadge": "必需",
     "sessionAffinityTitle": "Session 親和性",
@@ -11331,11 +11331,11 @@
       "copy": "複製",
       "autoscrollOn": "自動滾動：開啟",
       "autoscrollOff": "自動滾動：關閉",
-      "collapseAllLevels": "__MISSING__:Collapse all",
-      "collapseOneLevel": "__MISSING__:Collapse one level",
-      "currentExpandLevel": "__MISSING__:Current expand level",
-      "expandOneLevel": "__MISSING__:Expand one level",
-      "expandAllLevels": "__MISSING__:Expand all",
+      "collapseAllLevels": "全部摺疊",
+      "collapseOneLevel": "摺疊一層",
+      "currentExpandLevel": "目前展開層級",
+      "expandOneLevel": "展開一層",
+      "expandAllLevels": "全部展開",
       "payload": {
         "clientRawRequest": "客戶原始請求",
         "clientRequest": "客戶請求",
@@ -13001,14 +13001,14 @@
   },
   "combo": {
     "sort": {
-      "label": "__MISSING__:Sort by",
+      "label": "排序方式",
       "method": {
-        "manual": "__MISSING__:Manual",
-        "provider": "__MISSING__:Provider",
-        "score": "__MISSING__:Score (free models)",
-        "name": "__MISSING__:Name"
+        "manual": "手動",
+        "provider": "供應商",
+        "score": "評分（免費模型）",
+        "name": "名稱"
       },
-      "scoreHint": "__MISSING__:Score ranking applies to free providers only; others stay in place."
+      "scoreHint": "依評分排序只對免費供應商生效，其餘維持原位。"
     }
   },
   "comboControl": {

--- a/tests/unit/i18n-missing-keys-12272.test.ts
+++ b/tests/unit/i18n-missing-keys-12272.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression guard for #12272 — translate pre-existing __MISSING__: i18n keys
+ * (combo.sort, requestLogger.detail expand/collapse, common.profile,
+ * settings.resilienceCredentialHealth*).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { LOCALES } from "../../src/i18n/config";
+
+const MESSAGES_DIR = fileURLToPath(new URL("../../src/i18n/messages/", import.meta.url));
+
+const UNTRANSLATED_SENTINEL = "__MISSING__:";
+
+/** Dotted paths named in #12272. Scope is these 20 keys only — other
+ *  pre-existing sentinels (e.g. common.suspicious) are out of issue. */
+const ISSUE_KEYS = [
+  "common.profile",
+  "requestLogger.detail.collapseAllLevels",
+  "requestLogger.detail.collapseOneLevel",
+  "requestLogger.detail.currentExpandLevel",
+  "requestLogger.detail.expandOneLevel",
+  "requestLogger.detail.expandAllLevels",
+  "combo.sort.label",
+  "combo.sort.method.manual",
+  "combo.sort.method.provider",
+  "combo.sort.method.score",
+  "combo.sort.method.name",
+  "combo.sort.scoreHint",
+  "settings.resilienceCredentialHealthTitle",
+  "settings.resilienceCredentialHealthScope",
+  "settings.resilienceCredentialHealthTrigger",
+  "settings.resilienceCredentialHealthEffect",
+  "settings.resilienceCredentialHealthDesc",
+  "settings.resilienceCredentialHealthInterval",
+  "settings.resilienceCredentialHealthEveryMinutes",
+  "settings.resilienceCredentialHealthHint",
+] as const;
+
+function getDotted(obj: unknown, dotted: string): unknown {
+  return dotted.split(".").reduce<unknown>((cur, k) => {
+    if (cur == null || typeof cur !== "object" || Array.isArray(cur)) return undefined;
+    return (cur as Record<string, unknown>)[k];
+  }, obj);
+}
+
+function readCatalog(filePath: string, file: string): Record<string, unknown> {
+  const content = fs.readFileSync(filePath, "utf8");
+  try {
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to parse JSON in catalog ${file} (${filePath}): ${msg}`);
+  }
+}
+
+function requireString(rawVal: unknown, label: string): string {
+  assert.equal(typeof rawVal, "string", `${label} must be a string, got ${typeof rawVal}`);
+  return rawVal as string;
+}
+
+test("#12272 all canonical locales translate the named keys without untranslated sentinels", async (t) => {
+  assert.ok(LOCALES.length > 0, "LOCALES list must not be empty");
+
+  for (const locale of LOCALES) {
+    await t.test(`locale: ${locale}`, () => {
+      const file = `${locale}.json`;
+      const filePath = path.join(MESSAGES_DIR, file);
+      assert.ok(fs.existsSync(filePath), `Catalog file missing for canonical locale: ${file}`);
+
+      const data = readCatalog(filePath, file);
+      assert.ok(
+        data && typeof data === "object" && !Array.isArray(data),
+        `Catalog ${file} must be a valid object`,
+      );
+
+      for (const key of ISSUE_KEYS) {
+        const rawVal = getDotted(data, key);
+        assert.notEqual(rawVal, undefined, `Catalog ${file} missing ${key}`);
+        const val = requireString(rawVal, `Catalog ${file} ${key}`);
+        assert.ok(val.trim().length > 0, `Catalog ${file} has empty ${key}`);
+        assert.ok(
+          !val.trim().startsWith(UNTRANSLATED_SENTINEL),
+          `Catalog ${file} has untranslated sentinel for ${key}: ${val}`,
+        );
+        if (key === "settings.resilienceCredentialHealthEveryMinutes") {
+          assert.ok(
+            val.includes("{minutes}"),
+            `Catalog ${file} ${key} must contain '{minutes}': ${val}`,
+          );
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Description

Fills in the 20 `__MISSING__:` strings named in #12272, for 39 locales. `en`, `vi`, and `pt-BR` already had real copy.

Keys:

- `common.profile`
- `requestLogger.detail.collapseAllLevels`, `collapseOneLevel`, `currentExpandLevel`, `expandOneLevel`, `expandAllLevels`
- `combo.sort.label`, `method.manual`, `method.provider`, `method.score`, `method.name`, `scoreHint`
- `settings.resilienceCredentialHealthTitle`, `Scope`, `Trigger`, `Effect`, `Desc`, `Interval`, `EveryMinutes`, `Hint`

`EveryMinutes` keeps `{minutes}`. I did not rerun `sync-ui-keys.mjs`; that tool restamps the sentinel. Other leftover sentinels (`common.suspicious` and friends) are outside this issue.

Closes #12272

## Test plan

RED on tip: `tests/unit/i18n-missing-keys-12272.test.ts` fails because 39 locales still carry the sentinel. After the translations, 43/43 pass. Stamping `zh-CN` `common.profile` back to `__MISSING__:` turns the test red; restoring it turns it green.

Also green: `i18n:check-ui-coverage`, `i18n:check-glossary`, `i18n:check-ratio`, `typecheck:core`, `check:cycles`.

## Review

LOCAL `code-forge review --mode local --committed tests/unit/i18n-missing-keys-12272.test.ts` on `07f7b64a0`. Locale JSON left out of the review window (coverage guard noise). CONFIRMED items already in this SHA: `{minutes}` check folded into the typed loop, `getDotted` uses `cur == null`, parse errors throw, path via `fileURLToPath`, string narrowing via `requireString`.
