### PR TITLE
fix(providers): prevent ReferenceError: validationPsd is not defined for keyless providers

### DIFF
--- a/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/modals/EditConnectionModal.tsx
@@ -600,6 +600,7 @@ export default function EditConnectionModal({
           validatedBaseUrl = checked.value;
         }
       }
+      let validationPsd = validatedProviderSpecificData;
       if (!isOAuth && formData.apiKey) {
         let isValid = validationResult === "success";
         if (!isValid) {


### PR DESCRIPTION
Fixes #13063

### Summary

For keyless providers (such as `searxng-search`), `formData.apiKey` is empty. `validationPsd` was previously scoped inside the `if (!isOAuth && formData.apiKey)` block, but referenced later in the scope when assigning `updates.providerSpecificData`.

Moving `let validationPsd = validatedProviderSpecificData;` out of the `if (!isOAuth && formData.apiKey)` block ensures `validationPsd` is always in scope when saving keyless provider connections.