### PR TITLE
fix(sse): accept complete tool calls for minimum response content

### DIFF
--- a/open-sse/services/combo/responseValidation.ts
+++ b/open-sse/services/combo/responseValidation.ts
@@ -136,6 +136,14 @@ export function extractContentText(json: unknown): string {
     if (parts.length) return parts.join("");
   }
 
+  // Anthropic Messages: accompanying text remains subject to the configured
+  // substring predicates even if this response also contains a tool_use block.
+  if (obj.type === "message" && obj.role === "assistant" && Array.isArray(obj.content)) {
+    const parts = obj.content.filter((part) => part && typeof part === "object" &&
+      (part as Record<string, unknown>).type === "text" && typeof (part as Record<string, unknown>).text === "string");
+    if (parts.length) return parts.map((part) => (part as Record<string, string>).text).join("");
+  }
+
   // Responses API: output[].content[].text
   const output = obj.output;
   if (Array.isArray(output)) {
@@ -153,6 +161,81 @@ export function extractContentText(json: unknown): string {
   }
 
   return "";
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validToolId(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 512 && /^[^\s\x00-\x1f\x7f]+$/.test(value);
+}
+
+function validToolName(value: unknown): boolean {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{1,128}$/.test(value);
+}
+
+function validJsonArguments(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    return isRecord(JSON.parse(value));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Complete non-streaming function invocations are usable output without prose.
+ * This exempts only minContentLength. Required/forbidden text and JSON-path
+ * predicates still apply; malformed calls, deltas, results, and duplicates do not.
+ */
+function hasStructuredToolInvocation(json: unknown): boolean {
+  if (!isRecord(json) || (json.error !== undefined && json.error !== null)) return false;
+
+  const ids = new Set<string>();
+  const uniqueId = (id: unknown): boolean => {
+    if (!validToolId(id) || ids.has(id)) return false;
+    ids.add(id);
+    return true;
+  };
+
+  if (Array.isArray(json.choices)) {
+    let found = false;
+    for (const choice of json.choices) {
+      if (!isRecord(choice) || !isRecord(choice.message)) continue;
+      const message = choice.message;
+      if (message.tool_calls === undefined) continue;
+      if (choice.finish_reason !== undefined && choice.finish_reason !== "tool_calls") return false;
+      if (message.role !== "assistant" || !Array.isArray(message.tool_calls) || message.tool_calls.length === 0) return false;
+      for (const call of message.tool_calls) {
+        if (!isRecord(call) || call.type !== "function" || !uniqueId(call.id)
+          || !isRecord(call.function) || !validToolName(call.function.name)
+          || !validJsonArguments(call.function.arguments)) return false;
+        found = true;
+      }
+    }
+    return found;
+  }
+
+  if (json.type === "message" && json.role === "assistant" && Array.isArray(json.content)) {
+    if (json.stop_reason !== undefined && json.stop_reason !== "tool_use") return false;
+    const calls = json.content.filter((part) => isRecord(part) && part.type === "tool_use");
+    return calls.length > 0 && calls.every((call) => isRecord(call)
+      && uniqueId(call.id) && validToolName(call.name) && isRecord(call.input));
+  }
+
+  if (json.object === "response" && Array.isArray(json.output)) {
+    if (json.status !== undefined && json.status !== "completed" && json.status !== "done") return false;
+    const calls = json.output.filter((item) => isRecord(item) && item.type === "function_call");
+    return calls.length > 0 && calls.every((call) => isRecord(call)
+      && uniqueId(call.call_id) && (call.id === undefined || validToolId(call.id))
+      && validToolName(call.name) && validJsonArguments(call.arguments)
+      && (call.status === undefined || call.status === "completed"));
+  }
+
+  return false;
 }
 
 /**
@@ -183,7 +266,8 @@ export function evaluateResponseValidation(
     typeof config.minContentLength === "number" &&
     Number.isFinite(config.minContentLength) &&
     config.minContentLength > 0 &&
-    content.trim().length < config.minContentLength
+    content.trim().length < config.minContentLength &&
+    !hasStructuredToolInvocation(json)
   ) {
     return {
       valid: false,

--- a/open-sse/services/combo/responseValidation.ts
+++ b/open-sse/services/combo/responseValidation.ts
@@ -122,8 +122,7 @@ export function extractContentText(json: unknown): string {
     const parts: string[] = [];
     for (const choice of choices) {
       const message = (choice as Record<string, unknown>)?.message as
-        | Record<string, unknown>
-        | undefined;
+        Record<string, unknown> | undefined;
       const content = message?.content;
       if (typeof content === "string") parts.push(content);
       else if (Array.isArray(content)) {
@@ -139,8 +138,13 @@ export function extractContentText(json: unknown): string {
   // Anthropic Messages: accompanying text remains subject to the configured
   // substring predicates even if this response also contains a tool_use block.
   if (obj.type === "message" && obj.role === "assistant" && Array.isArray(obj.content)) {
-    const parts = obj.content.filter((part) => part && typeof part === "object" &&
-      (part as Record<string, unknown>).type === "text" && typeof (part as Record<string, unknown>).text === "string");
+    const parts = obj.content.filter(
+      (part) =>
+        part &&
+        typeof part === "object" &&
+        (part as Record<string, unknown>).type === "text" &&
+        typeof (part as Record<string, unknown>).text === "string"
+    );
     if (parts.length) return parts.map((part) => (part as Record<string, string>).text).join("");
   }
 
@@ -208,11 +212,22 @@ function hasStructuredToolInvocation(json: unknown): boolean {
       const message = choice.message;
       if (message.tool_calls === undefined) continue;
       if (choice.finish_reason !== undefined && choice.finish_reason !== "tool_calls") return false;
-      if (message.role !== "assistant" || !Array.isArray(message.tool_calls) || message.tool_calls.length === 0) return false;
+      if (
+        message.role !== "assistant" ||
+        !Array.isArray(message.tool_calls) ||
+        message.tool_calls.length === 0
+      )
+        return false;
       for (const call of message.tool_calls) {
-        if (!isRecord(call) || call.type !== "function" || !uniqueId(call.id)
-          || !isRecord(call.function) || !validToolName(call.function.name)
-          || !validJsonArguments(call.function.arguments)) return false;
+        if (
+          !isRecord(call) ||
+          call.type !== "function" ||
+          !uniqueId(call.id) ||
+          !isRecord(call.function) ||
+          !validToolName(call.function.name) ||
+          !validJsonArguments(call.function.arguments)
+        )
+          return false;
         found = true;
       }
     }
@@ -222,17 +237,31 @@ function hasStructuredToolInvocation(json: unknown): boolean {
   if (json.type === "message" && json.role === "assistant" && Array.isArray(json.content)) {
     if (json.stop_reason !== undefined && json.stop_reason !== "tool_use") return false;
     const calls = json.content.filter((part) => isRecord(part) && part.type === "tool_use");
-    return calls.length > 0 && calls.every((call) => isRecord(call)
-      && uniqueId(call.id) && validToolName(call.name) && isRecord(call.input));
+    return (
+      calls.length > 0 &&
+      calls.every(
+        (call) =>
+          isRecord(call) && uniqueId(call.id) && validToolName(call.name) && isRecord(call.input)
+      )
+    );
   }
 
   if (json.object === "response" && Array.isArray(json.output)) {
-    if (json.status !== undefined && json.status !== "completed" && json.status !== "done") return false;
+    if (json.status !== undefined && json.status !== "completed" && json.status !== "done")
+      return false;
     const calls = json.output.filter((item) => isRecord(item) && item.type === "function_call");
-    return calls.length > 0 && calls.every((call) => isRecord(call)
-      && uniqueId(call.call_id) && (call.id === undefined || validToolId(call.id))
-      && validToolName(call.name) && validJsonArguments(call.arguments)
-      && (call.status === undefined || call.status === "completed"));
+    return (
+      calls.length > 0 &&
+      calls.every(
+        (call) =>
+          isRecord(call) &&
+          uniqueId(call.call_id) &&
+          (call.id === undefined || validToolId(call.id)) &&
+          validToolName(call.name) &&
+          validJsonArguments(call.arguments) &&
+          (call.status === undefined || call.status === "completed")
+      )
+    );
   }
 
   return false;

--- a/tests/unit/services/responseValidation.test.ts
+++ b/tests/unit/services/responseValidation.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateResponseValidation,
+} from "../../../open-sse/services/combo/responseValidation.ts";
+
+type JsonRecord = Record<string, unknown>;
+
+const minimumContent = { minContentLength: 1 };
+
+function chatCall(overrides: JsonRecord = {}): JsonRecord {
+  return {
+    id: "call-chat",
+    type: "function",
+    function: { name: "read_file", arguments: "{}" },
+    ...overrides,
+  };
+}
+
+function chatToolTurn(toolCalls: readonly unknown[] = [chatCall()], finishReason: unknown = "tool_calls"): JsonRecord {
+  return {
+    choices: [{
+      finish_reason: finishReason,
+      message: { role: "assistant", content: null, tool_calls: toolCalls },
+    }],
+  };
+}
+
+function anthropicTool(overrides: JsonRecord = {}): JsonRecord {
+  return {
+    type: "message",
+    role: "assistant",
+    stop_reason: "tool_use",
+    content: [{ type: "tool_use", id: "tool-anthropic", name: "read_file", input: {} }],
+    ...overrides,
+  };
+}
+
+function responsesTool(overrides: JsonRecord = {}): JsonRecord {
+  return {
+    object: "response",
+    status: "completed",
+    output: [{
+      type: "function_call",
+      id: "fc-response",
+      call_id: "call-response",
+      name: "read_file",
+      arguments: "{}",
+      status: "completed",
+    }],
+    ...overrides,
+  };
+}
+
+test("complete non-streaming tool calls bypass only minContentLength", () => {
+  for (const [name, body] of [
+    ["Chat", chatToolTurn()],
+    ["Anthropic", anthropicTool()],
+    ["Responses", responsesTool()],
+  ] as const) {
+    assert.equal(evaluateResponseValidation(body, minimumContent).valid, true, name);
+    assert.equal(evaluateResponseValidation(body, { minContentLength: 10_000 }).valid, true, name);
+  }
+});
+
+test("malformed, incomplete, duplicate, result, and streaming shapes keep minimum-text rejection", () => {
+  const malformed = [
+    chatToolTurn([]),
+    chatToolTurn([chatCall({ id: " " })]),
+    chatToolTurn([chatCall({ function: { name: "bad/name", arguments: "{}" } })]),
+    chatToolTurn([chatCall({ function: { name: "read_file", arguments: "[]" } })]),
+    chatToolTurn([chatCall(), chatCall()]),
+    chatToolTurn([chatCall({ type: "tool_result" })]),
+    chatToolTurn([chatCall()], "stop"),
+    anthropicTool({ role: "user" }),
+    anthropicTool({ stop_reason: "end_turn" }),
+    anthropicTool({ content: [{ type: "tool_use", id: "tool-anthropic", name: "read_file", input: [] }] }),
+    { type: "content_block_start", content_block: { type: "tool_use", id: "tool-stream", name: "read_file", input: {} } },
+    { choices: [{ delta: { tool_calls: [chatCall()] } }] },
+    responsesTool({ status: "in_progress" }),
+    responsesTool({ output: [{ type: "function_call_output", call_id: "call-response", output: "result" }] }),
+  ];
+
+  for (const body of malformed) {
+    assert.equal(evaluateResponseValidation(body, minimumContent).valid, false);
+  }
+});
+
+test("tool-only completion retains required, forbidden, and JSON-path predicates", () => {
+  const chat = chatToolTurn();
+  assert.equal(
+    evaluateResponseValidation(chat, { ...minimumContent, requiredSubstrings: ["must appear"] }).valid,
+    false,
+  );
+  assert.equal(
+    evaluateResponseValidation(chat, {
+      ...minimumContent,
+      jsonPathPredicates: [{ path: "choices[0].message.content", condition: "nonEmpty" }],
+    }).valid,
+    false,
+  );
+
+  const anthropicWithText = anthropicTool({
+    content: [
+      { type: "tool_use", id: "tool-anthropic", name: "read_file", input: {} },
+      { type: "text", text: "FORBIDDEN" },
+    ],
+  });
+  const forbidden = evaluateResponseValidation(anthropicWithText, {
+    ...minimumContent,
+    forbiddenSubstrings: ["FORBIDDEN"],
+  });
+  assert.equal(forbidden.valid, false);
+  assert.match(forbidden.reason ?? "", /forbidden substring/);
+});
+
+test("function name bounds and legacy prose remain unchanged", () => {
+  const validName = "x".repeat(128);
+  assert.equal(
+    evaluateResponseValidation(chatToolTurn([
+      chatCall({ function: { name: validName, arguments: "{}" } }),
+    ]), minimumContent).valid,
+    true,
+  );
+  assert.equal(
+    evaluateResponseValidation(chatToolTurn([
+      chatCall({ function: { name: validName + "x", arguments: "{}" } }),
+    ]), minimumContent).valid,
+    false,
+  );
+  assert.equal(
+    evaluateResponseValidation({ choices: [{ message: { content: "short" } }] }, { minContentLength: 10 }).valid,
+    false,
+  );
+});

--- a/tests/unit/services/responseValidation.test.ts
+++ b/tests/unit/services/responseValidation.test.ts
@@ -1,9 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  evaluateResponseValidation,
-} from "../../../open-sse/services/combo/responseValidation.ts";
+import { evaluateResponseValidation } from "../../../open-sse/services/combo/responseValidation.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -18,12 +16,17 @@ function chatCall(overrides: JsonRecord = {}): JsonRecord {
   };
 }
 
-function chatToolTurn(toolCalls: readonly unknown[] = [chatCall()], finishReason: unknown = "tool_calls"): JsonRecord {
+function chatToolTurn(
+  toolCalls: readonly unknown[] = [chatCall()],
+  finishReason: unknown = "tool_calls"
+): JsonRecord {
   return {
-    choices: [{
-      finish_reason: finishReason,
-      message: { role: "assistant", content: null, tool_calls: toolCalls },
-    }],
+    choices: [
+      {
+        finish_reason: finishReason,
+        message: { role: "assistant", content: null, tool_calls: toolCalls },
+      },
+    ],
   };
 }
 
@@ -41,14 +44,16 @@ function responsesTool(overrides: JsonRecord = {}): JsonRecord {
   return {
     object: "response",
     status: "completed",
-    output: [{
-      type: "function_call",
-      id: "fc-response",
-      call_id: "call-response",
-      name: "read_file",
-      arguments: "{}",
-      status: "completed",
-    }],
+    output: [
+      {
+        type: "function_call",
+        id: "fc-response",
+        call_id: "call-response",
+        name: "read_file",
+        arguments: "{}",
+        status: "completed",
+      },
+    ],
     ...overrides,
   };
 }
@@ -75,11 +80,18 @@ test("malformed, incomplete, duplicate, result, and streaming shapes keep minimu
     chatToolTurn([chatCall()], "stop"),
     anthropicTool({ role: "user" }),
     anthropicTool({ stop_reason: "end_turn" }),
-    anthropicTool({ content: [{ type: "tool_use", id: "tool-anthropic", name: "read_file", input: [] }] }),
-    { type: "content_block_start", content_block: { type: "tool_use", id: "tool-stream", name: "read_file", input: {} } },
+    anthropicTool({
+      content: [{ type: "tool_use", id: "tool-anthropic", name: "read_file", input: [] }],
+    }),
+    {
+      type: "content_block_start",
+      content_block: { type: "tool_use", id: "tool-stream", name: "read_file", input: {} },
+    },
     { choices: [{ delta: { tool_calls: [chatCall()] } }] },
     responsesTool({ status: "in_progress" }),
-    responsesTool({ output: [{ type: "function_call_output", call_id: "call-response", output: "result" }] }),
+    responsesTool({
+      output: [{ type: "function_call_output", call_id: "call-response", output: "result" }],
+    }),
   ];
 
   for (const body of malformed) {
@@ -90,15 +102,16 @@ test("malformed, incomplete, duplicate, result, and streaming shapes keep minimu
 test("tool-only completion retains required, forbidden, and JSON-path predicates", () => {
   const chat = chatToolTurn();
   assert.equal(
-    evaluateResponseValidation(chat, { ...minimumContent, requiredSubstrings: ["must appear"] }).valid,
-    false,
+    evaluateResponseValidation(chat, { ...minimumContent, requiredSubstrings: ["must appear"] })
+      .valid,
+    false
   );
   assert.equal(
     evaluateResponseValidation(chat, {
       ...minimumContent,
       jsonPathPredicates: [{ path: "choices[0].message.content", condition: "nonEmpty" }],
     }).valid,
-    false,
+    false
   );
 
   const anthropicWithText = anthropicTool({
@@ -118,19 +131,24 @@ test("tool-only completion retains required, forbidden, and JSON-path predicates
 test("function name bounds and legacy prose remain unchanged", () => {
   const validName = "x".repeat(128);
   assert.equal(
-    evaluateResponseValidation(chatToolTurn([
-      chatCall({ function: { name: validName, arguments: "{}" } }),
-    ]), minimumContent).valid,
-    true,
+    evaluateResponseValidation(
+      chatToolTurn([chatCall({ function: { name: validName, arguments: "{}" } })]),
+      minimumContent
+    ).valid,
+    true
   );
   assert.equal(
-    evaluateResponseValidation(chatToolTurn([
-      chatCall({ function: { name: validName + "x", arguments: "{}" } }),
-    ]), minimumContent).valid,
-    false,
+    evaluateResponseValidation(
+      chatToolTurn([chatCall({ function: { name: validName + "x", arguments: "{}" } })]),
+      minimumContent
+    ).valid,
+    false
   );
   assert.equal(
-    evaluateResponseValidation({ choices: [{ message: { content: "short" } }] }, { minContentLength: 10 }).valid,
-    false,
+    evaluateResponseValidation(
+      { choices: [{ message: { content: "short" } }] },
+      { minContentLength: 10 }
+    ).valid,
+    false
   );
 });


### PR DESCRIPTION
## Problem and change

A complete tool-only response can contain usable function calls and no prose. With `minContentLength` configured, response validation currently rejects that turn as empty.

Recognize complete non-streaming Chat Completions, Anthropic Messages and Responses function calls when evaluating the minimum-content predicate. Validate IDs, names, structured arguments and completion status; malformed calls, duplicate IDs, deltas and tool-result-only shapes receive no exemption. Required/forbidden substrings and JSON-path predicates remain binding. Anthropic accompanying text is included in substring checks.

## Validation

- RED regression commit: `dd7cdb1`; implementation: `5ae56f8`; formatted reviewed head: `39bce7bb099cb73d181c8dfe0fecce25b008e42a`.
- `node --test tests/unit/services/responseValidation.test.ts`: four tests passed, zero failures.
- `node --check open-sse/services/combo/responseValidation.ts` and `git diff --check` passed.
- Changed files formatted with repository-pinned Prettier 3.9.6; three-commit secret scan passed.

This draft contains two source/test files. Full Node and Vitest suites have not been run for this head; merge readiness depends on the upstream checks. Streaming handling and installed runtime bundles are outside this change.
