### PR TITLE
fix(sse): synthesize Responses SSE stream for web_search fallback on streaming requests (#13033)

### DIFF
--- a/changelog.d/fixes/13033-responses-websearch-stream.md
+++ b/changelog.d/fixes/13033-responses-websearch-stream.md
@@ -1,0 +1,1 @@
+- **fix(sse):** synthesize Responses API SSE stream when streaming requests fall back to server-side non-streaming web search execution, preventing premature stream closes in Codex CLI and other Responses clients.

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -35,6 +35,7 @@ import { buildPostCallGuardrailContext } from "./chatCore/postCallGuardrailConte
 import { storeSemanticCacheResponse } from "./chatCore/semanticCacheStore.ts";
 import { buildNonStreamingResponseHeaders } from "./chatCore/nonStreamingResponseHeaders.ts";
 import { buildNonStreamingJsonResponse } from "./chatCore/nonStreamingJsonResponse.ts";
+import { buildNonStreamingResponsesSseResponse } from "../utils/responsesJsonToSse.ts";
 import { enforceOutputTokenBudget } from "./chatCore/outputTokenBudget.ts";
 import { maybeConvertJsonBodyToSse } from "./chatCore/jsonBodyToSse.ts";
 import { assembleStreamingResponseHeaders } from "./chatCore/streamingResponseHeaders.ts";
@@ -950,19 +951,22 @@ export async function handleChatCore({
       nativeCodexPassthrough: nativeResponsesPassthrough,
       interceptSearchOverride,
     });
+  let forcedNonStreamingResponsesSse = false;
   if (webSearchFallbackPlan.enabled) {
     body = bodyWithWebSearchFallback as typeof body;
     // Server-side web-search execution cannot be injected into an arbitrary
-    // client SSE stream (streaming interception is not implemented — #9725), so
+    // client SSE stream (streaming interception is not implemented -- #9725), so
     // a stream:true OpenAI Responses request whose web_search tool was converted
     // to the fallback is executed non-streaming: the assembled response then
-    // carries the executed results (function_call_output + web_search_call) and
-    // JSON-tolerating Responses clients (pi-web-access) consume it directly.
+    // carries the executed results (function_call_output + web_search_call).
+    // When the client requested a stream, synthesize Responses SSE events from
+    // the completed response (#13033) instead of returning plain JSON.
     if (
       sourceFormat === FORMATS.OPENAI_RESPONSES &&
       (body as Record<string, unknown>).stream === true
     ) {
       (body as Record<string, unknown>).stream = false;
+      forcedNonStreamingResponsesSse = true;
       log?.info?.("TOOLS", `web_search fallback forced non-streaming response for ${provider}`);
     }
     log?.info?.(
@@ -5483,17 +5487,24 @@ export async function handleChatCore({
           retries: 0,
           fallbackUsed: false, // combo-level fallback tracked by decisionTrace
           outcome: "success",
-          status: 200,
-          finishReason: routingFinishReason(translatedResponse),
-          connectionId: credentials?.connectionId ?? null,
-        })
-      );
+        status: 200,
+        finishReason: routingFinishReason(translatedResponse),
+        connectionId: credentials?.connectionId ?? null,
+      })
+    );
 
