### PR TITLE
Enforce API-key model policy after combo and connection resolution

### DIFF
--- a/open-sse/services/combo/comboPredicates.ts
+++ b/open-sse/services/combo/comboPredicates.ts
@@ -19,6 +19,7 @@ import {
 import { CONTEXT_OVERFLOW_PATTERNS, MODEL_ACCESS_DENIED_PATTERNS } from "../accountFallback.ts";
 import { isResourceNotFoundResponse } from "../errorClassifier.ts";
 import { getTrustedLocalRateLimitResponse } from "../rateLimitManager/errors.ts";
+import { isLocalModelPolicyResponse } from "../../../src/shared/utils/resolvedModelAccess.ts";
 import type { ResolvedComboTarget } from "./types.ts";
 
 // Status codes that should mark round-robin target semaphores as cooling down.
@@ -268,6 +269,7 @@ export function isComboRequestScopedFailure(
   error?: { code?: string | null; type?: string | null }
 ): boolean {
   return (
+    isLocalModelPolicyResponse(response) ||
     getTrustedLocalRateLimitResponse(response) !== null ||
     isRequestScopedUpstreamFailure(error) ||
     (response.status === 404 && isResourceNotFoundResponse(errorText))

--- a/open-sse/services/combo/targetExhaustion.ts
+++ b/open-sse/services/combo/targetExhaustion.ts
@@ -27,6 +27,7 @@ import {
 import { RateLimitReason } from "../../config/constants.ts";
 import { isProviderCircuitOpenResult, isRequestScopedUpstreamFailure } from "./comboPredicates.ts";
 import { isCloudflareFingerprintRejection } from "../errorClassifier.ts";
+import { isLocalModelPolicyResponse } from "../../../src/shared/utils/resolvedModelAccess.ts";
 // #10334 — agentrouter-exclusive predicate shared with the persistence layer
 // (markAccountUnavailable) so the same-request combo skip and the persisted
 // connection cooldown agree on exactly which fallbackResult shapes qualify.
@@ -113,6 +114,8 @@ export function applyComboTargetExhaustion(
   opts: ApplyComboTargetExhaustionOptions
 ): boolean {
   const { result, sets, log, tag, errorText, structuredError } = opts;
+  // Local key policy is neither upstream credential failure nor provider exhaustion.
+  if (isLocalModelPolicyResponse(result)) return false;
   const provider = target.provider;
 
   // #10334: agentrouter-exclusive account-wide quota exhaustion ("额度不足")

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -1500,15 +1500,18 @@ export async function getApiKeyMetadata(
  */
 export async function isModelAllowedForKey(
   key: string | null | undefined,
-  modelId: string | null | undefined
-) {
+  modelId: string | null | undefined,
+  resolvedModelId?: string | null
+): Promise<boolean> {
   // If no key provided, allow (request may be using different auth method like JWT)
   // If no modelId provided, deny (invalid request)
   if (!key) return true;
   if (!modelId) return false;
 
   // Create cache key
-  const cacheKey = `${key}:${modelId}`;
+  const cacheKey = resolvedModelId
+    ? JSON.stringify([key, modelId, resolvedModelId])
+    : `${key}:${modelId}`;
   const now = Date.now();
   const catalogGeneration = getModelCatalogCacheVersion();
   const usesSettingDependentClaudeRouting = isPotentialUnprefixedClaudeCodeModel(modelId);
@@ -1524,7 +1527,14 @@ export async function isModelAllowedForKey(
   if (!metadata) return false;
 
   const { modelAccessMode, allowedModels, blockedModels, disableNonPublicModels } = metadata;
-  const modelPermissionCandidates = await getModelPermissionCandidates(modelId);
+  // Preserve requested aliases for allow-list matching while applying resolved
+  // target candidates to deny rules and group access checks.
+  const modelPermissionCandidates = Array.from(
+    new Set([
+      ...(await getModelPermissionCandidates(modelId)),
+      ...(resolvedModelId ? await getModelPermissionCandidates(resolvedModelId) : []),
+    ])
+  );
 
   // Deny-list patterns win over any allow-list entry. This lets operators keep
   // broad dynamic scopes like cc/* while excluding expensive families.
@@ -1534,10 +1544,12 @@ export async function isModelAllowedForKey(
 
   // Check disableNonPublicModels flag
   if (disableNonPublicModels) {
-    const resolvedModelId = resolveModelAlias(modelId);
-    const effectiveModelId = resolvedModelId || modelId;
+    const effectiveModelId = resolvedModelId || resolveModelAlias(modelId) || modelId;
+    const publicationCandidates = resolvedModelId
+      ? await getModelPermissionCandidates(resolvedModelId)
+      : modelPermissionCandidates;
 
-    if (!hasClaudeCodeWildcardPermission(allowedModels, modelPermissionCandidates)) {
+    if (!hasClaudeCodeWildcardPermission(allowedModels, publicationCandidates)) {
       const lookupTarget = await getPublishedModelLookupTarget(effectiveModelId);
       const providerId = lookupTarget?.providerId || effectiveModelId.split("/")[0];
       const shortModelId = lookupTarget?.modelId || effectiveModelId.split("/").slice(1).join("/");
@@ -1570,16 +1582,22 @@ export async function isModelAllowedForKey(
       ? modelAccessMode !== "restricted"
       : allowedModels.some((pattern) => modelPatternMatches(pattern, modelPermissionCandidates));
 
-  // Extract model target and optional provider prefix if present (e.g. "openai/gpt-4" -> modelTarget: "gpt-4", provider: "openai")
-  const hasProviderPrefix = modelId?.includes("/");
-  const provider = hasProviderPrefix ? modelId.split("/")[0] : undefined;
-  const modelTarget = hasProviderPrefix ? modelId.split("/").slice(1).join("/") : modelId || "";
-
-  // If key belongs to groups, check both modelTarget and full modelId against group rules
+  // Group rules must see the requested alias and the concrete target. An allowed
+  // alias cannot hide a resolved target denied by group policy.
   if (metadata.id) {
-    const targetOk = checkKeyModelAccess(metadata.id, modelTarget, provider).allowed;
-    const fullOk = checkKeyModelAccess(metadata.id, modelId || "", provider).allowed;
-    if (!targetOk || !fullOk) allowed = false;
+    for (const groupModelId of new Set([
+      modelId,
+      ...(resolvedModelId ? [resolvedModelId] : []),
+    ])) {
+      const hasGroupProviderPrefix = groupModelId.includes("/");
+      const groupProvider = hasGroupProviderPrefix ? groupModelId.split("/")[0] : undefined;
+      const groupModelTarget = hasGroupProviderPrefix
+        ? groupModelId.split("/").slice(1).join("/")
+        : groupModelId;
+      const targetOk = checkKeyModelAccess(metadata.id, groupModelTarget, groupProvider).allowed;
+      const fullOk = checkKeyModelAccess(metadata.id, groupModelId, groupProvider).allowed;
+      if (!targetOk || !fullOk) allowed = false;
+    }
   }
   // Cache the result
   if (!usesSettingDependentClaudeRouting) {

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -1514,7 +1514,9 @@ export async function isModelAllowedForKey(
     : `${key}:${modelId}`;
   const now = Date.now();
   const catalogGeneration = getModelCatalogCacheVersion();
-  const usesSettingDependentClaudeRouting = isPotentialUnprefixedClaudeCodeModel(modelId);
+  const usesSettingDependentClaudeRouting =
+    isPotentialUnprefixedClaudeCodeModel(modelId) ||
+    (typeof resolvedModelId === "string" && isPotentialUnprefixedClaudeCodeModel(resolvedModelId));
 
   // Check permission cache
   const cached = getCachedModelPermission(cacheKey, now, catalogGeneration);
@@ -1585,10 +1587,7 @@ export async function isModelAllowedForKey(
   // Group rules must see the requested alias and the concrete target. An allowed
   // alias cannot hide a resolved target denied by group policy.
   if (metadata.id) {
-    for (const groupModelId of new Set([
-      modelId,
-      ...(resolvedModelId ? [resolvedModelId] : []),
-    ])) {
+    for (const groupModelId of new Set([modelId, ...(resolvedModelId ? [resolvedModelId] : [])])) {
       const hasGroupProviderPrefix = groupModelId.includes("/");
       const groupProvider = hasGroupProviderPrefix ? groupModelId.split("/")[0] : undefined;
       const groupModelTarget = hasGroupProviderPrefix

--- a/src/shared/utils/apiKeyPolicy.ts
+++ b/src/shared/utils/apiKeyPolicy.ts
@@ -28,6 +28,7 @@ import { resolveQuotaKeyScope } from "@/lib/quota/quotaKey";
 import { isQuotaModelName, parseQuotaModelName } from "@/lib/quota/quotaModelNaming";
 import { buildApiKeyUsageLimitPolicyRejection } from "@/lib/usage/apiKeyUsageLimits";
 import { ALL_COMBOS_ACCESS_RULE } from "@/shared/constants/comboAccess";
+import { hasApiKeyModelRestrictions } from "./resolvedModelAccess";
 
 // Default to no per-key request cap. API keys can still opt into explicit
 // limits via Settings/API Keys, while provider/account quota controls remain
@@ -72,6 +73,7 @@ export interface ApiKeyMetadata {
   name?: string;
   modelAccessMode?: "all" | "restricted";
   allowedModels?: string[];
+  blockedModels?: string[];
   allowedCombos?: string[];
   allowedConnections?: string[];
   allowedQuotas?: string[];
@@ -316,10 +318,7 @@ async function validateStandardRoutingTarget(
     }
   }
 
-  const hasModelRestrictions =
-    apiKeyInfo.modelAccessMode === "restricted" ||
-    Boolean(apiKeyInfo.allowedModels?.length) ||
-    apiKeyInfo.disableNonPublicModels === true;
+  const hasModelRestrictions = hasApiKeyModelRestrictions(apiKeyInfo);
   if (!requestedComboName && hasModelRestrictions && modelStr.startsWith("auto/")) {
     requestedComboName = modelStr;
   }
@@ -523,10 +522,7 @@ async function validateModelAccess(context: PolicyContext): Promise<Response | n
   if (comboAccess.rejection) return comboAccess.rejection;
   let requestedComboName = comboAccess.comboName;
 
-  const hasModelRestrictions =
-    apiKeyInfo.modelAccessMode === "restricted" ||
-    Boolean(apiKeyInfo.allowedModels?.length) ||
-    apiKeyInfo.disableNonPublicModels === true;
+  const hasModelRestrictions = hasApiKeyModelRestrictions(apiKeyInfo);
   if (!requestedComboName && hasModelRestrictions) {
     if (modelStr.startsWith("auto/") || modelStr.startsWith("qtSd/")) {
       requestedComboName = modelStr;

--- a/src/shared/utils/resolvedModelAccess.ts
+++ b/src/shared/utils/resolvedModelAccess.ts
@@ -1,0 +1,59 @@
+/** API-key model authority stays separate from target availability and retries. */
+export interface ModelAccessMetadata {
+  modelAccessMode?: string | null;
+  allowedModels?: string[] | null;
+  blockedModels?: string[] | null;
+  disableNonPublicModels?: boolean | null;
+}
+
+export type ResolvedModelPermission = "allowed" | "denied" | "unavailable";
+
+export function hasApiKeyModelRestrictions(
+  metadata: ModelAccessMetadata | null | undefined
+): boolean {
+  return Boolean(
+    metadata &&
+      (metadata.modelAccessMode === "restricted" ||
+        metadata.allowedModels?.length ||
+        metadata.blockedModels?.length ||
+        metadata.disableNonPublicModels === true)
+  );
+}
+
+export async function checkResolvedModelPermission(
+  input: {
+    hasApiKeyMetadata: boolean;
+    apiKey: string | null | undefined;
+    requestedModel: string;
+    resolvedModel: string;
+  },
+  isAllowed: (key: string, model: string, resolvedModel?: string) => Promise<boolean>
+): Promise<ResolvedModelPermission> {
+  if (!input.hasApiKeyMetadata) return "allowed";
+  if (!input.apiKey) return "unavailable";
+
+  try {
+    return (await isAllowed(input.apiKey, input.requestedModel, input.resolvedModel))
+      ? "allowed"
+      : "denied";
+  } catch {
+    return "unavailable";
+  }
+}
+
+// A process-local symbol cannot be spoofed by an upstream response body/header.
+// Symbol.for preserves marker identity across separately compiled server chunks.
+const LOCAL_MODEL_POLICY = Symbol.for("omniroute.local-model-policy-response");
+
+export function markLocalModelPolicyResponse(response: Response): Response {
+  Object.defineProperty(response, LOCAL_MODEL_POLICY, { value: true });
+  return response;
+}
+
+export function isLocalModelPolicyResponse(response: unknown): boolean {
+  return (
+    response !== null &&
+    typeof response === "object" &&
+    (response as Record<symbol, unknown>)[LOCAL_MODEL_POLICY] === true
+  );
+}

--- a/src/shared/validation/schemas/keys.ts
+++ b/src/shared/validation/schemas/keys.ts
@@ -125,6 +125,7 @@ export const updateKeyPermissionsSchema = z
     modelAccessMode: z.enum(["all", "restricted"]).optional(),
     connectionAccessMode: z.enum(["all", "restricted"]).optional(),
     allowedModels: z.array(z.string().trim().min(1)).max(1000).optional(),
+    blockedModels: z.array(z.string().trim().min(1)).max(1000).optional(),
     allowedCombos: z.array(z.string().trim().min(1).max(200)).max(500).optional(),
     allowedConnections: z.array(z.string().uuid()).max(100).optional(),
     noLog: z.boolean().optional(),
@@ -191,6 +192,7 @@ export const updateKeyPermissionsSchema = z
       value.modelAccessMode === undefined &&
       value.connectionAccessMode === undefined &&
       value.allowedModels === undefined &&
+      value.blockedModels === undefined &&
       value.allowedCombos === undefined &&
       value.allowedConnections === undefined &&
       value.noLog === undefined &&

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1154,6 +1154,10 @@ async function handleChatImplementation(
             sessionId,
             sessionAffinityKey,
             forceLiveComboTest: isComboLiveTest,
+            // The preflight allow-list admits the originally requested combo or
+            // alias. Preserve that context while every resolved target remains
+            // subject to its own blocked/group/publication policy checks.
+            authorizationContextModel: resolvedModelStr,
             forcedConnectionId: target?.connectionId ?? null,
             allowedConnectionIds: target?.allowedConnectionIds ?? null,
             comboStepId: target?.stepId || null,
@@ -1389,6 +1393,8 @@ async function handleSingleModelChat(
     reasoningIntent?: ExtractedReasoningIntent | null;
     reasoningRequestTags?: string[];
     reasoningTransportFallback?: "skip" | "drop";
+    /** Original request identity admitted by combo/alias preflight. */
+    authorizationContextModel?: string | null;
     managedLease?: ManagedLeaseDispatchContext | null;
     /** #12150 P1b: video-bridge log/Memory shadow — undefined on every non-video request. */
     videoBridgeLog?: VideoBridgeLog;
@@ -1457,6 +1463,7 @@ async function handleSingleModelChat(
           {
             sessionId: "", // safety-net redirect doesn't have session context
             forceLiveComboTest: false,
+            authorizationContextModel: runtimeOptions.authorizationContextModel ?? modelStr,
             forcedConnectionId: null,
             allowedConnectionIds: null,
             comboStepId: null,
@@ -1518,13 +1525,18 @@ async function handleSingleModelChat(
     // Intentional override (e.g. providerId points to a different credential pool).
     return runtimeOptions.providerId;
   })();
+  const authorizationContextModel =
+    typeof runtimeOptions.authorizationContextModel === "string" &&
+    runtimeOptions.authorizationContextModel.trim().length > 0
+      ? runtimeOptions.authorizationContextModel.trim()
+      : modelStr;
   // Entry admission authorizes the requested model string. Resolve aliases and
   // target overrides before dispatch, then require the same key to admit both.
   const modelPermission = await checkResolvedModelPermission(
     {
       hasApiKeyMetadata: Boolean(apiKeyInfo),
       apiKey: extractApiKey(request),
-      requestedModel: modelStr,
+      requestedModel: authorizationContextModel,
       resolvedModel: `${provider}/${model}`,
     },
     isModelAllowedForKey
@@ -1884,7 +1896,7 @@ async function handleSingleModelChat(
           {
             hasApiKeyMetadata: Boolean(apiKeyInfo),
             apiKey: extractApiKey(request),
-            requestedModel: modelStr,
+            requestedModel: authorizationContextModel,
             resolvedModel,
           },
           isModelAllowedForKey

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -80,7 +80,7 @@ import {
 import { dispatchChatWithAffinityEviction } from "./chatDispatch";
 import { getCachedSettings, getCombosCacheVersion } from "@/lib/db/readCache";
 import { comboCheckProvider, ghComboGate } from "./chat/githubLiveCatalogFilter.ts";
-import { comboTargetPassesKeyModelPolicy } from "./chat/comboTargetKeyPolicy.ts";
+import { evaluateComboTargetPreflight } from "./chat/comboTargetKeyPolicy.ts";
 import { getCombos } from "@/lib/db/combos";
 import { resolveModelLockoutSettings } from "@/lib/resilience/modelLockoutSettings";
 import {
@@ -993,8 +993,8 @@ async function handleChatImplementation(
       `Combo "${modelStr}" [${combo.strategy || "priority"}] with ${combo.models.length} models`
     );
 
-    // Pre-check function used by combo routing. For explicit combo live tests,
-    // avoid pre-skipping so each model gets a real execution attempt.
+    // Pre-check function used by combo routing. A live-test marker may skip
+    // availability only after target authorization succeeds.
     const comboPreselectedCredentials = new Map<string, any>();
     const getComboCredentialCacheKey = (
       modelString: string,
@@ -1010,12 +1010,16 @@ async function handleChatImplementation(
         providerId?: string | null;
       }
     ) => {
-      if (isComboLiveTest) return true;
-      // #12886: combo-name allow-list must not skip inner targets (#9057 still
-      // checks auto/* / disableNonPublic via comboTargetPassesKeyModelPolicy).
-      if (!(await comboTargetPassesKeyModelPolicy({ apiKey, apiKeyInfo, requestedModelStr: resolvedModelStr, targetModelStr: modelString, isModelAllowedForKey }))) {
-        return false;
-      }
+      const preflightDecision = await evaluateComboTargetPreflight({
+        apiKey,
+        apiKeyInfo,
+        requestedModelStr: resolvedModelStr,
+        targetModelStr: modelString,
+        isComboLiveTest,
+        isModelAllowedForKey,
+      });
+      if (preflightDecision === "deny") return false;
+      if (preflightDecision === "bypass-availability") return true;
 
       // Use getModelInfo to resolve custom prefixes, but prefer the combo
       // target's providerId when available — the model string's provider

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -71,6 +71,10 @@ import { isChatGptWebCodexModel } from "@/shared/constants/chatgptWebCodex";
 import { deleteHandoff, getHandoff } from "@/lib/db/contextHandoffs";
 import { getComboByName, updateCombo } from "@/lib/db/combos";
 import { isModelAllowedForKey } from "@/lib/db/apiKeys";
+import {
+  checkResolvedModelPermission,
+  markLocalModelPolicyResponse,
+} from "@/shared/utils/resolvedModelAccess";
 import { promoteSuccessfulComboModel } from "@/lib/combos/autoPromote";
 import {
   deleteSessionAccountAffinity,
@@ -1514,6 +1518,27 @@ async function handleSingleModelChat(
     // Intentional override (e.g. providerId points to a different credential pool).
     return runtimeOptions.providerId;
   })();
+  // Entry admission authorizes the requested model string. Resolve aliases and
+  // target overrides before dispatch, then require the same key to admit both.
+  const modelPermission = await checkResolvedModelPermission(
+    {
+      hasApiKeyMetadata: Boolean(apiKeyInfo),
+      apiKey: extractApiKey(request),
+      requestedModel: modelStr,
+      resolvedModel: `${provider}/${model}`,
+    },
+    isModelAllowedForKey
+  );
+  if (modelPermission !== "allowed") {
+    return markLocalModelPolicyResponse(
+      errorResponse(
+        modelPermission === "denied" ? HTTP_STATUS.FORBIDDEN : HTTP_STATUS.SERVICE_UNAVAILABLE,
+        modelPermission === "denied"
+          ? "Resolved model is not allowed for this API key"
+          : "API key model policy unavailable"
+      )
+    );
+  }
   const forceLiveComboTest = runtimeOptions.forceLiveComboTest === true;
   const bypassProviderQuotaPolicy = hasProviderQuotaBypassScope(apiKeyInfo?.scopes);
   const forcedConnectionId =
@@ -1845,6 +1870,38 @@ async function handleSingleModelChat(
           return connectionRouting.response;
         }
         requestBody = connectionRouting.body;
+      }
+      // Connection defaults and reasoning rules can replace an admitted alias.
+      // Recheck before token refresh or any upstream dispatch.
+      const effectivePolicyTargets = new Set([`${provider}/${effectiveModel}`]);
+      if (typeof requestBody.model === "string" && requestBody.model.length > 0) {
+        effectivePolicyTargets.add(
+          requestBody.model.includes("/") ? requestBody.model : `${provider}/${requestBody.model}`
+        );
+      }
+      for (const resolvedModel of effectivePolicyTargets) {
+        const effectivePermission = await checkResolvedModelPermission(
+          {
+            hasApiKeyMetadata: Boolean(apiKeyInfo),
+            apiKey: extractApiKey(request),
+            requestedModel: modelStr,
+            resolvedModel,
+          },
+          isModelAllowedForKey
+        );
+        if (effectivePermission !== "allowed") {
+          releaseOAuthSession();
+          return markLocalModelPolicyResponse(
+            errorResponse(
+              effectivePermission === "denied"
+                ? HTTP_STATUS.FORBIDDEN
+                : HTTP_STATUS.SERVICE_UNAVAILABLE,
+              effectivePermission === "denied"
+                ? "Resolved model is not allowed for this API key"
+                : "API key model policy unavailable"
+            )
+          );
+        }
       }
       let injectedHandoff = null;
       if (

--- a/src/sse/handlers/chat/comboTargetKeyPolicy.ts
+++ b/src/sse/handlers/chat/comboTargetKeyPolicy.ts
@@ -7,8 +7,11 @@
  * inner target so #9057 holds.
  */
 
+import { hasApiKeyModelRestrictions } from "../../../shared/utils/resolvedModelAccess.ts";
+
 export type ComboTargetKeyPolicyInfo = {
   allowedModels?: string[] | null;
+  blockedModels?: string[] | null;
   disableNonPublicModels?: boolean | null;
   modelAccessMode?: string | null;
 };
@@ -45,11 +48,7 @@ export async function comboTargetPassesKeyModelPolicy(
   const { apiKey, apiKeyInfo, requestedModelStr, targetModelStr, isModelAllowedForKey } = opts;
   if (!apiKey || !apiKeyInfo) return true;
 
-  const hasModelRestrictions =
-    apiKeyInfo.modelAccessMode === "restricted" ||
-    Boolean(apiKeyInfo.allowedModels?.length) ||
-    apiKeyInfo.disableNonPublicModels === true;
-  if (!hasModelRestrictions) return true;
+  if (!hasApiKeyModelRestrictions(apiKeyInfo)) return true;
 
   if (allowListCoversRequestedCombo(apiKeyInfo.allowedModels, requestedModelStr)) {
     return true;

--- a/src/sse/handlers/chat/comboTargetKeyPolicy.ts
+++ b/src/sse/handlers/chat/comboTargetKeyPolicy.ts
@@ -37,7 +37,9 @@ export async function comboTargetPassesKeyModelPolicy(opts: {
   if (!apiKey || !apiKeyInfo) return true;
 
   const hasModelRestrictions =
-    Boolean(apiKeyInfo.allowedModels?.length) || apiKeyInfo.disableNonPublicModels === true;
+    apiKeyInfo.modelAccessMode === "restricted" ||
+    Boolean(apiKeyInfo.allowedModels?.length) ||
+    apiKeyInfo.disableNonPublicModels === true;
   if (!hasModelRestrictions) return true;
 
   if (allowListCoversRequestedCombo(apiKeyInfo.allowedModels, requestedModelStr)) {

--- a/src/sse/handlers/chat/comboTargetKeyPolicy.ts
+++ b/src/sse/handlers/chat/comboTargetKeyPolicy.ts
@@ -13,6 +13,19 @@ export type ComboTargetKeyPolicyInfo = {
   modelAccessMode?: string | null;
 };
 
+export type ComboTargetKeyPolicyOptions = {
+  apiKey: string | null | undefined;
+  apiKeyInfo: ComboTargetKeyPolicyInfo | null | undefined;
+  requestedModelStr: string;
+  targetModelStr: string;
+  isModelAllowedForKey: (key: string, model: string) => Promise<boolean>;
+};
+
+export type ComboTargetPreflightDecision =
+  | "deny"
+  | "check-availability"
+  | "bypass-availability";
+
 function modelMatchesAllowPattern(pattern: string, model: string): boolean {
   if (pattern.endsWith("/*")) return model.startsWith(pattern.slice(0, -1));
   return pattern === model;
@@ -26,13 +39,9 @@ function allowListCoversRequestedCombo(
   return allowedModels.some((pattern) => modelMatchesAllowPattern(pattern, requestedModelStr));
 }
 
-export async function comboTargetPassesKeyModelPolicy(opts: {
-  apiKey: string | null | undefined;
-  apiKeyInfo: ComboTargetKeyPolicyInfo | null | undefined;
-  requestedModelStr: string;
-  targetModelStr: string;
-  isModelAllowedForKey: (key: string, model: string) => Promise<boolean>;
-}): Promise<boolean> {
+export async function comboTargetPassesKeyModelPolicy(
+  opts: ComboTargetKeyPolicyOptions
+): Promise<boolean> {
   const { apiKey, apiKeyInfo, requestedModelStr, targetModelStr, isModelAllowedForKey } = opts;
   if (!apiKey || !apiKeyInfo) return true;
 
@@ -47,4 +56,15 @@ export async function comboTargetPassesKeyModelPolicy(opts: {
   }
 
   return isModelAllowedForKey(apiKey, targetModelStr);
+}
+
+/**
+ * A combo live test may skip availability probes only after target authorization.
+ * The client marker can never convert a denied model into an authorized target.
+ */
+export async function evaluateComboTargetPreflight(
+  opts: ComboTargetKeyPolicyOptions & { isComboLiveTest: boolean }
+): Promise<ComboTargetPreflightDecision> {
+  if (!(await comboTargetPassesKeyModelPolicy(opts))) return "deny";
+  return opts.isComboLiveTest ? "bypass-availability" : "check-availability";
 }

--- a/tests/unit/api-key-resolved-model-cache-12899.test.ts
+++ b/tests/unit/api-key-resolved-model-cache-12899.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #12899 — cache bypass must use a setting-dependent resolved target even
+ * when the caller supplied a friendly alias as the requested model.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-resolved-model-cache-12899-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "resolved-model-cache-12899";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeys = await import("../../src/lib/db/apiKeys.ts");
+const readCache = await import("../../src/lib/db/readCache.ts");
+const settingsDb = await import("../../src/lib/db/settings.ts");
+
+async function resetStorage() {
+  apiKeys.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  apiKeys.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("resolved setting-dependent Claude target never reuses a friendly-alias permission cache entry", async () => {
+  const key = await apiKeys.createApiKey("Resolved Claude cache", "machine-12899");
+  await apiKeys.updateApiKeyPermissions(key.id, {
+    modelAccessMode: "restricted",
+    allowedModels: ["cc/*"],
+  });
+
+  await settingsDb.updateSettings({
+    preferClaudeCodeForUnprefixedClaudeModels: true,
+  });
+  assert.equal(
+    await apiKeys.isModelAllowedForKey(key.key, "friendly-alias", "claude-fable-5"),
+    true
+  );
+
+  // A settings refresh can update the active snapshot before the catalog cache
+  // generation changes. The resolved target, not only the friendly request
+  // alias, must therefore opt out of the short permission cache.
+  const cachedSettings = await readCache.getCachedSettings();
+  const previousPreference = cachedSettings.preferClaudeCodeForUnprefixedClaudeModels;
+  cachedSettings.preferClaudeCodeForUnprefixedClaudeModels = false;
+  try {
+    assert.equal(
+      await apiKeys.isModelAllowedForKey(key.key, "friendly-alias", "claude-fable-5"),
+      false
+    );
+  } finally {
+    cachedSettings.preferClaudeCodeForUnprefixedClaudeModels = previousPreference;
+  }
+});

--- a/tests/unit/chat-combo-model-authority-flow-12886.test.ts
+++ b/tests/unit/chat-combo-model-authority-flow-12886.test.ts
@@ -1,0 +1,139 @@
+/**
+ * #12886 / #12899 — a restricted key may name a combo, while the concrete
+ * target still has to pass every downstream policy check.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const COMBO = "combo-authority-flow-12886";
+const TARGET = "openai/gpt-4.1";
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-combo-authority-flow-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
+process.env.REQUIRE_API_KEY = "false";
+process.env.DASHBOARD_PASSWORD = "";
+process.env.INITIAL_PASSWORD = "";
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "combo-authority-flow-12886";
+delete process.env.JWT_SECRET;
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { handleChat } = await import("../../src/sse/handlers/chat.ts");
+const originalFetch = globalThis.fetch;
+
+async function resetStorage() {
+  globalThis.fetch = originalFetch;
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+  apiKeysDb.resetApiKeyState();
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+});
+
+async function seedNamedComboKey() {
+  await providersDb.createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    name: "openai-combo-authority-flow",
+    apiKey: "sk-combo-authority-flow",
+    isActive: true,
+    testStatus: "active",
+  });
+  await combosDb.createCombo({
+    name: COMBO,
+    strategy: "priority",
+    models: [TARGET],
+  });
+  const key = await apiKeysDb.createApiKey("Combo authority flow", "machine-12886");
+  await apiKeysDb.updateApiKeyPermissions(key.id, { allowedModels: [COMBO] });
+  return key;
+}
+
+function comboRequest(key: string, headers: Record<string, string> = {}) {
+  return new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${key}`,
+      ...headers,
+    },
+    body: JSON.stringify({
+      model: COMBO,
+      messages: [{ role: "user", content: "Reply with OK only." }],
+      max_tokens: 16,
+      stream: false,
+    }),
+  });
+}
+
+function upstreamResponse(content: string) {
+  return Response.json({
+    id: "chatcmpl-combo-authority-flow",
+    choices: [{ message: { role: "assistant", content } }],
+  });
+}
+
+test("named-combo allow-list reaches its configured concrete target through handleChat", async () => {
+  const key = await seedNamedComboKey();
+  let upstreamCalls = 0;
+  globalThis.fetch = async () => {
+    upstreamCalls += 1;
+    return upstreamResponse("combo policy passed");
+  };
+
+  const response = await handleChat(comboRequest(key.key));
+  const body = (await response.json()) as {
+    choices: Array<{ message: { content: string } }>;
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(upstreamCalls, 1);
+  assert.equal(body.choices[0].message.content, "combo policy passed");
+});
+
+test("live-test marker does not let a named combo dispatch a blocked concrete target", async () => {
+  const key = await seedNamedComboKey();
+  await apiKeysDb.updateApiKeyPermissions(key.id, {
+    blockedModels: [TARGET],
+  });
+  let upstreamCalls = 0;
+  globalThis.fetch = async () => {
+    upstreamCalls += 1;
+    return upstreamResponse("must not dispatch");
+  };
+
+  const response = await handleChat(
+    comboRequest(key.key, { "X-Internal-Test": "combo-health-check" })
+  );
+
+  assert.equal(response.status, 403);
+  assert.equal(upstreamCalls, 0);
+});

--- a/tests/unit/chat-combo-model-authority-flow-12886.test.ts
+++ b/tests/unit/chat-combo-model-authority-flow-12886.test.ts
@@ -11,26 +11,30 @@ import test from "node:test";
 
 const COMBO = "combo-authority-flow-12886";
 const TARGET = "openai/gpt-4.1";
-const TEST_DATA_DIR = fs.mkdtempSync(
-  path.join(os.tmpdir(), "omniroute-combo-authority-flow-")
-);
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-combo-authority-flow-"));
+const TEST_PLUGIN_DIR = path.join(TEST_DATA_DIR, "plugins");
 process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.OMNIROUTE_PLUGINS_DIR = TEST_PLUGIN_DIR;
 process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
 process.env.REQUIRE_API_KEY = "false";
 process.env.DASHBOARD_PASSWORD = "";
 process.env.INITIAL_PASSWORD = "";
 process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "combo-authority-flow-12886";
 delete process.env.JWT_SECRET;
+delete process.env.QUOTA_STORE_DRIVER;
+delete process.env.QUOTA_STORE_REDIS_URL;
 
 const core = await import("../../src/lib/db/core.ts");
 const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
 const combosDb = await import("../../src/lib/db/combos.ts");
 const providersDb = await import("../../src/lib/db/providers.ts");
+const proxyLogger = await import("../../src/lib/proxyLogger.ts");
 const { handleChat } = await import("../../src/sse/handlers/chat.ts");
 const originalFetch = globalThis.fetch;
 
 async function resetStorage() {
   globalThis.fetch = originalFetch;
+  proxyLogger.flushProxyLogsSync();
   apiKeysDb.resetApiKeyState();
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, {
@@ -39,7 +43,7 @@ async function resetStorage() {
     maxRetries: 5,
     retryDelay: 100,
   });
-  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+  fs.mkdirSync(TEST_PLUGIN_DIR, { recursive: true });
 }
 
 test.beforeEach(async () => {
@@ -48,6 +52,7 @@ test.beforeEach(async () => {
 
 test.after(() => {
   globalThis.fetch = originalFetch;
+  proxyLogger.flushProxyLogsSync();
   apiKeysDb.resetApiKeyState();
   core.resetDbInstance();
   fs.rmSync(TEST_DATA_DIR, {

--- a/tests/unit/combo-restricted-key-target-policy-12886.test.ts
+++ b/tests/unit/combo-restricted-key-target-policy-12886.test.ts
@@ -62,6 +62,22 @@ test("#9057: disableNonPublicModels still rejects a keyless inner target", async
   assert.equal(ok, false);
 });
 
+test("#9057: restricted auto combo checks an inner target even without allow-list entries", async () => {
+  let calls = 0;
+  const ok = await comboTargetPassesKeyModelPolicy({
+    apiKey: KEY,
+    apiKeyInfo: { modelAccessMode: "restricted", allowedModels: [] },
+    requestedModelStr: "auto/best",
+    targetModelStr: "private/target",
+    isModelAllowedForKey: async () => {
+      calls += 1;
+      return false;
+    },
+  });
+  assert.equal(ok, false, "a restricted key must not gain access through auto routing");
+  assert.equal(calls, 1, "the concrete target must be checked");
+});
+
 test("#12886: unrestricted key skips the gate", async () => {
   let called = 0;
   const ok = await comboTargetPassesKeyModelPolicy({

--- a/tests/unit/combo-restricted-key-target-policy-12886.test.ts
+++ b/tests/unit/combo-restricted-key-target-policy-12886.test.ts
@@ -5,7 +5,10 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { comboTargetPassesKeyModelPolicy } from "../../src/sse/handlers/chat/comboTargetKeyPolicy.ts";
+import {
+  comboTargetPassesKeyModelPolicy,
+  evaluateComboTargetPreflight,
+} from "../../src/sse/handlers/chat/comboTargetKeyPolicy.ts";
 
 const KEY = "sk-test-12886";
 const COMBO = "combo-deepseek-v4-flash";
@@ -76,6 +79,35 @@ test("#9057: restricted auto combo checks an inner target even without allow-lis
   });
   assert.equal(ok, false, "a restricted key must not gain access through auto routing");
   assert.equal(calls, 1, "the concrete target must be checked");
+});
+
+test("combo live-test requests cannot bypass a denied target policy", async () => {
+  let calls = 0;
+  const decision = await evaluateComboTargetPreflight({
+    apiKey: KEY,
+    apiKeyInfo: { modelAccessMode: "restricted", allowedModels: ["public/*"] },
+    requestedModelStr: "auto/best",
+    targetModelStr: "private/target",
+    isComboLiveTest: true,
+    isModelAllowedForKey: async () => {
+      calls += 1;
+      return false;
+    },
+  });
+  assert.equal(decision, "deny");
+  assert.equal(calls, 1, "the client live-test marker must not grant model authority");
+});
+
+test("combo live-test requests bypass availability only after named-combo admission", async () => {
+  const decision = await evaluateComboTargetPreflight({
+    apiKey: KEY,
+    apiKeyInfo: { modelAccessMode: "restricted", allowedModels: [COMBO] },
+    requestedModelStr: COMBO,
+    targetModelStr: INNER,
+    isComboLiveTest: true,
+    isModelAllowedForKey: async () => false,
+  });
+  assert.equal(decision, "bypass-availability");
 });
 
 test("#12886: unrestricted key skips the gate", async () => {

--- a/tests/unit/resolved-model-access.test.ts
+++ b/tests/unit/resolved-model-access.test.ts
@@ -67,6 +67,21 @@ test("resolved-model policy distinguishes local mode from unavailable key policy
   assert.equal(calls, 0);
 });
 
+test("resolved-model policy fails closed when the key checker is unavailable", async () => {
+  const result = await checkResolvedModelPermission(
+    {
+      hasApiKeyMetadata: true,
+      apiKey: "sk-test-resolved",
+      requestedModel: "friendly-alias",
+      resolvedModel: "provider/private-target",
+    },
+    async () => {
+      throw new Error("policy backend unavailable");
+    }
+  );
+  assert.equal(result, "unavailable");
+});
+
 test("local model-policy responses remain distinguishable from upstream responses", () => {
   const local = markLocalModelPolicyResponse(new Response("denied", { status: 403 }));
   assert.equal(isLocalModelPolicyResponse(local), true);

--- a/tests/unit/resolved-model-access.test.ts
+++ b/tests/unit/resolved-model-access.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  checkResolvedModelPermission,
+  hasApiKeyModelRestrictions,
+  isLocalModelPolicyResponse,
+  markLocalModelPolicyResponse,
+} from "../../src/shared/utils/resolvedModelAccess.ts";
+
+test("resolved-model policy recognizes every persisted restriction", () => {
+  assert.equal(hasApiKeyModelRestrictions({ modelAccessMode: "restricted" }), true);
+  assert.equal(hasApiKeyModelRestrictions({ allowedModels: ["public/*"] }), true);
+  assert.equal(hasApiKeyModelRestrictions({ blockedModels: ["private/*"] }), true);
+  assert.equal(hasApiKeyModelRestrictions({ disableNonPublicModels: true }), true);
+  assert.equal(hasApiKeyModelRestrictions({ modelAccessMode: "all" }), false);
+  assert.equal(hasApiKeyModelRestrictions(null), false);
+});
+
+test("resolved-model policy asks the key checker about requested and concrete identities", async () => {
+  const calls: Array<[string, string, string | undefined]> = [];
+  const result = await checkResolvedModelPermission(
+    {
+      hasApiKeyMetadata: true,
+      apiKey: "sk-test-resolved",
+      requestedModel: "friendly-alias",
+      resolvedModel: "provider/private-target",
+    },
+    async (key, requestedModel, resolvedModel) => {
+      calls.push([key, requestedModel, resolvedModel]);
+      return false;
+    }
+  );
+  assert.equal(result, "denied");
+  assert.deepEqual(calls, [["sk-test-resolved", "friendly-alias", "provider/private-target"]]);
+});
+
+test("resolved-model policy distinguishes local mode from unavailable key policy", async () => {
+  let calls = 0;
+  const checker = async () => {
+    calls += 1;
+    return true;
+  };
+  assert.equal(
+    await checkResolvedModelPermission(
+      {
+        hasApiKeyMetadata: false,
+        apiKey: null,
+        requestedModel: "alias",
+        resolvedModel: "provider/target",
+      },
+      checker
+    ),
+    "allowed"
+  );
+  assert.equal(
+    await checkResolvedModelPermission(
+      {
+        hasApiKeyMetadata: true,
+        apiKey: null,
+        requestedModel: "alias",
+        resolvedModel: "provider/target",
+      },
+      checker
+    ),
+    "unavailable"
+  );
+  assert.equal(calls, 0);
+});
+
+test("local model-policy responses remain distinguishable from upstream responses", () => {
+  const local = markLocalModelPolicyResponse(new Response("denied", { status: 403 }));
+  assert.equal(isLocalModelPolicyResponse(local), true);
+  assert.equal(isLocalModelPolicyResponse(new Response("denied", { status: 403 })), false);
+});


### PR DESCRIPTION
## Problem

A routing alias or combo can resolve to a concrete model after entry-point API-key admission. Resolved model and connection/reasoning overrides must still honor model policy, including during internal combo health checks.

## Change

Preserve the requested combo/alias as allow-list context while checking each resolved target against blocked-model, key-group and publication rules. Keep explicit restricted empty lists denied. Mark locally generated policy responses so they stop inappropriate fallback. Permission caching now also accounts for setting-dependent Claude routing in an explicitly resolved target.

The named-combo path retains the intended allow-list behavior from #12899 while enforcing the resolved-target checks covered by #12886.

## Validation

- 15 focused tests passed, including actual `handleChat` named-combo dispatch, a blocked target under the live-test marker, and an actual database-backed resolved-target cache regression.
- Parent review ran 10 relevant policy/group/database/terminal-status suites: 91 tests passed and one source-inspection test initially could not read a file omitted by sparse checkout. After materializing that tracked file, its complete scope suite passed.
- Changed-file Prettier and diff checks passed; Gitleaks scanned all nine commits with zero findings.
- Focused ESLint reports 11 pre-existing unused-symbol errors in `chat.ts` and `apiKeys.ts`; no lint cleanup is included.

This draft has not passed the complete Node/Vitest matrix or upstream review. Fixtures use disposable SQLite state and mocked fetch; no installed service or provider call is claimed.
