### PR TITLE
fix(resilience): classify Cline 401 as refreshable OAuth (#12594)

### DIFF
--- a/changelog.d/fixes/12594-cline-401-oauth.md
+++ b/changelog.d/fixes/12594-cline-401-oauth.md
@@ -1,1 +1,1 @@
-Cline 401 bodies that say "re-authenticate your Cline account" classify as a refreshable OAuth token, not a terminal expired key. The cooling panel no longer labels every cooldown as a 429; it shows the recorded last error instead. (#12594)
+- Cline 401 bodies that say "re-authenticate your Cline account" classify as a refreshable OAuth token, not a terminal expired key. The cooling panel no longer labels every cooldown as a 429; it shows the recorded last error instead. (#12594)

--- a/changelog.d/fixes/12594-cline-401-oauth.md
+++ b/changelog.d/fixes/12594-cline-401-oauth.md
@@ -1,0 +1,1 @@
+Cline 401 bodies that say "re-authenticate your Cline account" classify as a refreshable OAuth token, not a terminal expired key. The cooling panel no longer labels every cooldown as a 429; it shows the recorded last error instead. (#12594)

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -261,6 +261,7 @@ export const OAUTH_INVALID_TOKEN_SIGNALS = [
   "login cookie",
   "valid authentication credential",
   "invalid credentials",
+  "re-authenticate your cline account",
 ];
 
 // A model that upstream has permanently retired — Gemini's deprecated-model 404

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/CoolingConnectionsPanel.tsx
@@ -56,6 +56,19 @@ function isCoolingNow(connection: ConnectionRowConnection, now: number): boolean
   return Number.isFinite(until) && until > now;
 }
 
+/** Visible last-error text (truncated) plus the full string for the tooltip. */
+function coolingRecordedError(connection: ConnectionRowConnection): {
+  display: string;
+  title: string;
+} | null {
+  const raw = typeof connection.lastError === "string" ? connection.lastError.trim() : "";
+  if (!raw) return null;
+  return {
+    display: raw.length > 160 ? `${raw.slice(0, 157)}...` : raw,
+    title: raw,
+  };
+}
+
 interface ClearCooldownButtonProps {
   /** Row's connection id — without one there is nothing to PUT, so no button. */
   readonly connectionId: string | undefined;
@@ -126,7 +139,7 @@ export default function CoolingConnectionsPanel(props: CoolingConnectionsPanelPr
         {providerText(
           t,
           "coolingConnectionsDescription",
-          "These connections returned a 429 (rate-limit) on their last request. OmniRoute will skip them until the timer expires — no manual disable required."
+          "These connections are cooling after their last request. OmniRoute will skip them until the timer expires — no manual disable required."
         )}
       </p>
       <ul className="space-y-1">
@@ -139,13 +152,25 @@ export default function CoolingConnectionsPanel(props: CoolingConnectionsPanelPr
             (c.id
               ? `${providerText(t, "connectionFallback", "connection")} ${c.id.slice(0, 8)}`
               : providerText(t, "connectionFallback", "connection"));
+          const recorded = coolingRecordedError(c);
           const clearing = clearingCooldownId != null && clearingCooldownId === c.id;
           return (
             <li
               key={c.id ?? label}
               className="flex items-center justify-between gap-2 rounded border border-amber-500/30 bg-background/40 px-3 py-2 text-sm"
             >
-              <span className="font-medium">{label}</span>
+              <span className="min-w-0">
+                <span className="font-medium">{label}</span>
+                {recorded ? (
+                  <span
+                    className="mt-0.5 block truncate text-xs text-muted-foreground"
+                    data-testid="cooling-last-error"
+                    title={recorded.title}
+                  >
+                    {recorded.display}
+                  </span>
+                ) : null}
+              </span>
               <span className="flex items-center gap-2">
                 <span
                   className="font-mono text-xs text-amber-700 dark:text-amber-300"

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/CoolingConnectionsPanel.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/CoolingConnectionsPanel.test.tsx
@@ -147,4 +147,33 @@ describe("CoolingConnectionsPanel — manual clear cooldown", () => {
     });
     expect(panelRoot!.querySelectorAll("button").length).toBe(0);
   });
+
+  it("#12594 does not claim every cooldown is a 429", () => {
+    const lastError =
+      "Please make sure you're using the latest version of Cline and re-authenticate your Cline account.";
+    const { panelRoot } = renderPanel({
+      connections: [
+        coolingConnection({
+          lastErrorType: "oauth_invalid_token",
+          lastError,
+          errorCode: 401,
+        }),
+      ],
+    });
+    expect(panelRoot!.textContent).not.toMatch(/429 \(rate-limit\)/);
+    const recorded = panelRoot!.querySelector("[data-testid='cooling-last-error']");
+    expect(recorded?.textContent).toMatch(/re-authenticate your Cline account/i);
+    expect(recorded?.getAttribute("title")).toBe(lastError);
+  });
+
+  it("#12594 tooltip keeps the full lastError when the visible text is truncated", () => {
+    const lastError = `${"x".repeat(200)} unique-tail`;
+    const { panelRoot } = renderPanel({
+      connections: [coolingConnection({ lastError })],
+    });
+    const recorded = panelRoot!.querySelector("[data-testid='cooling-last-error']");
+    expect(recorded?.textContent).toHaveLength(160);
+    expect(recorded?.textContent).toMatch(/\.\.\.$/);
+    expect(recorded?.getAttribute("title")).toBe(lastError);
+  });
 });

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "فشل في بدء الأمر Code auth",
     "connectionDeleted": "تم حذف الاتصال",
     "connectionFallback": "الاتصال",
-    "coolingConnectionsDescription": "أعادت هذه الاتصالات 429 (حد معدل) في آخر طلب لها. ستتخطى OmniRoute هذه الاتصالات حتى تنتهي مدة المؤقت - لا حاجة لتعطيل يدوي.",
+    "coolingConnectionsDescription": "هذه الاتصالات في فترة تبريد بعد آخر طلب. ستتخطاها OmniRoute حتى ينتهي المؤقت — لا حاجة للتعطيل اليدوي.",
     "coolingConnectionsTitle": "التبريد الحالي ({count})",
     "failedDeleteAlias": "فشل في حذف الاسم المستعار",
     "failedDeleteConnection": "فشل في حذف الاتصال",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Komanda Kodu auth başlamaqda uğursuz oldu",
     "connectionDeleted": "Bağlantı silindi",
     "connectionFallback": "bağlantı",
-    "coolingConnectionsDescription": "Bu bağlantılar son sorğularında 429 (sürət limiti) aldı. OmniRoute onları zamanlayıcı bitənə qədər atlayacaq — əl ilə deaktiv etməyə ehtiyac yoxdur.",
+    "coolingConnectionsDescription": "Bu bağlantılar son sorğudan sonra soyumaqdadır. OmniRoute taymer bitənə qədər onları atlayacaq — əl ilə söndürmək lazım deyil.",
     "coolingConnectionsTitle": "Hazırda soyudulur ({count})",
     "failedDeleteAlias": "Alias silinmədi",
     "failedDeleteConnection": "Bağlantını silmək mümkün olmadı",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Неуспешно стартиране на Command Code auth",
     "connectionDeleted": "Връзката е изтрита",
     "connectionFallback": "връзка",
-    "coolingConnectionsDescription": "Тези връзки върнаха 429 (ограничение на скоростта) при последната си заявка. OmniRoute ще ги пропусне, докато таймерът изтече — не е необходимо ръчно деактивиране.",
+    "coolingConnectionsDescription": "Тези връзки се охлаждат след последната заявка. OmniRoute ще ги пропусне, докато таймерът изтече — не е нужно ръчно изключване.",
     "coolingConnectionsTitle": "В момента охлаждане ({count})",
     "failedDeleteAlias": "Неуспешно изтриване на псевдоним",
     "failedDeleteConnection": "Неуспешно изтриване на връзката",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code auth শুরু করতে ব্যর্থ হয়েছে",
     "connectionDeleted": "সংযোগ মুছে ফেলা হয়েছে",
     "connectionFallback": "সংযোগ",
-    "coolingConnectionsDescription": "এই সংযোগগুলি তাদের শেষ অনুরোধে 429 (রেট-লিমিট) ফিরিয়ে দিয়েছে। OmniRoute সেগুলি সময়সীমা শেষ হওয়া পর্যন্ত বাদ দেবে — কোন ম্যানুয়াল নিষ্ক্রিয়করণ প্রয়োজন নেই।",
+    "coolingConnectionsDescription": "এই সংযোগগুলি শেষ অনুরোধের পর ঠান্ডা হচ্ছে। টাইমার শেষ না হওয়া পর্যন্ত OmniRoute সেগুলি এড়িয়ে যাবে — হাতে বন্ধ করার দরকার নেই।",
     "coolingConnectionsTitle": "বর্তমানে শীতলকরণ ({count})",
     "failedDeleteAlias": "অ্যালিয়াস মুছতে ব্যর্থ হয়েছে",
     "failedDeleteConnection": "সংযোগ মুছতে ব্যর্থ হয়েছে",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Nepodařilo se spustit příkaz Code auth",
     "connectionDeleted": "Připojení bylo smazáno",
     "connectionFallback": "připojení",
-    "coolingConnectionsDescription": "Tyto připojení vrátily 429 (omezení rychlosti) při posledním požadavku. OmniRoute je přeskočí, dokud nevyprší časovač — není potřeba manuální deaktivace.",
+    "coolingConnectionsDescription": "Tato připojení se po posledním požadavku ochlazují. OmniRoute je přeskočí, dokud nevyprší časovač — ruční vypnutí není potřeba.",
     "coolingConnectionsTitle": "Aktuálně chlazení ({count})",
     "failedDeleteAlias": "Nepodařilo se smazat alias",
     "failedDeleteConnection": "Nepodařilo se smazat připojení",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Mislykkedes at starte Command Code auth",
     "connectionDeleted": "Forbindelse slettet",
     "connectionFallback": "forbindelse",
-    "coolingConnectionsDescription": "Disse forbindelser returnerede en 429 (rate-limit) ved deres sidste anmodning. OmniRoute vil springe dem over, indtil timeren udløber - ingen manuel deaktivering kræves.",
+    "coolingConnectionsDescription": "Disse forbindelser køler ned efter sidste anmodning. OmniRoute springer dem over, indtil timeren udløber — ingen manuel deaktivering nødvendig.",
     "coolingConnectionsTitle": "I øjeblikket køler ({count})",
     "failedDeleteAlias": "Kunne ikke slette alias",
     "failedDeleteConnection": "Fejl ved sletning af forbindelse",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Fehler beim Starten des Befehls Code auth",
     "connectionDeleted": "Verbindung gelöscht",
     "connectionFallback": "Verbindung",
-    "coolingConnectionsDescription": "Diese Verbindungen haben bei ihrer letzten Anfrage einen 429 (Rate-Limit) zurückgegeben. OmniRoute wird sie überspringen, bis der Timer abläuft – eine manuelle Deaktivierung ist nicht erforderlich.",
+    "coolingConnectionsDescription": "Diese Verbindungen kühlen nach der letzten Anfrage ab. OmniRoute überspringt sie, bis der Timer abläuft — keine manuelle Deaktivierung nötig.",
     "coolingConnectionsTitle": "Aktuell kühlen ({count})",
     "failedDeleteAlias": "Alias konnte nicht gelöscht werden",
     "failedDeleteConnection": "Verbindung konnte nicht gelöscht werden",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -6435,7 +6435,7 @@
     "connectionDeleted": "Connection deleted",
     "connectionFallback": "connection",
     "connectionCooldownCleared": "Cooldown cleared — connection rejoined routing",
-    "coolingConnectionsDescription": "These connections returned a 429 (rate-limit) on their last request. OmniRoute will skip them until the timer expires — no manual disable required.",
+    "coolingConnectionsDescription": "These connections are cooling after their last request. OmniRoute will skip them until the timer expires — no manual disable required.",
     "coolingConnectionsTitle": "Currently cooling ({count})",
     "failedClearConnectionCooldown": "Failed to clear cooldown",
     "failedDeleteAlias": "Failed to delete alias",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Error al iniciar el comando Code auth",
     "connectionDeleted": "Conexión eliminada",
     "connectionFallback": "conexión",
-    "coolingConnectionsDescription": "Estas conexiones devolvieron un 429 (límite de tasa) en su última solicitud. OmniRoute las omitirá hasta que expire el temporizador; no se requiere desactivación manual.",
+    "coolingConnectionsDescription": "Estas conexiones se están enfriando tras su última solicitud. OmniRoute las omitirá hasta que expire el temporizador; no hace falta desactivarlas a mano.",
     "coolingConnectionsTitle": "Enfriando actualmente ({count})",
     "failedDeleteAlias": "Error al eliminar el alias",
     "failedDeleteConnection": "Error al eliminar la conexión",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "شروع Command Code auth با شکست مواجه شد",
     "connectionDeleted": "اتصال حذف شد",
     "connectionFallback": "اتصال",
-    "coolingConnectionsDescription": "این اتصالات در آخرین درخواست خود یک ۴۲۹ (محدودیت نرخ) دریافت کردند. OmniRoute تا زمانی که تایمر منقضی شود، آنها را نادیده خواهد گرفت - نیازی به غیرفعال‌سازی دستی نیست.",
+    "coolingConnectionsDescription": "این اتصالات پس از آخرین درخواست در حال خنک‌شدن هستند. OmniRoute تا پایان تایمر از آنها می‌گذرد — نیازی به غیرفعال‌سازی دستی نیست.",
     "coolingConnectionsTitle": "در حال حاضر خنک‌سازی ({count})",
     "failedDeleteAlias": "حذف مستعار ناموفق بود",
     "failedDeleteConnection": "حذف اتصال ناموفق بود",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Komennon Code auth käynnistys epäonnistui",
     "connectionDeleted": "Yhteys poistettu",
     "connectionFallback": "yhteys",
-    "coolingConnectionsDescription": "Nämä yhteydet palauttivat 429 (nopeusrajoitus) viimeisellä pyynnöllään. OmniRoute ohittaa ne, kunnes ajastin umpeutuu — manuaalista poistamista ei vaadita.",
+    "coolingConnectionsDescription": "Nämä yhteydet jäähtyvät viimeisen pyynnön jälkeen. OmniRoute ohittaa ne, kunnes ajastin umpeutuu — manuaalista poistoa ei tarvita.",
     "coolingConnectionsTitle": "Tällä hetkellä jäähdytys ({count})",
     "failedDeleteAlias": "Aliasn poistaminen epäonnistui",
     "failedDeleteConnection": "Yhteyden poistaminen epäonnistui",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Échec de start Command Code auth",
     "connectionDeleted": "connexions deleted",
     "connectionFallback": "connexions",
-    "coolingConnectionsDescription": "These connexions returned a 429 (rate-limit) on their last request. OmniRoute will skip them until the timer expires — no manual disable required.",
+    "coolingConnectionsDescription": "Ces connexions refroidissent après leur dernière requête. OmniRoute les ignorera jusqu'à l'expiration du minuteur — aucune désactivation manuelle requise.",
     "coolingConnectionsTitle": "Connexions actuellement en refroidissement ({count})",
     "failedDeleteAlias": "Échec de delete alias",
     "failedDeleteConnection": "Échec de delete connexions",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code auth શરૂ કરવામાં નિષ્ફળ રહ્યું",
     "connectionDeleted": "કનેક્શન કાઢી નાખવામાં આવ્યું",
     "connectionFallback": "સંબંધ",
-    "coolingConnectionsDescription": "આ કનેક્શનોએ તેમના છેલ્લા વિનંતી પર 429 (દર-મર્યાદા) પાછું આપ્યું. ઓમ્નીરૂટ તેમને ટાઈમર સમાપ્ત થાય ત્યાં સુધી છોડી દેશે - કોઈ મેન્યુઅલ નિષ્ક્રિય કરવાની જરૂર નથી.",
+    "coolingConnectionsDescription": "આ કનેક્શનો છેલ્લી વિનંતી પછી ઠંડા થઈ રહ્યાં છે. ટાઈમર પૂરું થાય ત્યાં સુધી OmniRoute તેમને છોડી દેશે — હાથથી બંધ કરવાની જરૂર નથી.",
     "coolingConnectionsTitle": "હાલમાં ઠંડું કરી રહ્યા છીએ ({count})",
     "failedDeleteAlias": "એલિયસ કાઢવામાં નિષ્ફળ થયું",
     "failedDeleteConnection": "કનેક્શન કાઢવામાં નિષ્ફળ થયું",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "נכשל בהפעלה של Command Code auth",
     "connectionDeleted": "החיבור נמחק",
     "connectionFallback": "חיבור",
-    "coolingConnectionsDescription": "חיבורים אלה החזירו 429 (מגבלת קצב) בבקשה האחרונה שלהם. OmniRoute ידלג עליהם עד שהטיימר יפוג — אין צורך להשבית ידנית.",
+    "coolingConnectionsDescription": "החיבורים האלה מתקררים אחרי הבקשה האחרונה. OmniRoute ידלג עליהם עד שיפוג הטיימר — אין צורך לבטל ידנית.",
     "coolingConnectionsTitle": "כרגע מקרר ({count})",
     "failedDeleteAlias": "כישלון במחיקת הכינוי",
     "failedDeleteConnection": "כישלון במחקת החיבור",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code auth शुरू करने में विफल रहा",
     "connectionDeleted": "कनेक्शन हटा दिया गया",
     "connectionFallback": "संयोग",
-    "coolingConnectionsDescription": "इन कनेक्शनों ने अपनी अंतिम अनुरोध पर 429 (रेट-सीमा) लौटाया। OmniRoute उन्हें तब तक छोड़ देगा जब तक टाइमर समाप्त नहीं हो जाता — कोई मैनुअल अक्षम करने की आवश्यकता नहीं है।",
+    "coolingConnectionsDescription": "ये कनेक्शन आखिरी अनुरोध के बाद ठंडे हो रहे हैं। टाइमर खत्म होने तक OmniRoute इन्हें छोड़ देगा — हाथ से बंद करने की ज़रूरत नहीं।",
     "coolingConnectionsTitle": "वर्तमान में ठंडा कर रहे हैं ({count})",
     "failedDeleteAlias": "उपनाम हटाने में विफल",
     "failedDeleteConnection": "कनेक्शन हटाने में विफल",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Nem sikerült elindítani a Command Code auth-ot",
     "connectionDeleted": "Kapcsolat törölve",
     "connectionFallback": "kapcsolat",
-    "coolingConnectionsDescription": "Ezek a kapcsolatok 429 (rate-limit) választ adtak az utolsó kérésükre. Az OmniRoute kihagyja őket, amíg az időzítő le nem jár — manuális letiltás nem szükséges.",
+    "coolingConnectionsDescription": "Ezek a kapcsolatok az utolsó kérés után hűlnek. Az OmniRoute kihagyja őket, amíg az időzítő le nem jár — nincs szükség kézi tiltásra.",
     "coolingConnectionsTitle": "Jelenleg hűtés ({count})",
     "failedDeleteAlias": "Nem sikerült törölni az alias-t",
     "failedDeleteConnection": "A kapcsolat törlése nem sikerült",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Gagal memulai Command Code auth",
     "connectionDeleted": "Koneksi dihapus",
     "connectionFallback": "koneksi",
-    "coolingConnectionsDescription": "Koneksi ini mengembalikan 429 (batas-kecepatan) pada permintaan terakhir mereka. OmniRoute akan melewatkan mereka sampai timer berakhir — tidak perlu menonaktifkan secara manual.",
+    "coolingConnectionsDescription": "Koneksi ini sedang mendingin setelah permintaan terakhir. OmniRoute akan melewatinya sampai timer habis — tidak perlu menonaktifkan secara manual.",
     "coolingConnectionsTitle": "Saat ini mendinginkan ({count})",
     "failedDeleteAlias": "Gagal menghapus alias",
     "failedDeleteConnection": "Gagal menghapus koneksi",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Impossibile avviare il comando Code auth",
     "connectionDeleted": "Connessione eliminata",
     "connectionFallback": "connessione",
-    "coolingConnectionsDescription": "Queste connessioni hanno restituito un 429 (limite di frequenza) nell'ultima richiesta. OmniRoute le salterà fino alla scadenza del timer — non è necessaria alcuna disattivazione manuale.",
+    "coolingConnectionsDescription": "Queste connessioni si stanno raffreddando dopo l'ultima richiesta. OmniRoute le salterà fino alla scadenza del timer — nessuna disattivazione manuale richiesta.",
     "coolingConnectionsTitle": "Attualmente raffreddando ({count})",
     "failedDeleteAlias": "Impossibile eliminare l'alias",
     "failedDeleteConnection": "Impossibile eliminare la connessione",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code authの起動に失敗しました",
     "connectionDeleted": "接続が削除されました",
     "connectionFallback": "接続",
-    "coolingConnectionsDescription": "これらの接続は、最後のリクエストで429（レート制限）を返しました。OmniRouteは、タイマーが切れるまでそれらをスキップします — 手動での無効化は必要ありません。",
+    "coolingConnectionsDescription": "これらの接続は前回のリクエスト後に冷却中です。タイマーが切れるまで OmniRoute はそれらをスキップします — 手動で無効にする必要はありません。",
     "coolingConnectionsTitle": "現在冷却中 ({count})",
     "failedDeleteAlias": "エイリアスの削除に失敗しました",
     "failedDeleteConnection": "接続の削除に失敗しました",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code auth를 시작하지 못했습니다.",
     "connectionDeleted": "연결이 삭제되었습니다",
     "connectionFallback": "연결",
-    "coolingConnectionsDescription": "이 연결은 마지막 요청에서 429(요청 한도 초과)를 반환했습니다. OmniRoute는 타이머가 만료될 때까지 이들을 건너뜁니다 — 수동으로 비활성화할 필요가 없습니다.",
+    "coolingConnectionsDescription": "이 연결은 마지막 요청 이후 냉각 중입니다. OmniRoute는 타이머가 끝날 때까지 건너뜁니다 — 수동으로 끌 필요 없습니다.",
     "coolingConnectionsTitle": "현재 냉각 중 ({count})",
     "failedDeleteAlias": "별칭을 삭제하지 못했습니다.",
     "failedDeleteConnection": "연결 삭제에 실패했습니다.",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "कमांड कोड प्रमाणीकरण सुरू करण्यात अयशस्वी",
     "connectionDeleted": "संपर्क हटवला गेला",
     "connectionFallback": "संपर्क",
-    "coolingConnectionsDescription": "या कनेक्शनने त्यांच्या अंतिम विनंतीवर 429 (दर-सीमा) परत केला. OmniRoute त्यांना टाइमर संपेपर्यंत वगळेल - कोणतीही मॅन्युअल अक्षम करणे आवश्यक नाही.",
+    "coolingConnectionsDescription": "ही कनेक्शन शेवटच्या विनंतीनंतर थंड होत आहेत. टाइमर संपेपर्यंत OmniRoute त्यांना वगळेल — हाताने बंद करण्याची गरज नाही.",
     "coolingConnectionsTitle": "सध्या थंड करणे ({count})",
     "failedDeleteAlias": "अलियास हटवण्यात अयशस्वी",
     "failedDeleteConnection": "संपर्क हटवण्यात अयशस्वी",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Gagal untuk memulakan Command Code auth",
     "connectionDeleted": "Sambungan dipadamkan",
     "connectionFallback": "sambungan",
-    "coolingConnectionsDescription": "Sambungan ini mengembalikan 429 (had kadar) pada permintaan terakhir mereka. OmniRoute akan mengabaikannya sehingga pemasa tamat — tiada penyahaktifan manual diperlukan.",
+    "coolingConnectionsDescription": "Sambungan ini sedang menyejuk selepas permintaan terakhir. OmniRoute akan langkauinya sehingga pemasa tamat — tidak perlu dinyahaktif secara manual.",
     "coolingConnectionsTitle": "Sedang menyejukkan ({count})",
     "failedDeleteAlias": "Gagal untuk memadam alias",
     "failedDeleteConnection": "Gagal untuk memadam sambungan",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Kon opdracht Code auth niet starten",
     "connectionDeleted": "Verbinding verwijderd",
     "connectionFallback": "verbinding",
-    "coolingConnectionsDescription": "Deze verbindingen hebben een 429 (rate-limit) geretourneerd bij hun laatste verzoek. OmniRoute zal ze overslaan totdat de timer verloopt — handmatig uitschakelen is niet nodig.",
+    "coolingConnectionsDescription": "Deze verbindingen koelen af na hun laatste verzoek. OmniRoute slaat ze over tot de timer verloopt — handmatig uitschakelen is niet nodig.",
     "coolingConnectionsTitle": "Momenteel aan het koelen ({count})",
     "failedDeleteAlias": "Kon alias niet verwijderen",
     "failedDeleteConnection": "Verbinding verwijderen mislukt",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Kunne ikke starte Command Code auth",
     "connectionDeleted": "Tilkobling slettet",
     "connectionFallback": "tilkobling",
-    "coolingConnectionsDescription": "Disse tilkoblingene returnerte en 429 (rate-limit) på sin siste forespørsel. OmniRoute vil hoppe over dem til timeren utløper — ingen manuell deaktivering nødvendig.",
+    "coolingConnectionsDescription": "Disse tilkoblingene kjøler ned etter siste forespørsel. OmniRoute hopper over dem til timeren utløper — ingen manuell deaktivering nødvendig.",
     "coolingConnectionsTitle": "For øyeblikket kjøler ({count})",
     "failedDeleteAlias": "Kunne ikke slette aliaset",
     "failedDeleteConnection": "Kunne ikke slette tilkoblingen",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Nabigong simulan ang Command Code auth",
     "connectionDeleted": "Nabura ang koneksyon",
     "connectionFallback": "koneksyon",
-    "coolingConnectionsDescription": "Ang mga koneksyong ito ay nagbalik ng 429 (rate-limit) sa kanilang huling kahilingan. Ang OmniRoute ay laktawan ang mga ito hanggang sa mag-expire ang timer — walang kinakailangang manu-manong pag-disable.",
+    "coolingConnectionsDescription": "Ang mga koneksyong ito ay nagpapalamig pagkatapos ng huling kahilingan. Lalaktawan sila ng OmniRoute hanggang mag-expire ang timer — hindi kailangang i-disable nang mano-mano.",
     "coolingConnectionsTitle": "Kasalukuyang nagpapalamig ({count})",
     "failedDeleteAlias": "Nabigong tanggalin ang alias",
     "failedDeleteConnection": "Nabigong tanggalin ang koneksyon",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Nie udało się uruchomić polecenia Code auth",
     "connectionDeleted": "Połączenie usunięte",
     "connectionFallback": "połączenie",
-    "coolingConnectionsDescription": "Te połączenia zwróciły 429 (limit szybkości) w swoim ostatnim żądaniu. OmniRoute pominie je, aż timer wygaśnie — nie jest wymagana ręczna dezaktywacja.",
+    "coolingConnectionsDescription": "Te połączenia stygną po ostatnim żądaniu. OmniRoute pominie je, aż timer wygaśnie — ręczna dezaktywacja nie jest potrzebna.",
     "coolingConnectionsTitle": "Obecnie chłodzenie ({count})",
     "failedDeleteAlias": "Nie udało się usunąć aliasu",
     "failedDeleteConnection": "Nie udało się usunąć połączenia",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -6432,7 +6432,7 @@
     "commandCodeStartFailed": "Falha ao iniciar o comando Code auth",
     "connectionDeleted": "Conexão excluída",
     "connectionFallback": "conexão",
-    "coolingConnectionsDescription": "Essas conexões retornaram um 429 (limite de taxa) na última solicitação. O OmniRoute as ignorará até que o temporizador expire — não é necessário desativação manual.",
+    "coolingConnectionsDescription": "Essas conexões estão esfriando após a última solicitação. O OmniRoute as ignorará até o temporizador expirar — não é necessário desativar manualmente.",
     "coolingConnectionsTitle": "Resfriando atualmente ({count})",
     "failedDeleteAlias": "Falha ao excluir o alias",
     "failedDeleteConnection": "Falha ao excluir a conexão",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Falha ao iniciar o comando Code auth",
     "connectionDeleted": "Conexão eliminada",
     "connectionFallback": "conexão",
-    "coolingConnectionsDescription": "Estas conexões retornaram um 429 (limite de taxa) na sua última solicitação. O OmniRoute irá ignorá-las até que o temporizador expire — não é necessário desativação manual.",
+    "coolingConnectionsDescription": "Estas conexões estão a arrefecer após o último pedido. O OmniRoute irá ignorá-las até o temporizador expirar — não é necessária desativação manual.",
     "coolingConnectionsTitle": "Atualmente a arrefecer ({count})",
     "failedDeleteAlias": "Falha ao eliminar o alias",
     "failedDeleteConnection": "Falha ao eliminar a ligação",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Nu s-a reușit să se pornească Command Code auth",
     "connectionDeleted": "Conexiune ștearsă",
     "connectionFallback": "conexiune",
-    "coolingConnectionsDescription": "Aceste conexiuni au returnat un 429 (limită de rată) la ultima lor solicitare. OmniRoute le va sări peste până când temporizatorul expiră — nu este necesară dezactivarea manuală.",
+    "coolingConnectionsDescription": "Aceste conexiuni se răcesc după ultima solicitare. OmniRoute le va sări până expiră temporizatorul — nu e nevoie de dezactivare manuală.",
     "coolingConnectionsTitle": "În prezent răcire ({count})",
     "failedDeleteAlias": "Nu s-a reușit ștergerea aliasului",
     "failedDeleteConnection": "Nu s-a putut șterge conexiunea",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Не удалось запустить команду Code auth",
     "connectionDeleted": "Соединение удалено",
     "connectionFallback": "соединение",
-    "coolingConnectionsDescription": "Эти соединения вернули 429 (лимит частоты) в своем последнем запросе. OmniRoute пропустит их, пока таймер не истечет — отключение вручную не требуется.",
+    "coolingConnectionsDescription": "Эти соединения остывают после последнего запроса. OmniRoute пропустит их, пока не истечёт таймер — отключать вручную не нужно.",
     "coolingConnectionsTitle": "В настоящее время охлаждение ({count})",
     "failedDeleteAlias": "Не удалось удалить псевдоним",
     "failedDeleteConnection": "Не удалось удалить соединение",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Nepodarilo sa spustiť príkaz Code auth",
     "connectionDeleted": "Pripojenie bolo odstránené",
     "connectionFallback": "pripojenie",
-    "coolingConnectionsDescription": "Tieto pripojenia vrátili 429 (limit rýchlosti) pri ich poslednej žiadosti. OmniRoute ich preskočí, kým neuplynie časovač — nie je potrebné manuálne vypnutie.",
+    "coolingConnectionsDescription": "Tieto pripojenia sa po poslednej žiadosti ochladzujú. OmniRoute ich preskočí, kým nevyprší časovač — ručné vypnutie nie je potrebné.",
     "coolingConnectionsTitle": "Momentálne chladenie ({count})",
     "failedDeleteAlias": "Nepodarilo sa odstrániť alias",
     "failedDeleteConnection": "Nepodarilo sa odstrániť pripojenie",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Misslyckades med att starta Command Code auth",
     "connectionDeleted": "Anslutning raderad",
     "connectionFallback": "anslutning",
-    "coolingConnectionsDescription": "Dessa anslutningar returnerade en 429 (rate-limit) på sin senaste begäran. OmniRoute kommer att hoppa över dem tills timern går ut — ingen manuell inaktivering krävs.",
+    "coolingConnectionsDescription": "Dessa anslutningar svalnar efter senaste begäran. OmniRoute hoppar över dem tills timern går ut — ingen manuell inaktivering krävs.",
     "coolingConnectionsTitle": "För närvarande kylning ({count})",
     "failedDeleteAlias": "Misslyckades med att ta bort aliaset",
     "failedDeleteConnection": "Misslyckades med att ta bort anslutning",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Imeshindikana kuanzisha Command Code auth",
     "connectionDeleted": "Muunganisho umefutwa",
     "connectionFallback": "muunganisho",
-    "coolingConnectionsDescription": "Mawasiliano haya yalirudisha 429 (kikomo cha kiwango) kwenye ombi lao la mwisho. OmniRoute itayaepuka hadi kipima muda kikamilike — hakuna kuzima kwa mikono kunahitajika.",
+    "coolingConnectionsDescription": "Miunganisho hii inapoa baada ya ombi la mwisho. OmniRoute itayaruka hadi kipima muda kiishe — hakuna haja ya kuzima kwa mkono.",
     "coolingConnectionsTitle": "Sasa inapoa ({count})",
     "failedDeleteAlias": "Imeshindikana kufuta jina la utambulisho",
     "failedDeleteConnection": "Imeshindikana kufuta muunganisho",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code auth ஐ துவங்குவதில் தோல்வி அடைந்தது",
     "connectionDeleted": "இணைப்பு நீக்கப்பட்டது",
     "connectionFallback": "இணைப்பு",
-    "coolingConnectionsDescription": "இந்த இணைப்புகள் அவர்களின் கடைசி கோரிக்கையில் 429 (விகித-கட்டுப்பாடு) ஐ திருப்பின. OmniRoute அவற்றைப் புறக்கணிக்கும், நேரம் முடிவடையும்வரை — கைமுறையால் முடக்க தேவையில்லை.",
+    "coolingConnectionsDescription": "இந்த இணைப்புகள் கடைசி கோரிக்கைக்குப் பிறகு குளிர்கின்றன. நேரம் முடியும் வரை OmniRoute அவற்றைத் தவிர்க்கும் — கைமுறையாக முடக்க வேண்டியதில்லை.",
     "coolingConnectionsTitle": "தற்போது குளிர்ச்சி ({count})",
     "failedDeleteAlias": "அலியாஸ் நீக்குவதில் தோல்வி அடைந்தது",
     "failedDeleteConnection": "இணைப்பை நீக்க முடியவில்லை",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code auth ప్రారంభించడంలో విఫలమైంది",
     "connectionDeleted": "కనెక్షన్ తొలగించబడింది",
     "connectionFallback": "కనెక్షన్",
-    "coolingConnectionsDescription": "ఈ కనెక్షన్లు వారి చివరి అభ్యర్థనపై 429 (రేట్-లిమిట్) ను తిరిగి ఇచ్చాయి. OmniRoute సమయ పరిమితి ముగిసే వరకు వాటిని దాటిస్తుంది — మాన్యువల్ డిసేబుల్ అవసరం లేదు.",
+    "coolingConnectionsDescription": "ఈ కనెక్షన్లు చివరి అభ్యర్థన తర్వాత చల్లబడుతున్నాయి. టైమర్ అయిపోయే వరకు OmniRoute వాటిని దాటవేస్తుంది — చేతితో ఆపాల్సిన అవసరం లేదు.",
     "coolingConnectionsTitle": "ప్రస్తుతం కూలింగ్ ({count})",
     "failedDeleteAlias": "అలియాస్‌ను తొలగించడంలో విఫలమైంది",
     "failedDeleteConnection": "కనెక్షన్ తొలగించడంలో విఫలమైంది",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "ไม่สามารถเริ่มคำสั่ง Code auth ได้",
     "connectionDeleted": "การเชื่อมต่อถูกลบแล้ว",
     "connectionFallback": "การเชื่อมต่อ",
-    "coolingConnectionsDescription": "การเชื่อมต่อเหล่านี้ส่งคืน 429 (อัตราการจำกัด) ในคำขอครั้งสุดท้ายของพวกเขา OmniRoute จะข้ามพวกเขาจนกว่าจะหมดเวลา — ไม่ต้องปิดการใช้งานด้วยตนเอง",
+    "coolingConnectionsDescription": "การเชื่อมต่อเหล่านี้กำลังพักหลังคำขอล่าสุด OmniRoute จะข้ามไปจนกว่าตัวจับเวลาจะหมด — ไม่ต้องปิดด้วยมือ",
     "coolingConnectionsTitle": "กำลังทำความเย็นอยู่ ({count})",
     "failedDeleteAlias": "ไม่สามารถลบชื่อเล่นได้",
     "failedDeleteConnection": "ไม่สามารถลบการเชื่อมต่อได้",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Command Code auth başlatılamadı",
     "connectionDeleted": "Bağlantı silindi",
     "connectionFallback": "bağlantı",
-    "coolingConnectionsDescription": "Bu bağlantılar son isteğinde 429 (hız limiti) döndürdü. OmniRoute, zamanlayıcı süresi dolana kadar bunları atlayacak — manuel devre dışı bırakma gerekmez.",
+    "coolingConnectionsDescription": "Bu bağlantılar son istekten sonra soğuyor. OmniRoute zamanlayıcı bitene kadar onları atlayacak — elle kapatmaya gerek yok.",
     "coolingConnectionsTitle": "Şu anda soğutma ({count})",
     "failedDeleteAlias": "Alias silinemedi",
     "failedDeleteConnection": "Bağlantı silinemedi",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "Не вдалося запустити команду Code auth",
     "connectionDeleted": "З'єднання видалено",
     "connectionFallback": "з'єднання",
-    "coolingConnectionsDescription": "Ці з'єднання повернули 429 (обмеження швидкості) у своєму останньому запиті. OmniRoute пропустить їх, поки не закінчиться таймер — вручну вимикати не потрібно.",
+    "coolingConnectionsDescription": "Ці з'єднання остигають після останнього запиту. OmniRoute пропустить їх, поки не скінчиться таймер — вимикати вручну не потрібно.",
     "coolingConnectionsTitle": "Наразі охолодження ({count})",
     "failedDeleteAlias": "Не вдалося видалити псевдонім",
     "failedDeleteConnection": "Не вдалося видалити з'єднання",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "کمانڈ کوڈ کی توثیق شروع کرنے میں ناکامی",
     "connectionDeleted": "کنکشن حذف کر دیا گیا",
     "connectionFallback": "کنکشن",
-    "coolingConnectionsDescription": "یہ کنکشنز نے اپنی آخری درخواست پر 429 (ریٹ-لیمٹ) واپس کیا۔ OmniRoute انہیں اس وقت تک چھوڑ دے گا جب تک کہ ٹائمر ختم نہ ہو جائے — کوئی دستی غیر فعال کرنے کی ضرورت نہیں۔",
+    "coolingConnectionsDescription": "یہ کنکشن آخری درخواست کے بعد ٹھنڈے ہو رہے ہیں۔ ٹائمر ختم ہونے تک OmniRoute انہیں چھوڑ دے گا — ہاتھ سے بند کرنے کی ضرورت نہیں۔",
     "coolingConnectionsTitle": "فی الحال ٹھنڈا کر رہا ہے ({count})",
     "failedDeleteAlias": "ایلیاس کو حذف کرنے میں ناکامی",
     "failedDeleteConnection": "کنکشن کو حذف کرنے میں ناکامی",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -6432,7 +6432,7 @@
     "commandCodeStartFailed": "Không thể bắt đầu xác thực Command Code",
     "connectionDeleted": "Đã xóa kết nối",
     "connectionFallback": "kết nối",
-    "coolingConnectionsDescription": "Các kết nối này trả về 429 (giới hạn tốc độ) trong yêu cầu gần nhất. OmniRoute sẽ bỏ qua chúng cho đến khi bộ hẹn giờ hết hạn — không cần tắt thủ công.",
+    "coolingConnectionsDescription": "Các kết nối này đang nguội sau yêu cầu gần nhất. OmniRoute sẽ bỏ qua chúng đến khi hết giờ — không cần tắt thủ công.",
     "coolingConnectionsTitle": "Các kết nối đang tạm làm mát ({count})",
     "failedDeleteAlias": "Không thể xóa alias",
     "failedDeleteConnection": "Không thể xóa kết nối",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "无法启动命令代码 auth",
     "connectionDeleted": "连接已删除",
     "connectionFallback": "连接",
-    "coolingConnectionsDescription": "这些连接在最后一次请求时返回了429（速率限制）。OmniRoute将在计时器到期之前跳过它们 — 无需手动禁用。",
+    "coolingConnectionsDescription": "这些连接在上次请求后正在冷却。计时器到期前 OmniRoute 会跳过它们 — 无需手动禁用。",
     "coolingConnectionsTitle": "当前冷却中 ({count})",
     "failedDeleteAlias": "删除别名失败",
     "failedDeleteConnection": "无法删除连接",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -6428,7 +6428,7 @@
     "commandCodeStartFailed": "無法啟動 Command Code auth",
     "connectionDeleted": "連線已刪除",
     "connectionFallback": "連接",
-    "coolingConnectionsDescription": "這些連接在最後一次請求時返回了 429（速率限制）。OmniRoute 將跳過它們，直到計時器到期 — 無需手動禁用。",
+    "coolingConnectionsDescription": "這些連線在上次請求後正在冷卻。計時器到期前 OmniRoute 會跳過它們 — 無需手動停用。",
     "coolingConnectionsTitle": "目前冷卻中 ({count})",
     "failedDeleteAlias": "無法刪除別名",
     "failedDeleteConnection": "無法刪除連接",

--- a/tests/unit/cline-401-oauth-12594.test.ts
+++ b/tests/unit/cline-401-oauth-12594.test.ts
@@ -1,0 +1,86 @@
+/**
+ * #12594 — Cline 401 "re-authenticate your Cline account" was classified
+ * UNAUTHORIZED → resolveTerminalConnectionStatus → expired, then the cooling
+ * panel hardcoded that cooldown as a 429. Token refresh (cline.ts) never ran.
+ *
+ * Reporter body (issue):
+ *   [401]: Unauthorized: Please make sure you're using the latest version of
+ *   Cline and re-authenticate your Cline account.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const CLINE_401 =
+  "[401]: Unauthorized: Please make sure you're using the latest version of Cline and re-authenticate your Cline account.";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-12594-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "12594-test-secret";
+
+const { isOAuthInvalidToken } = await import("../../open-sse/services/accountFallback.ts");
+const { classifyProviderError, PROVIDER_ERROR_TYPES } =
+  await import("../../open-sse/services/errorClassifier.ts");
+const { resolveTerminalConnectionStatus } =
+  await import("../../src/sse/services/authTerminalStatus.ts");
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("#12594 isOAuthInvalidToken matches Cline re-authenticate phrasing", () => {
+  assert.equal(isOAuthInvalidToken(CLINE_401), true);
+  assert.equal(isOAuthInvalidToken("plain rate limit"), false);
+  // Must not swallow unrelated 401s that only say "re-authenticate" without Cline.
+  assert.equal(isOAuthInvalidToken("Please re-authenticate the connection."), false);
+});
+
+test("#12594 classifyProviderError maps Cline 401 to OAUTH_INVALID_TOKEN", () => {
+  assert.equal(
+    classifyProviderError(401, CLINE_401, "cline"),
+    PROVIDER_ERROR_TYPES.OAUTH_INVALID_TOKEN
+  );
+});
+
+test("#12594 Cline 401 is not a terminal expired/banned status", () => {
+  const classified = classifyProviderError(401, CLINE_401, "cline");
+  assert.equal(
+    resolveTerminalConnectionStatus(401, {}, classified, "cline", false, CLINE_401),
+    null
+  );
+});
+
+test("#12594 markAccountUnavailable keeps Cline 401 refreshable (not expired)", async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+
+  const conn = await providersDb.createProviderConnection({
+    provider: "cline",
+    authType: "oauth",
+    accessToken: "cline-access",
+    refreshToken: "cline-refresh",
+    isActive: true,
+    testStatus: "active",
+  });
+
+  const result = await auth.markAccountUnavailable(
+    (conn as { id: string }).id,
+    401,
+    CLINE_401,
+    "cline",
+    "sonnet4.6-500k"
+  );
+  const after = await providersDb.getProviderConnectionById((conn as { id: string }).id);
+
+  assert.equal(result.shouldFallback, true);
+  assert.equal(after.testStatus, "active");
+  assert.equal(after.lastErrorType, "oauth_invalid_token");
+  assert.notEqual(after.testStatus, "expired");
+});


### PR DESCRIPTION
## Description

Cline returns 401 with "re-authenticate your Cline account" when the access token is stale. That phrasing was not in `OAUTH_INVALID_TOKEN_SIGNALS`, so `classifyProviderError` treated it as a generic `UNAUTHORIZED` and `resolveTerminalConnectionStatus` marked the connection `expired`. A token refresh would have recovered it (`refreshClineToken` already exists). The cooling panel then printed "429 (rate-limit)" for every connection with a future cooldown timestamp, including this auth failure.

Reporter: usable ~15 min after re-auth, then the same 401. Diego already traced both defects on the issue.

## Changes

- Add `"re-authenticate your cline account"` to `OAUTH_INVALID_TOKEN_SIGNALS`. A Cline 401 now classifies as `oauth_invalid_token` (non-terminal) instead of `expired`.
- Cooling panel copy no longer assumes 429. Rows show the recorded `lastError` when present.
- 42 locale strings for `coolingConnectionsDescription` updated to match.

## Test plan

- `node --import tsx/esm --test tests/unit/cline-401-oauth-12594.test.ts` (4/4)
- Injection: drop the Cline signal → 4/4 red; restore → 4/4 green
- `tests/unit/account-fallback-service.test.ts` + `tests/unit/auth-terminal-status.test.ts` (107/107)
- vitest CoolingConnectionsPanel 10/10
- `accountFallback.ts` stays at frozen 2467 lines

Closes #12594