+    if (forcedNonStreamingResponsesSse && sourceFormat === FORMATS.OPENAI_RESPONSES) {
       return {
         success: true,
-        response: buildNonStreamingJsonResponse(translatedResponse, responseHeaders),
+        response: buildNonStreamingResponsesSseResponse(translatedResponse, responseHeaders),
       };
-    } catch (error) {
+    }
+
+    return {
+      success: true,
+      response: buildNonStreamingJsonResponse(translatedResponse, responseHeaders),
+    };
+  } catch (error) {
       trackPendingRequest(model, provider, connectionId, false);
       if (isManagedLeaseFenceError(error)) return managedLeaseFenceErrorResult(error);
       if (isSemaphoreCapacityError(error)) {

--- a/open-sse/utils/responsesJsonToSse.ts
+++ b/open-sse/utils/responsesJsonToSse.ts
@@ -1,0 +1,330 @@
+/**
+ * #13033 -- Convert a complete OpenAI Responses API JSON body into an equivalent
+ * Responses SSE event stream.
+ *
+ * When an OpenAI Responses client (such as Codex CLI or Cursor) requests `stream: true`
+ * and declares tools (like `web_search`), OmniRoute may execute the upstream request
+ * non-streaming to perform server-side tool loops (web search fallback). Upstream
+ * returns a complete Responses JSON object (`status: "completed"`).
+ *
+ * Returning `Content-Type: application/json` directly to a streaming Responses client
+ * causes Codex to close early and crash with "stream closed before response.completed".
+ * This helper synthesizes the spec-compliant Responses SSE event sequence from the
+ * assembled JSON object so streaming clients receive a valid SSE stream ending with
+ * `response.completed` and `data: [DONE]`.
+ */
+
+import { randomUUID } from "node:crypto";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveResponsesRoot(value: unknown): JsonRecord | null {
+  if (!isRecord(value)) return null;
+  if (
+    isRecord(value.response) &&
+    (value.response.object === "response" || Array.isArray(value.response.output))
+  ) {
+    return value.response;
+  }
+  if (value.object === "response" || Array.isArray(value.output)) {
+    return value;
+  }
+  return null;
+}
+
+function sseEvent(eventType: string, data: unknown): string {
+  return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/**
+ * Synthesizes OpenAI Responses API SSE events from a complete Responses JSON object.
+ * Returns an empty string if the input is not a valid Responses object.
+ */
+export function synthesizeResponsesSseFromResponse(responseInput: unknown): string {
+  let record: JsonRecord | null = null;
+  if (typeof responseInput === "string") {
+    try {
+      record = resolveResponsesRoot(JSON.parse(responseInput));
+    } catch {
+      return "";
+    }
+  } else {
+    record = resolveResponsesRoot(responseInput);
+  }
+
+  if (!record) return "";
+
+  const responseId =
+    typeof record.id === "string" && record.id
+      ? record.id
+      : `resp_${randomUUID().replace(/-/g, "")}`;
+  const createdAt =
+    typeof record.created_at === "number" ? record.created_at : Math.floor(Date.now() / 1000);
+  const model = typeof record.model === "string" && record.model ? record.model : undefined;
+  const output = Array.isArray(record.output) ? (record.output as unknown[]) : [];
+
+  let stream = "";
+
+  // 1. response.created
+  const createdResponse: JsonRecord = {
+    id: responseId,
+    object: "response",
+    created_at: createdAt,
+    status: "in_progress",
+    background: false,
+    error: null,
+    output: [],
+  };
+  if (model) createdResponse.model = model;
+
+  stream += sseEvent("response.created", {
+    type: "response.created",
+    response: createdResponse,
+  });
+
+  // 2. response.in_progress
+  const inProgressResponse: JsonRecord = {
+    id: responseId,
+    object: "response",
+    created_at: createdAt,
+    status: "in_progress",
+    background: false,
+    error: null,
+    output: [],
+  };
+  if (model) inProgressResponse.model = model;
+
+  stream += sseEvent("response.in_progress", {
+    type: "response.in_progress",
+    response: inProgressResponse,
+  });
+
+  // 3. Emit output items
+  output.forEach((item, outputIndex) => {
+    if (!isRecord(item)) return;
+
+    const itemType = typeof item.type === "string" ? item.type : "";
+
+    if (itemType === "message") {
+      const itemId = typeof item.id === "string" ? item.id : `msg_${outputIndex}`;
+      const role = typeof item.role === "string" ? item.role : "assistant";
+      const content = Array.isArray(item.content) ? (item.content as unknown[]) : [];
+
+      stream += sseEvent("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: outputIndex,
+        item: {
+          id: itemId,
+          object: "realtime.item",
+          type: "message",
+          status: "in_progress",
+          role,
+          content: [],
+        },
+      });
+
+      content.forEach((part, contentIndex) => {
+        if (!isRecord(part)) return;
+        const partType = typeof part.type === "string" ? part.type : "output_text";
+
+        if (partType === "output_text" || partType === "text") {
+          stream += sseEvent("response.content_part.added", {
+            type: "response.content_part.added",
+            item_id: itemId,
+            output_index: outputIndex,
+            content_index: contentIndex,
+            part: { type: partType, text: "" },
+          });
+
+          const text = typeof part.text === "string" ? part.text : "";
+          if (text) {
+            stream += sseEvent("response.output_text.delta", {
+              type: "response.output_text.delta",
+              item_id: itemId,
+              output_index: outputIndex,
+              content_index: contentIndex,
+              delta: text,
+            });
+            stream += sseEvent("response.output_text.done", {
+              type: "response.output_text.done",
+              item_id: itemId,
+              output_index: outputIndex,
+              content_index: contentIndex,
+              text,
+            });
+          }
+
+          stream += sseEvent("response.content_part.done", {
+            type: "response.content_part.done",
+            item_id: itemId,
+            output_index: outputIndex,
+            content_index: contentIndex,
+            part,
+          });
+        } else {
+          stream += sseEvent("response.content_part.added", {
+            type: "response.content_part.added",
+            item_id: itemId,
+            output_index: outputIndex,
+            content_index: contentIndex,
+            part,
+          });
+          stream += sseEvent("response.content_part.done", {
+            type: "response.content_part.done",
+            item_id: itemId,
+            output_index: outputIndex,
+            content_index: contentIndex,
+            part,
+          });
+        }
+      });
+
+      stream += sseEvent("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: outputIndex,
+        item,
+      });
+    } else if (itemType === "function_call") {
+      const itemId = typeof item.id === "string" ? item.id : `call_${outputIndex}`;
+      const callId = typeof item.call_id === "string" ? item.call_id : itemId;
+      const args = typeof item.arguments === "string" ? item.arguments : "";
+
+      stream += sseEvent("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: outputIndex,
+        item: {
+          ...item,
+          arguments: "",
+          status: "in_progress",
+        },
+      });
+
+      if (args) {
+        stream += sseEvent("response.function_call_arguments.delta", {
+          type: "response.function_call_arguments.delta",
+          item_id: itemId,
+          call_id: callId,
+          output_index: outputIndex,
+          delta: args,
+        });
+        stream += sseEvent("response.function_call_arguments.done", {
+          type: "response.function_call_arguments.done",
+          item_id: itemId,
+          call_id: callId,
+          output_index: outputIndex,
+          arguments: args,
+        });
+      }
+
+      stream += sseEvent("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: outputIndex,
+        item,
+      });
+    } else {
+      // Other output items (web_search_call, function_call_output, reasoning, etc.)
+      const addedItem = typeof item.status === "string" ? { ...item, status: "in_progress" } : item;
+      stream += sseEvent("response.output_item.added", {
+        type: "response.output_item.added",
+        output_index: outputIndex,
+        item: addedItem,
+      });
+      stream += sseEvent("response.output_item.done", {
+        type: "response.output_item.done",
+        output_index: outputIndex,
+        item,
+      });
+    }
+  });
+
+  // 4. response.completed
+  // Forward upstream record while omitting any internal properties prefixed with '_'
+  const sanitizedRecord: JsonRecord = {};
+  for (const [k, v] of Object.entries(record)) {
+    if (!k.startsWith("_")) {
+      sanitizedRecord[k] = v;
+    }
+  }
+
+  const completedResponse: JsonRecord = {
+    ...sanitizedRecord,
+    id: responseId,
+    created_at: createdAt,
+  };
+  if (model) completedResponse.model = model;
+
+  stream += sseEvent("response.completed", {
+    type: "response.completed",
+    response: completedResponse,
+  });
+
+  // 5. Terminal [DONE] marker
+  stream += "data: [DONE]\n\n";
+
+  return stream;
+}
+
+function synthesizeMinimalFallbackSse(fallbackPayload: unknown): string {
+  const id = `resp_fallback_${randomUUID().replace(/-/g, "")}`;
+  const created = Math.floor(Date.now() / 1000);
+  const errObj =
+    fallbackPayload && typeof fallbackPayload === "object"
+      ? (fallbackPayload as Record<string, unknown>)
+      : { error: String(fallbackPayload ?? "Unknown error") };
+  const status = errObj.error ? "failed" : "completed";
+  const completedResponse: JsonRecord = {
+    id,
+    object: "response",
+    created_at: created,
+    status,
+    output: [],
+    error: errObj.error ?? null,
+  };
+  let sse = "";
+  sse += sseEvent("response.created", {
+    type: "response.created",
+    response: {
+      id,
+      object: "response",
+      created_at: created,
+      status: "in_progress",
+      output: [],
+    },
+  });
+  sse += sseEvent("response.completed", {
+    type: "response.completed",
+    response: completedResponse,
+  });
+  sse += "data: [DONE]\n\n";
+  return sse;
+}
+
+/**
+ * Builds a 200 text/event-stream Response from a completed Responses API JSON object.
+ * If synthesis fails (e.g. malformed or empty input), safely falls back to a minimal
+ * valid Responses SSE envelope ending with response.completed and [DONE], ensuring
+ * streaming clients never crash on unexpected stream closes.
+ */
+export function buildNonStreamingResponsesSseResponse(
+  translatedResponse: unknown,
+  responseHeaders?: HeadersInit | Record<string, string>
+): Response {
+  const sseBody =
+    synthesizeResponsesSseFromResponse(translatedResponse) ||
+    synthesizeMinimalFallbackSse(translatedResponse);
+
+  const headers = new Headers(responseHeaders as HeadersInit);
+  headers.set("content-type", "text/event-stream; charset=utf-8");
+  headers.set("cache-control", "no-cache");
+  headers.set("connection", "keep-alive");
+  headers.delete("content-length");
+
+  return new Response(sseBody, {
+    status: 200,
+    headers,
+  });
+}

