### PR TITLE
fix(providers): resolve unsupportedParams via model aliases so K3 stops 400ing on temperature

### DIFF
--- a/open-sse/config/providerRegistry.ts
+++ b/open-sse/config/providerRegistry.ts
@@ -252,9 +252,9 @@ function ensureUnsupportedParamsPopulated(): void {
  */
 export function getUnsupportedParams(provider: string, modelId: string): readonly string[] {
   ensureUnsupportedParamsPopulated();
-  // 1. Check current provider's registry (exact match)
+  // 1. Check current provider's registry (exact match, then declared aliases)
   const entry = getRegistryEntry(provider);
-  const modelEntry = entry?.models?.find((m) => m.id === modelId);
+  const modelEntry = entry?.models?.find((m) => m.id === modelId || m.aliases?.includes(modelId));
   if (modelEntry?.unsupportedParams) return modelEntry.unsupportedParams;
 
   // 2. O(1) lookup in precomputed map (handles cross-provider routing)

--- a/open-sse/config/providers/registry/moonshot/index.ts
+++ b/open-sse/config/providers/registry/moonshot/index.ts
@@ -5,6 +5,12 @@ import { REASONING_UNSUPPORTED, type RegistryEntry, type RegistryModel } from ".
 export const KIMI_K3_MODEL: RegistryModel = {
   id: "kimi-k3",
   name: "Kimi K3",
+  // Moonshot's LIVE catalogue serves this model as `k3` and `k3-256k` (the
+  // 256K-context cut), NOT as `kimi-k3`. Both spellings must resolve to this
+  // entry or `getUnsupportedParams` returns [] and temperature reaches an
+  // upstream that hard-400s ("invalid temperature: only 1 is allowed for this
+  // model") — which silently drops the target out of every combo it sits in.
+  aliases: ["k3", "k3-256k"],
   contextLength: 1048576,
   maxOutputTokens: 1048576,
   supportsVision: true,

--- a/tests/unit/moonshot-k3-unsupported-params-aliases.test.ts
+++ b/tests/unit/moonshot-k3-unsupported-params-aliases.test.ts
@@ -1,0 +1,67 @@
+// tests/unit/moonshot-k3-unsupported-params-aliases.test.ts
+//
+// Live incident (2026-09-07): every `moonshot/k3-256k` hop in the `judge` and
+// `best-reasoning-paid` combos hard-400'd with
+//   "invalid temperature: only 1 is allowed for this model"
+// because the registry catalogues the model as `kimi-k3` while Moonshot's live
+// catalogue serves it as `k3` / `k3-256k`. `getUnsupportedParams` matched on the
+// canonical id only, returned [], and temperature was forwarded upstream.
+//
+// The kimi-coding provider (`kmc`/`kmca`) serves its OWN `k3`/`k3-256k` over the
+// Anthropic-format path and DOES accept temperature — verified live: temp=0
+// returns 200 there. So the resolution must stay provider-scoped; a global
+// alias index would wrongly strip temperature for kimi-coding.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getUnsupportedParams } from "../../open-sse/config/providerRegistry.ts";
+
+const stripsTemperature = (provider: string, modelId: string): boolean =>
+  getUnsupportedParams(provider, modelId).includes("temperature");
+
+test("moonshot live K3 ids resolve to the kimi-k3 reasoning restrictions", () => {
+  for (const modelId of ["k3", "k3-256k", "kimi-k3"]) {
+    assert.equal(
+      stripsTemperature("moonshot", modelId),
+      true,
+      `moonshot/${modelId} must strip temperature`
+    );
+  }
+});
+
+test("the kimi provider shares the moonshot catalogue and resolves the same aliases", () => {
+  assert.equal(stripsTemperature("kimi", "k3-256k"), true);
+  assert.equal(stripsTemperature("kimi", "k3"), true);
+});
+
+test("full REASONING_UNSUPPORTED set resolves via alias, not just temperature", () => {
+  const viaAlias = getUnsupportedParams("moonshot", "k3-256k");
+  const viaCanonical = getUnsupportedParams("moonshot", "kimi-k3");
+  assert.deepEqual([...viaAlias], [...viaCanonical]);
+  for (const param of ["temperature", "top_p", "frequency_penalty", "n"]) {
+    assert.ok(viaAlias.includes(param), `expected ${param} in alias-resolved params`);
+  }
+});
+
+test("kimi-coding keeps temperature — its k3 ids are a DIFFERENT upstream that accepts it", () => {
+  for (const provider of ["kimi-coding", "kmc", "kimi-coding-apikey", "kmca"]) {
+    for (const modelId of ["k3", "k3-256k"]) {
+      assert.equal(
+        stripsTemperature(provider, modelId),
+        false,
+        `${provider}/${modelId} must NOT strip temperature`
+      );
+    }
+  }
+});
+
+test("non-K3 moonshot models are unaffected by the alias resolution", () => {
+  // kimi-for-coding has no unsupportedParams and accepts temperature live.
+  assert.equal(stripsTemperature("moonshot", "kimi-for-coding"), false);
+  // Sibling reasoning models keep their existing restrictions.
+  assert.equal(stripsTemperature("moonshot", "kimi-k2.7-code"), true);
+  assert.equal(stripsTemperature("moonshot", "kimi-k2.6"), true);
+});
+
+test("an unknown model id still resolves to no restrictions", () => {
+  assert.deepEqual([...getUnsupportedParams("moonshot", "definitely-not-a-model")], []);
+});


### PR DESCRIPTION
## Summary

Moonshot's live catalogue serves Kimi K3 as `k3` and `k3-256k`, but the registry catalogues it as
`kimi-k3`. `getUnsupportedParams()` matched on the canonical `RegistryModel.id` only, so both live
ids resolved to `[]`, `temperature` was forwarded upstream, and Moonshot hard-400'd:

```
invalid temperature: only 1 is allowed for this model
```

The failure is **invisible by construction**: the lookup returns an empty list rather than raising,
and inside a combo the 400 is swallowed by failover — so the combo still answers `200` while never
actually serving K3. Nothing in the logs says "restriction lookup missed".

Live impact, 7 days of `call_logs` on a production gateway: **188** 400s on this exact error, **157**
of them one combo's K3 step. Only calls passing an explicit `temperature` are affected — omitting it
lets Moonshot apply its own default, which is why the same model shows **1659** successful responses
over the same window. That mix is what kept this quiet.

Both halves of the fix are load-bearing (mutation-verified below):

- declare the live ids as `aliases` on `KIMI_K3_MODEL`
- match `m.aliases` alongside `m.id` in the provider-scoped lookup

**Deliberately provider-scoped, not global.** `kimi-coding` (`kmc`/`kmca`) serves its *own*
`k3`/`k3-256k` over the Anthropic path and **does** accept `temperature`. Indexing these aliases into
the global `_unsupportedParamsMap` would wrongly strip a supported param there. A test pins that
boundary so a future refactor can't quietly globalise it.

## Related Issues

- Related to #

## Validation

- [x] Change type: **provider**
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base (`release/v3.8.51`); focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

Run on top of `release/v3.8.51`:

```
node --import tsx/esm --test tests/unit/moonshot-k3-unsupported-params-aliases.test.ts
# tests 6 / pass 6 / fail 0

npm run typecheck:core   # exit 0, no errors
npm run lint             # exit 0
npx prettier --check <changed files>   # all match
```

**Mutation proof (each half reverted independently, test file kept in place):**

| Mutation | Result |
| --- | --- |
| revert `providerRegistry.ts` only | 6 tests, **3 pass / 3 fail** |
| revert `moonshot/index.ts` aliases only | 6 tests, **3 pass / 3 fail** |
| both restored | 6 tests, **6 pass / 0 fail** |

Test count stays 6 in every run, so the failures are real assertions flipping — not a suite that
failed to load.

**Live verification.** Built and deployed to a production gateway; the request that returned 400
before now returns 200 and the strip is visible in the logs:

```
Stripped unsupported params for k3-256k: temperature
```

| request | before | after |
| --- | --- | --- |
| `moonshot/k3-256k`, `temperature: 0` | 400 invalid temperature | 200 |
| `moonshot/k3-256k`, `temperature: 0.7` | 400 invalid temperature | 200 |
| `moonshot/k3`, `temperature: 0` | 400 invalid temperature | 200 |

## Tests Added Or Updated

- `tests/unit/moonshot-k3-unsupported-params-aliases.test.ts` (new, 6 cases): both live ids resolve
  to the restriction set, the canonical id keeps working, the `kimi-coding` boundary stays
  unstripped, and an unknown id still resolves to no restrictions.

## Coverage Notes

Touches `open-sse/config/`. Both changed functions are covered by the new test: the alias branch in
`getUnsupportedParams()` and the `aliases` field it reads. Coverage does not move down in either
file — the diff is 2 changed lines plus 6 added, all exercised.

## Reviewer Notes

- **Scope kept to one story.** This branch is the moonshot fix alone. Unrelated reasoning-budget
  commits that shared my working branch were deliberately excluded — verified by file list, the diff
  is 3 files.
- **The risky direction is generalising this.** If a future change moves alias resolution into the
  global map, `kmc`/`kmca` silently lose `temperature` support. That is exactly what the fourth test
  case guards.
- No migration, no feature flag, no config key. Behaviour change is limited to which params are
  stripped for Moonshot's K3 ids.
- I do not have a reproducible upstream account to file an issue against; the impact numbers come
  from my own deployment's `call_logs` and are labelled as such rather than presented as general.
