### PR TITLE
chore(quality): rebaseline chatCore.ts after the non-streaming regression fixes

### DIFF
--- a/config/quality/file-size-baseline.json
+++ b/config/quality/file-size-baseline.json
@@ -424,14 +424,13 @@
     "open-sse/executors/codex.ts": 1505,
     "open-sse/executors/cursor.ts": 1759,
     "open-sse/executors/muse-spark-web.ts": 1405,
-    "open-sse/handlers/chatCore.ts": 5984,
+    "open-sse/handlers/chatCore.ts": 6021,
     "open-sse/handlers/imageGeneration.ts": 3259,
     "open-sse/handlers/search.ts": 1789,
     "open-sse/mcp-server/schemas/tools.ts": 1621,
     "open-sse/mcp-server/server.ts": 1572,
     "open-sse/services/accountFallback.ts": 2467,
     "open-sse/services/adobeFireflyBrowserLogin.ts": 1401,
-    "open-sse/services/combo.ts": 4084,
     "open-sse/services/combo.ts": 4080,
     "open-sse/services/combo/executeTargetAttempt.ts": 1205,
     "open-sse/translator/response/openai-responses.ts": 1466,
@@ -652,5 +651,6 @@
   "_rebaseline_2026_09_03_12352_apikey_acl": "PR #12352 (fix/api-key-create-acl-12275) crescimento proprio: src/lib/db/apiKeys.ts 1610->1625 (+15). A criacao de API key descartava a ACL enviada no payload; preservar essa ACL exige carregar e persistir o conjunto no mesmo chokepoint de INSERT do modulo de dominio, sem extracao possivel sem partir a funcao de criacao ao meio. Coberto pelos testes do proprio PR (54/54 focados na leva).",
   "_rebaseline_2026_09_03_houminxi_combo_stacked": "Leva HouMinXi (#12624 #12626 #12632 #12637): open-sse/services/combo.ts 4075->4080 (+5), medido no tip com os quatro mergeados. Cada PR registrou o proprio crescimento contra o tip de onde forkou (o #12637 ja subira o cap para 4075); as 5 linhas restantes so aparecem quando eles empilham, porque mais de um toca o mesmo chokepoint de scoring reset-aware em combo.ts. Fiacao em ponto existente, sem extracao possivel sem partir a funcao de selecao de alvos. Coberto por combo-strategies e reset-aware-request-scope-12600 (119/119 focados na leva).",
   "_rebaseline_2026_09_04_12641_continuation_effective_input": "PR #12641 crescimento proprio: src/sse/handlers/chat.ts 2450->2454 (+4). A continuacao por previous_response_id encadeava a partir de clientRawRequest.body.input, que e capturado ANTES da reconstrucao do proprio chat.ts; quando o turno anterior ja era uma continuacao, esse campo guarda so o delta do cliente, e o erro se acumulava a cada salto ate a reconstrucao virar itens de tool sem prefixo. Persistir o input EFETIVO exige as linhas no ponto onde a reconstrucao termina, dentro do fluxo de despacho. Coberto por tests/unit/responses-continuation-store.test.ts (22/22 focados na leva).",
-  "_rebaseline_2026_09_05_12671_combos_usage_guide_external_store": "combos/page.tsx 5018 -> 5066: #12671 replaces the effect-based localStorage read with useSyncExternalStore; the +48 lines are the store helpers (subscribe/getSnapshot/getServerSnapshot/emit) hoisted to module scope, which is the sanctioned shape and what let the react-hooks/set-state-in-effect suppression be dropped."
+  "_rebaseline_2026_09_05_12671_combos_usage_guide_external_store": "combos/page.tsx 5018 -> 5066: #12671 replaces the effect-based localStorage read with useSyncExternalStore; the +48 lines are the store helpers (subscribe/getSnapshot/getServerSnapshot/emit) hoisted to module scope, which is the sanctioned shape and what let the react-hooks/set-state-in-effect suppression be dropped.",
+  "_rebaseline_2026_09_07_chatcore_nonstreaming_regression_fixes": "Own growth: open-sse/handlers/chatCore.ts 5984->6021 (+37). Two of my own PRs on top of #12867: #12963 pins the ok variant of the non-streaming leg result in its own binding (the discriminated-union narrowing was lost across the tool-loop reassignment, 13 TS2339 under tsconfig.typecheck-api.json), and #12990 restores four behaviours the same refactor dropped — abort classification through isLocalStreamLifecycleError, the omitted synthetic clientResponse, the claudePromptCacheLogMeta rebuild on the leg path, and the lazy fail-closed fence identity. Irreducible at the existing chokepoints: each edit sits where chatCore already owns the decision, and the helpers themselves (nonStreamingProviderLeg.ts, serverOwnedToolLoopWire.ts) are under cap. Covered by tests/unit/chatcore-translation-paths.test.ts (72/74; the 2 open are issue #13043)."
 }


### PR DESCRIPTION
## Base-red, e é meu

```
✗ open-sse/handlers/chatCore.ts: 6021 > congelado 5984 (não pode crescer)
```

Mergeei o #12963 e o #12990 sem rebaselinar o arquivo que ambos fazem crescer. Os dois passaram nos próprios gates porque cada um mediu contra o tip de onde saiu; o cap só estoura no conjunto — exatamente o padrão que o handoff da campanha anterior registrou sete vezes, e que eu repeti.

## Crescimento

`5984 → 6021`, +37 linhas, de dois PRs meus em cima do #12867:

- **#12963** fixa a variante `ok` do resultado do leg num binding próprio. A narrowing da união discriminada se perdia na reatribuição do tool loop, gerando 13 `TS2339` sob `tsconfig.typecheck-api.json`.
- **#12990** restaura quatro comportamentos que o mesmo refactor derrubou: classificação de abort via `isLocalStreamLifecycleError`, o `clientResponse` sintético que deve ser omitido, a reconstrução do `claudePromptCacheLogMeta` no caminho do leg, e a identidade de fence derivada preguiçosamente e falhando fechada.

Irredutível nos chokepoints existentes: cada edição fica onde o `chatCore` já toma a decisão, e os helpers (`nonStreamingProviderLeg.ts`, `serverOwnedToolLoopWire.ts`) estão sob o cap.

Coberto por `tests/unit/chatcore-translation-paths.test.ts` — 72/74; as 2 abertas são a issue #13043.