--- a/tests/integration/skills-pipeline.test.ts
+++ b/tests/integration/skills-pipeline.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { OMNIROUTE_WEB_SEARCH_FALLBACK_TOOL_NAME } from "../../open-sse/services/webSearchFallback.ts";
 import { decodeSkillToolName, encodeSkillToolName } from "../../src/lib/skills/injection.ts";
+import { parseSSEToResponsesOutput } from "../../open-sse/handlers/sseParser.ts";
 
 import { createChatPipelineHarness } from "./_chatPipelineHarness.ts";
 
@@ -1057,14 +1058,21 @@ test("web_search fallback executes stream:true responses requests non-streaming 
       },
     })
   );
-  const json = (await response.json()) as {
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") || "", /text\/event-stream/);
+  const sseText = await response.text();
+  assert.match(sseText, /event: response\.created/);
+  assert.match(sseText, /event: response\.completed/);
+  assert.ok(sseText.endsWith("data: [DONE]\n\n"));
+
+  const json = parseSSEToResponsesOutput(sseText, "gpt-4o-mini") as {
     output: Array<Record<string, unknown>>;
   };
+  assert.ok(json && Array.isArray(json.output));
   const webSearchCall = json.output.find((item) => item.type === "web_search_call");
   const functionCall = json.output.find((item) => item.type === "function_call");
   const functionCallOutput = json.output.find((item) => item.type === "function_call_output");
 
-  assert.equal(response.status, 200);
   // The upstream must have been called non-streaming so interception can run.
   assert.equal(upstreamBodies.length, 1);
   assert.equal(upstreamBodies[0].stream, false);

--- a/tests/unit/responses-json-to-sse-13033.test.ts
+++ b/tests/unit/responses-json-to-sse-13033.test.ts
@@ -1,0 +1,291 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  synthesizeResponsesSseFromResponse,
+  buildNonStreamingResponsesSseResponse,
+} from "../../open-sse/utils/responsesJsonToSse.ts";
+import { parseSSEToResponsesOutput } from "../../open-sse/handlers/sseParser.ts";
+
+test("synthesizeResponsesSseFromResponse produces spec-compliant SSE stream for text messages", () => {
+  const sampleResponse = {
+    id: "resp_test_123",
+    object: "response",
+    created_at: 1725000000,
+    status: "completed",
+    model: "gpt-4o-mini",
+    output: [
+      {
+        type: "message",
+        id: "msg_abc",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: "Hello, world!",
+          },
+        ],
+      },
+    ],
+    usage: {
+      input_tokens: 15,
+      output_tokens: 25,
+      total_tokens: 40,
+    },
+  };
+
+  const sse = synthesizeResponsesSseFromResponse(sampleResponse);
+  assert.ok(sse.length > 0);
+  assert.match(sse, /event: response\.created/);
+  assert.match(sse, /event: response\.in_progress/);
+  assert.match(sse, /event: response\.output_item\.added/);
+  assert.match(sse, /event: response\.content_part\.added/);
+  assert.match(sse, /event: response\.output_text\.delta/);
+  assert.match(sse, /event: response\.output_text\.done/);
+  assert.match(sse, /event: response\.output_item\.done/);
+  assert.match(sse, /event: response\.completed/);
+  assert.ok(sse.endsWith("data: [DONE]\n\n"));
+
+  // Verify round-trip parsing via parseSSEToResponsesOutput
+  const reconstructed = parseSSEToResponsesOutput(sse, "gpt-4o-mini");
+  assert.ok(reconstructed);
+  assert.equal(reconstructed.id, "resp_test_123");
+  assert.equal(reconstructed.model, "gpt-4o-mini");
+  assert.equal(reconstructed.status, "completed");
+  assert.deepEqual(reconstructed.usage, sampleResponse.usage);
+  assert.equal(reconstructed.output.length, 1);
+  assert.equal(reconstructed.output[0].type, "message");
+  assert.equal(reconstructed.output[0].content[0].text, "Hello, world!");
+});
+
+test("synthesizeResponsesSseFromResponse produces spec-compliant SSE for web_search_call and function_call", () => {
+  const sampleResponse = {
+    id: "resp_search_456",
+    object: "response",
+    created_at: 1725000100,
+    status: "completed",
+    model: "gpt-5-codex",
+    output: [
+      {
+        type: "function_call",
+        id: "call_1",
+        call_id: "call_1",
+        name: "omniroute_web_search",
+        arguments: '{"query":"latest release"}',
+        status: "completed",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: '{"results":[{"title":"Doc","url":"https://example.com"}]}',
+      },
+      {
+        type: "web_search_call",
+        id: "call_search_1",
+        status: "completed",
+        action: {
+          type: "web_search",
+          query: "latest release",
+          sources: [
+            {
+              title: "Doc",
+              url: "https://example.com",
+              caption: "Release notes",
+            },
+          ],
+        },
+      },
+      {
+        type: "message",
+        id: "msg_final",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: "Based on the search, here is the latest release.",
+          },
+        ],
+      },
+    ],
+    usage: {
+      input_tokens: 50,
+      output_tokens: 80,
+      total_tokens: 130,
+    },
+  };
+
+  const sse = synthesizeResponsesSseFromResponse(sampleResponse);
+  assert.ok(sse.length > 0);
+  assert.match(sse, /event: response\.function_call_arguments\.delta/);
+  assert.match(sse, /event: response\.function_call_arguments\.done/);
+
+  const reconstructed = parseSSEToResponsesOutput(sse, "gpt-5-codex");
+  assert.ok(reconstructed);
+  assert.equal(reconstructed.id, "resp_search_456");
+  assert.equal(reconstructed.output.length, 4);
+
+  const webSearchCall = reconstructed.output.find(
+    (item: Record<string, unknown>) => item.type === "web_search_call"
+  );
+  assert.ok(webSearchCall);
+  const action = (webSearchCall as Record<string, unknown>).action as Record<string, unknown>;
+  assert.equal(action.query, "latest release");
+
+  const funcOutput = reconstructed.output.find(
+    (item: Record<string, unknown>) => item.type === "function_call_output"
+  );
+  assert.ok(funcOutput);
+
+  const msg = reconstructed.output.find((item: Record<string, unknown>) => item.type === "message");
+  assert.ok(msg);
+});
+
+test("synthesizeResponsesSseFromResponse handles wrapped responses and JSON string inputs", () => {
+  const wrapped = {
+    response: {
+      id: "resp_wrapped",
+      object: "response",
+      created_at: 1725000200,
+      status: "completed",
+      output: [],
+    },
+  };
+
+  const sseFromObj = synthesizeResponsesSseFromResponse(wrapped);
+  assert.match(sseFromObj, /"id":"resp_wrapped"/);
+  assert.match(sseFromObj, /event: response\.completed/);
+
+  const sseFromString = synthesizeResponsesSseFromResponse(JSON.stringify(wrapped));
+  assert.equal(sseFromString, sseFromObj);
+
+  // Invalid inputs return empty string
+  assert.equal(synthesizeResponsesSseFromResponse(null), "");
+  assert.equal(synthesizeResponsesSseFromResponse(undefined), "");
+  assert.equal(synthesizeResponsesSseFromResponse("not valid json"), "");
+  assert.equal(synthesizeResponsesSseFromResponse({ other: "data" }), "");
+});
+
+test("buildNonStreamingResponsesSseResponse sets proper SSE headers and status", async () => {
+  const sampleResponse = {
+    id: "resp_headers_test",
+    object: "response",
+    status: "completed",
+    output: [],
+  };
+
+  const res = buildNonStreamingResponsesSseResponse(sampleResponse, {
+    "x-custom-header": "omniroute-test",
+    "content-length": "1234",
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "text/event-stream; charset=utf-8");
+  assert.equal(res.headers.get("cache-control"), "no-cache");
+  assert.equal(res.headers.get("connection"), "keep-alive");
+  assert.equal(res.headers.get("x-custom-header"), "omniroute-test");
+  assert.equal(res.headers.get("content-length"), null);
+
+  const body = await res.text();
+  assert.match(body, /event: response\.completed/);
+  assert.ok(body.endsWith("data: [DONE]\n\n"));
+});
+
+test("buildNonStreamingResponsesSseResponse falls back to minimal valid SSE stream when synthesis fails", async () => {
+  const malformedInput = { not_a_response: true };
+  const res = buildNonStreamingResponsesSseResponse(malformedInput, {
+    "x-test": "fallback",
+  });
+
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") || "", /text\/event-stream/);
+  assert.equal(res.headers.get("x-test"), "fallback");
+  const sseText = await res.text();
+  assert.match(sseText, /event: response\.created/);
+  assert.match(sseText, /event: response\.completed/);
+  assert.ok(sseText.endsWith("data: [DONE]\n\n"));
+});
+
+test("synthesizeResponsesSseFromResponse maintains id and created_at consistency across created and completed events", () => {
+  // Input without id and created_at
+  const minimalResponse = {
+    object: "response",
+    status: "completed",
+    output: [],
+  };
+
+  const sse = synthesizeResponsesSseFromResponse(minimalResponse);
+  assert.ok(sse);
+
+  const lines = sse.trim().split("\n\n");
+  const createdLine = lines.find((l) => l.includes('"type":"response.created"'));
+  const completedLine = lines.find((l) => l.includes('"type":"response.completed"'));
+
+  assert.ok(createdLine && completedLine);
+  const createdEvent = JSON.parse(createdLine.slice(createdLine.indexOf("data: ") + 6));
+  const completedEvent = JSON.parse(completedLine.slice(completedLine.indexOf("data: ") + 6));
+
+  assert.equal(createdEvent.response.id, completedEvent.response.id);
+  assert.equal(createdEvent.response.created_at, completedEvent.response.created_at);
+  assert.match(createdEvent.response.id, /^resp_[0-9a-f]{32}$/);
+});
+
+test("synthesizeResponsesSseFromResponse strips internal properties prefixed with underscore from completed response", () => {
+  const responseWithInternal = {
+    id: "resp_123",
+    object: "response",
+    status: "completed",
+    output: [],
+    _internal_cache_key: "secret",
+    _dedupSnapshot: { foo: "bar" },
+    public_metadata: { env: "prod" },
+  };
+
+  const sse = synthesizeResponsesSseFromResponse(responseWithInternal);
+  assert.ok(sse);
+
+  const lines = sse.trim().split("\n\n");
+  const completedLine = lines.find((l) => l.includes('"type":"response.completed"'));
+  assert.ok(completedLine);
+  const completedEvent = JSON.parse(completedLine.slice(completedLine.indexOf("data: ") + 6));
+
+  assert.equal(completedEvent.response.id, "resp_123");
+  assert.deepEqual(completedEvent.response.public_metadata, { env: "prod" });
+  assert.equal(completedEvent.response._internal_cache_key, undefined);
+  assert.equal(completedEvent.response._dedupSnapshot, undefined);
+});
+
+test("synthesizeResponsesSseFromResponse emits complete response.in_progress matching created schema", () => {
+  const minimalResponse = {
+    id: "resp_in_progress_test",
+    object: "response",
+    status: "completed",
+    output: [],
+  };
+
+  const sse = synthesizeResponsesSseFromResponse(minimalResponse);
+  assert.ok(sse);
+
+  const lines = sse.trim().split("\n\n");
+  const inProgressLine = lines.find((l) => l.includes('"type":"response.in_progress"'));
+  assert.ok(inProgressLine);
+  const inProgressEvent = JSON.parse(inProgressLine.slice(inProgressLine.indexOf("data: ") + 6));
+
+  assert.equal(inProgressEvent.response.id, "resp_in_progress_test");
+  assert.equal(inProgressEvent.response.status, "in_progress");
+  assert.equal(inProgressEvent.response.background, false);
+  assert.equal(inProgressEvent.response.error, null);
+  assert.deepEqual(inProgressEvent.response.output, []);
+});
+
+test("buildNonStreamingResponsesSseResponse marks fallback response status as failed when error is present", async () => {
+  const errorPayload = { error: { message: "rate limit exceeded", type: "rate_limit" } };
+  const res = buildNonStreamingResponsesSseResponse(errorPayload);
+  const sseText = await res.text();
+
+  const lines = sseText.trim().split("\n\n");
+  const completedLine = lines.find((l) => l.includes('"type":"response.completed"'));
+  assert.ok(completedLine);
+  const completedEvent = JSON.parse(completedLine.slice(completedLine.indexOf("data: ") + 6));
+
+  assert.equal(completedEvent.response.status, "failed");
+  assert.ok(completedEvent.response.error);
+});


### PR DESCRIPTION
Fixes #13033.

### Problem
When an OpenAI Responses API client (such as Codex CLI, Cursor, or direct `/v1/responses` callers) requests `stream: true` on a request containing a native `web_search` tool, OmniRoute converts the search into server-side execution via `omniroute_web_search`.

To execute this server-side multi-turn loop, PR #12031 forced `body.stream = false` prior to execution. However, once execution completed, `chatCore` treated the request as non-streaming and called `buildNonStreamingJsonResponse`, returning `Content-Type: application/json`. Standard Responses streaming clients expecting `text/event-stream` immediately abort with:
```
stream closed before response.completed
```

### Solution
1. **Preserve streaming intent flag**: In `chatCore.ts`, when an OpenAI Responses request with `stream: true` has its search tool converted to fallback execution, track `forcedNonStreamingResponsesSse = true` while keeping `body.stream = false` for the server-side tool execution pipeline.
2. **Synthesize Responses SSE stream**: When the response is ready, synthesize a spec-compliant Responses API SSE event sequence (`response.created` -> `response.in_progress` -> `response.output_item.added` -> `response.output_text.delta`/`done` -> `response.output_item.done` -> `response.completed` -> `data: [DONE]`) via `buildNonStreamingResponsesSseResponse`.
3. **Spec compliance and edge-runtime safety**:
   - Maintains exact ID and `created_at` consistency across `response.created` and `response.completed`.
   - Populates complete `response.in_progress` fields (`status`, `background`, `error`, `output`) matching `response.created`.
   - Omits internal properties prefixed with `_` from the completed response.
   - Replaces `Date.now()` with `crypto.randomUUID()` for collision-free fallback IDs.
   - Avoids Node-specific global buffer dependencies for content headers.

### Verification
- Added comprehensive unit tests in `tests/unit/responses-json-to-sse-13033.test.ts` covering message streams, tool call events (`web_search_call`, `function_call`), JSON payload wrapping, ID consistency, fallback envelopes, and internal property stripping (9/9 passed).
- Updated integration test in `tests/integration/skills-pipeline.test.ts` verifying that `stream: true` Responses requests with web search return `text/event-stream` with valid SSE lifecycle events.
- Validated via bug-injection: reverting the SSE synthesis branch caused `skills-pipeline.test.ts` to fail with `Input did not match /text\/event-stream/`; restoring it returned 100% green.
- `npm run typecheck:core` passed with zero errors.
- Clean ASCII diff checked with zero non-ASCII characters.
