### PR TITLE
fix(codex): reconcile preflight cooldowns after verified quota rollover

### DIFF
--- a/docs/architecture/RESILIENCE_GUIDE.md
+++ b/docs/architecture/RESILIENCE_GUIDE.md
@@ -637,6 +637,12 @@ default `test:integration`, chaos and heap self-skip (without `RUN_CHAOS_INT`/`-
 
 ### Codex preflight window recovery
 
+A late preflight response cannot overwrite an active or malformed same-scope
+cooldown. The existing SQLite transaction preserves the entire current metadata
+and row timestamp in that case, including a newer provider refusal or preflight
+block. Provenance can be published only for absent or validly expired scoped
+state.
+
 A Codex quota preflight block records the normal child's blocking window name,
 window duration, and reset alongside its fallback cooldown. A later successful
 live usage fetch can retire that child cooldown only when the same window and

--- a/docs/architecture/RESILIENCE_GUIDE.md
+++ b/docs/architecture/RESILIENCE_GUIDE.md
@@ -634,3 +634,27 @@ default `test:integration`, chaos and heap self-skip (without `RUN_CHAOS_INT`/`-
 - [Architecture Guide](./ARCHITECTURE.md) — System architecture and internals
 - [User Guide](../guides/USER_GUIDE.md) — Providers, combos, CLI integration
 - [Auto-Combo Engine](../routing/AUTO-COMBO.md) — 13-factor scoring, mode packs
+
+### Codex preflight window recovery
+
+A Codex quota preflight block records the normal child's blocking window name,
+window duration, and reset alongside its fallback cooldown. A later successful
+live usage fetch can retire that child cooldown only when the same window and
+duration have a strictly later reset and every present normal quota window has
+headroom above the effective connection, provider, or global cutoff. Both raw
+normal-window fields must be present (an explicitly absent window may be null),
+with a boolean nonexhausted signal and finite usage, reset, and duration values.
+Tolerant dashboard normalization is not recovery evidence.
+
+Recovery captures the exact connection and resilience policy before the fetch,
+then compares both inside the existing SQLite transaction. A changed connection,
+policy, or observation older than 30 seconds leaves the cooldown in place.
+Ordinary cooldown and quota-response writers invalidate prior preflight origin
+for their scope, including writes that retain an authoritative `quota_reset`.
+Spark, other provider state, credentials, and legitimate current refusal remain
+unchanged. Legacy fallback rows without recorded preflight origin are not
+implicitly reclassified; they still require scoped operator diagnosis.
+
+The regression suite exercises the public live-usage path with temporary SQLite
+stores and bounded upstream fixtures, including concurrent state changes and
+malformed usage that would otherwise look healthy after display normalization.

--- a/open-sse/services/codexAccount/write.ts
+++ b/open-sse/services/codexAccount/write.ts
@@ -11,13 +11,15 @@ export async function persistCodexChildCooldown(params: {
   connectionId: string;
   model: string;
   rateLimitedUntil: string;
+  quotaPreflightWindow?: { name: string; windowSeconds: number };
 }): Promise<PersistCodexChildCooldownResult | null> {
   if (params.model.trim().length === 0) return null;
   const scope = getCodexModelScope(params.model);
   const providerSpecificData = await updateCodexScopeCooldown(
     params.connectionId,
     scope,
-    params.rateLimitedUntil
+    params.rateLimitedUntil,
+    params.quotaPreflightWindow
   );
   return providerSpecificData ? { scope, providerSpecificData } : null;
 }

--- a/open-sse/services/codexQuotaFetcher.ts
+++ b/open-sse/services/codexQuotaFetcher.ts
@@ -46,11 +46,14 @@ const CACHE_TTL_MS = 60_000; // 60 seconds
 
 // Per-account quota window info (richer than QuotaInfo — includes both windows)
 export interface CodexDualWindowQuota extends QuotaInfo {
-  window5h: { percentUsed: number; resetAt: string | null };
-  window7d: { percentUsed: number; resetAt: string | null };
+  window5h: { percentUsed: number; resetAt: string | null; windowSeconds?: number };
+  window7d: { percentUsed: number; resetAt: string | null; windowSeconds?: number };
   limitReached: boolean;
   /** All known Codex quota windows, including Spark when the upstream exposes it. */
-  allWindows?: Record<string, { percentUsed: number; resetAt: string | null }>;
+  allWindows?: Record<
+    string,
+    { percentUsed: number; resetAt: string | null; windowSeconds?: number }
+  >;
   /**
    * Banked reset credits available on the account (display-only, issue #5199).
    * Eligibility-gated: absent for most accounts. Never throws when missing.
@@ -177,8 +180,8 @@ function getCodexConnectionMeta(
 }
 
 function getDominantResetAt(quota: {
-  window5h: { percentUsed: number; resetAt: string | null };
-  window7d: { percentUsed: number; resetAt: string | null };
+  window5h: { percentUsed: number; resetAt: string | null; windowSeconds?: number };
+  window7d: { percentUsed: number; resetAt: string | null; windowSeconds?: number };
 }): string | null {
   if (quota.window7d.percentUsed > quota.window5h.percentUsed) {
     return quota.window7d.resetAt || quota.window5h.resetAt;
@@ -308,10 +311,17 @@ function parseWindowReset(window: Record<string, unknown>): string | null {
 
 function parseCodexWindow(
   window: Record<string, unknown> | null | undefined
-): { percentUsed: number; resetAt: string | null } | null {
+): { percentUsed: number; resetAt: string | null; windowSeconds?: number } | null {
   if (!window || Object.keys(window).length === 0) return null;
   const percentUsed = toNumber(window["used_percent"] ?? window["usedPercent"], 0) / 100;
-  return { percentUsed, resetAt: parseWindowReset(window) };
+  const seconds = window["limit_window_seconds"];
+  return {
+    percentUsed,
+    resetAt: parseWindowReset(window),
+    ...(typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+      ? { windowSeconds: seconds }
+      : {}),
+  };
 }
 
 /**
@@ -365,8 +375,8 @@ function findSparkRateLimit(data: Record<string, unknown>): Record<string, unkno
 }
 
 function getCodexRateLimitWindows(rateLimit: Record<string, unknown>): {
-  primary: { percentUsed: number; resetAt: string | null } | null;
-  secondary: { percentUsed: number; resetAt: string | null } | null;
+  primary: { percentUsed: number; resetAt: string | null; windowSeconds?: number } | null;
+  secondary: { percentUsed: number; resetAt: string | null; windowSeconds?: number } | null;
 } {
   return {
     primary: parseCodexWindow(toRecord(rateLimit["primary_window"] ?? rateLimit["primaryWindow"])),
@@ -377,7 +387,7 @@ function getCodexRateLimitWindows(rateLimit: Record<string, unknown>): {
 }
 
 function assignCodexWindows(
-  target: Record<string, { percentUsed: number; resetAt: string | null }>,
+  target: Record<string, { percentUsed: number; resetAt: string | null; windowSeconds?: number }>,
   rateLimit: Record<string, unknown>,
   names: { primary: string; secondary: string }
 ): void {
@@ -422,12 +432,18 @@ function parseCodexUsageResponse(
     selectedRateLimit["limit_reached"] ?? selectedRateLimit["limitReached"]
   );
 
-  const windows: Record<string, { percentUsed: number; resetAt: string | null }> = {};
+  const windows: Record<
+    string,
+    { percentUsed: number; resetAt: string | null; windowSeconds?: number }
+  > = {};
   assignCodexWindows(windows, selectedRateLimit, {
     primary: useSparkWindows ? CODEX_SPARK_QUOTA_SESSION : CODEX_WINDOW_SESSION,
     secondary: useSparkWindows ? CODEX_SPARK_QUOTA_WEEKLY : CODEX_WINDOW_WEEKLY,
   });
-  const allWindows: Record<string, { percentUsed: number; resetAt: string | null }> = {
+  const allWindows: Record<
+    string,
+    { percentUsed: number; resetAt: string | null; windowSeconds?: number }
+  > = {
     ...windows,
   };
 

--- a/open-sse/services/quotaPreflight.ts
+++ b/open-sse/services/quotaPreflight.ts
@@ -27,9 +27,11 @@ export interface PreflightQuotaResult {
   reason?: string;
   quotaPercent?: number;
   resetAt?: string | null;
+  blockingWindow?: { name: string; windowSeconds: number };
 }
 
 export interface QuotaWindowInfo {
+  windowSeconds?: number;
   percentUsed: number;
   resetAt?: string | null;
 }
@@ -191,7 +193,14 @@ function quotaWindowCutoffResult(
     worstResetAt = windowInfo.resetAt ?? null;
   }
 
-  return worstWindow === null ? null : exhaustedResult(worstUsedPercent, worstResetAt);
+  if (worstWindow === null) return null;
+  const seconds = windows[worstWindow].windowSeconds;
+  return {
+    ...exhaustedResult(worstUsedPercent, worstResetAt),
+    ...(typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+      ? { blockingWindow: { name: worstWindow, windowSeconds: seconds } }
+      : {}),
+  };
 }
 
 function quotaPercentCutoffResult(
@@ -333,11 +342,20 @@ export async function preflightQuota(
       console.info(
         `[QuotaPreflight] ${provider}/${connectionId} ${worstWindow}: ${worstRemaining.toFixed(1)}% remaining — switching`
       );
+      const windowSeconds = quota.windows[worstWindow].windowSeconds;
       return {
         proceed: false,
         reason: "quota_exhausted",
         quotaPercent: worstUsedPercent,
         resetAt: worstResetAt,
+        ...(typeof windowSeconds === "number" && Number.isFinite(windowSeconds) && windowSeconds > 0
+          ? {
+              blockingWindow: {
+                name: worstWindow,
+                windowSeconds,
+              },
+            }
+          : {}),
       };
     }
 

--- a/open-sse/services/usage/codex.ts
+++ b/open-sse/services/usage/codex.ts
@@ -1,3 +1,4 @@
+import { retainCodexRecoveryEvidence } from "./codexRecoveryEvidence.ts";
 /**
  * usage/codex.ts — Codex (OpenAI / ChatGPT backend) usage fetcher.
  *
@@ -65,7 +66,7 @@ export async function getCodexUsage(
     const { rateLimit, quotas, bankedResetCredits, rateLimitReachedType } =
       buildCodexUsageQuotas(data);
 
-    return {
+    const usage = {
       plan: String(getFieldValue(data, "plan_type", "planType") || "unknown"),
       limitReached: Boolean(getFieldValue(rateLimit, "limit_reached", "limitReached")),
       quotas,
@@ -74,6 +75,8 @@ export async function getCodexUsage(
       ...(bankedResetCredits !== undefined ? { bankedResetCredits } : {}),
       ...(rateLimitReachedType !== undefined ? { rateLimitReachedType } : {}),
     };
+    retainCodexRecoveryEvidence(data, usage);
+    return usage;
   } catch (error) {
     return { message: `Failed to fetch Codex usage: ${(error as Error).message}` };
   }

--- a/open-sse/services/usage/codexRecoveryEvidence.ts
+++ b/open-sse/services/usage/codexRecoveryEvidence.ts
@@ -1,0 +1,60 @@
+/** Strict recovery evidence is separate from tolerant quota display normalization. */
+export interface CodexRecoveryWindow {
+  readonly usedPercent: number;
+  readonly resetAt: number;
+  readonly windowSeconds: number;
+}
+export interface CodexRecoveryEvidence {
+  readonly windows: Readonly<Partial<Record<"session" | "weekly", CodexRecoveryWindow>>>;
+}
+const evidence = new WeakMap<object, CodexRecoveryEvidence>();
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Called only on the actual successful Codex usage response, before coercion. */
+export function retainCodexRecoveryEvidence(raw: unknown, usage: object): void {
+  const rate = record(record(raw)?.rate_limit);
+  if (!rate || rate.limit_reached !== false) return;
+  const windows: Partial<Record<"session" | "weekly", CodexRecoveryWindow>> = {};
+  for (const [rawKey, key] of [
+    ["primary_window", "session"],
+    ["secondary_window", "weekly"],
+  ] as const) {
+    if (!Object.hasOwn(rate, rawKey)) return;
+    if (rate[rawKey] === null) continue;
+    const w = record(rate[rawKey]);
+    if (!w) return;
+    const used = w.used_percent,
+      reset = w.reset_at,
+      seconds = w.limit_window_seconds;
+    if (
+      typeof used !== "number" ||
+      !Number.isFinite(used) ||
+      used < 0 ||
+      used > 100 ||
+      typeof reset !== "number" ||
+      !Number.isFinite(reset) ||
+      reset <= 0 ||
+      reset * 1000 > 8.64e15 ||
+      typeof seconds !== "number" ||
+      !Number.isFinite(seconds) ||
+      seconds <= 0
+    )
+      return;
+    windows[key] = Object.freeze({
+      usedPercent: used,
+      resetAt: reset * 1000,
+      windowSeconds: seconds,
+    });
+  }
+  if (Object.keys(windows).length === 0) return;
+  evidence.set(usage, Object.freeze({ windows: Object.freeze(windows) }));
+}
+
+/** Normalized or caller-created display objects do not possess this evidence. */
+export function getCodexRecoveryEvidence(usage: unknown): CodexRecoveryEvidence | null {
+  return usage !== null && typeof usage === "object" ? (evidence.get(usage) ?? null) : null;
+}

--- a/src/lib/db/providers/codexAccountState.ts
+++ b/src/lib/db/providers/codexAccountState.ts
@@ -49,6 +49,22 @@ export async function updateCodexScopedQuotaState(
     const existingRecord = toRecord(rowToCamel(existing));
     if (existingRecord.provider !== "codex") return null;
     const providerSpecificData = toRecord(existingRecord.providerSpecificData);
+    // A preflight may have started before another response published its refusal.
+    // Never reclassify active or unknown scoped state from that late read.
+    if (patch.quotaPreflightWindow) {
+      const scoped = providerSpecificData.codexScopeRateLimitedUntil;
+      if (
+        scoped !== undefined &&
+        (scoped === null || typeof scoped !== "object" || Array.isArray(scoped))
+      ) {
+        return providerSpecificData;
+      }
+      const cooldowns = toRecord(scoped);
+      if (Object.hasOwn(cooldowns, scope)) {
+        const deadline = typeof cooldowns[scope] === "string" ? Date.parse(cooldowns[scope]) : NaN;
+        if (!Number.isFinite(deadline) || deadline > Date.now()) return providerSpecificData;
+      }
+    }
     const nextProviderSpecificData: JsonRecord = { ...providerSpecificData };
 
     if (patch.quotaState) {

--- a/src/lib/db/providers/codexAccountState.ts
+++ b/src/lib/db/providers/codexAccountState.ts
@@ -1,3 +1,8 @@
+import type { CodexRecoveryEvidence } from "@omniroute/open-sse/services/usage/codexRecoveryEvidence.ts";
+import { resolveResilienceSettings } from "../../resilience/settings";
+import { createHash } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { decryptConnectionFields } from "../encryption";
 import { backupDbFile } from "../backup";
 import { getDbInstance, rowToCamel } from "../core";
 import { invalidateDbCache } from "../readCache";
@@ -20,6 +25,7 @@ type CodexScopedQuotaPatch = {
   exhaustedWindow?: "5h" | "7d" | null;
   rateLimitedUntil?: string;
   rateLimitSource?: "fallback" | "quota_reset";
+  quotaPreflightWindow?: { name: string; windowSeconds: number };
 };
 
 /**
@@ -70,6 +76,10 @@ export async function updateCodexScopedQuotaState(
       }
     }
 
+    // Every ordinary cooldown/quota response invalidates older preflight provenance.
+    const preflightWindows = { ...toRecord(providerSpecificData.codexScopePreflightWindow) };
+    delete preflightWindows[scope];
+
     if (patch.rateLimitedUntil) {
       const scopeCooldowns = toRecord(providerSpecificData.codexScopeRateLimitedUntil);
       const sourceByScope = toRecord(providerSpecificData.codexScopeRateLimitSource);
@@ -92,6 +102,25 @@ export async function updateCodexScopedQuotaState(
           ? sourceByScope[scope]
           : (patch.rateLimitSource ?? "fallback"),
       };
+      const origin = patch.quotaPreflightWindow;
+      if (
+        !existingIsAuthoritative &&
+        patch.rateLimitSource === "fallback" &&
+        origin &&
+        ["session", "weekly"].includes(origin.name) &&
+        Number.isFinite(origin.windowSeconds) &&
+        origin.windowSeconds > 0 &&
+        Number.isFinite(Date.parse(patch.rateLimitedUntil))
+      ) {
+        preflightWindows[scope] = { ...origin, resetAt: patch.rateLimitedUntil };
+      }
+    }
+
+    if (
+      providerSpecificData.codexScopePreflightWindow !== undefined ||
+      Object.keys(preflightWindows).length
+    ) {
+      nextProviderSpecificData.codexScopePreflightWindow = preflightWindows;
     }
 
     db.prepare(
@@ -110,10 +139,174 @@ export async function updateCodexScopedQuotaState(
 export async function updateCodexScopeCooldown(
   id: string,
   scope: "codex" | "spark",
-  rateLimitedUntil: string
+  rateLimitedUntil: string,
+  quotaPreflightWindow?: { name: string; windowSeconds: number }
 ): Promise<JsonRecord | null> {
   return updateCodexScopedQuotaState(id, scope, {
     rateLimitedUntil,
     rateLimitSource: "fallback",
+    quotaPreflightWindow,
   });
+}
+
+/** Internal observation only; never deserialized from an HTTP request. */
+export interface CodexScopeRecoveryObservation {
+  readonly connectionId: string;
+  readonly rowDigest: string;
+  readonly policyRaw: string | null;
+  readonly oldResetAt: number;
+  readonly blockingWindow: "session" | "weekly";
+  readonly windowSeconds: number;
+  readonly startedAt: number;
+}
+
+function rowDigest(row: unknown): string {
+  return createHash("sha256").update(JSON.stringify(row)).digest("hex");
+}
+
+function policySnapshot(db: DbLike): string | null {
+  const row = db
+    .prepare<{ value: string }>(
+      "SELECT value FROM key_value WHERE namespace = 'settings' AND key = 'resilienceSettings'"
+    )
+    .get();
+  return row?.value ?? null;
+}
+
+function policy(raw: string | null) {
+  try {
+    const value: unknown = raw === null ? undefined : JSON.parse(raw);
+    if (value !== undefined && (!value || typeof value !== "object" || Array.isArray(value)))
+      return null;
+    return resolveResilienceSettings({ resilienceSettings: value }).quotaPreflight;
+  } catch {
+    return null;
+  }
+}
+
+/** Bind exact credentials/workspace and policy before the live usage fetch. */
+export function captureCodexScopeRecovery(
+  connection: JsonRecord
+): CodexScopeRecoveryObservation | null {
+  const startedAt = performance.now();
+  if (connection.provider !== "codex" || connection.authType !== "oauth") return null;
+  const db = getDbInstance() as unknown as DbLike;
+  const row = db.prepare("SELECT * FROM provider_connections WHERE id = ?").get(connection.id);
+  if (!row) return null;
+  const current = decryptConnectionFields(toRecord(rowToCamel(row)));
+  if (current.provider !== "codex" || current.isActive !== true) return null;
+  if (["banned", "expired", "credits_exhausted"].includes(String(current.testStatus))) return null;
+  for (const key of ["authType", "accessToken", "refreshToken", "providerSpecificData"]) {
+    if (JSON.stringify(current[key]) !== JSON.stringify(connection[key])) return null;
+  }
+  const data = toRecord(current.providerSpecificData);
+  if (toRecord(data.codexScopeRateLimitSource).codex !== "fallback") return null;
+  const oldResetAt = Date.parse(String(toRecord(data.codexScopeRateLimitedUntil).codex));
+  if (!Number.isFinite(oldResetAt) || oldResetAt <= Date.now()) return null;
+  const origin = toRecord(toRecord(data.codexScopePreflightWindow).codex);
+  if (
+    (origin.name !== "session" && origin.name !== "weekly") ||
+    Date.parse(String(origin.resetAt)) !== oldResetAt ||
+    typeof origin.windowSeconds !== "number" ||
+    !Number.isFinite(origin.windowSeconds) ||
+    origin.windowSeconds <= 0
+  )
+    return null;
+  const policyRaw = policySnapshot(db);
+  if (!policy(policyRaw)) return null;
+  return Object.freeze({
+    connectionId: String(connection.id),
+    rowDigest: rowDigest(row),
+    policyRaw,
+    oldResetAt,
+    blockingWindow: origin.name,
+    windowSeconds: origin.windowSeconds,
+    startedAt,
+  });
+}
+
+function hasAdvancedCodexWindows(
+  evidence: CodexRecoveryEvidence,
+  observation: CodexScopeRecoveryObservation,
+  row: JsonRecord
+): boolean {
+  const blocked = evidence.windows[observation.blockingWindow];
+  if (
+    !blocked ||
+    blocked.windowSeconds !== observation.windowSeconds ||
+    blocked.resetAt <= observation.oldResetAt
+  )
+    return false;
+  const currentPolicy = policy(observation.policyRaw);
+  if (!currentPolicy) return false;
+  const thresholds = toRecord(rowToCamel(row)?.quotaWindowThresholds);
+  const providerDefaults = currentPolicy.providerWindowDefaults.codex ?? {};
+  return Object.entries(evidence.windows).every(([key, window]) => {
+    // These are normal Codex window keys, so the auth resolver's base-window alias is identical.
+    const threshold =
+      thresholds[key] ?? providerDefaults[key] ?? currentPolicy.defaultThresholdPercent;
+    return (
+      typeof threshold === "number" &&
+      Number.isFinite(threshold) &&
+      threshold >= 0 &&
+      threshold <= 100 &&
+      100 - window.usedPercent > threshold &&
+      window.resetAt > Date.now()
+    );
+  });
+}
+
+/** Retire only a proven obsolete normal-Codex preflight fallback, under row + policy CAS. */
+export function reconcileCodexScopeRecovery(
+  observation: CodexScopeRecoveryObservation,
+  evidence: CodexRecoveryEvidence | null
+): boolean {
+  const fresh = () => {
+    const elapsed = performance.now() - observation.startedAt;
+    return Number.isFinite(elapsed) && elapsed >= 0 && elapsed <= 30_000;
+  };
+  if (!evidence || !fresh()) return false;
+  const db = getDbInstance() as unknown as DbLike;
+  backupDbFile("pre-write");
+  const changed = db.transaction(() => {
+    const raw = db
+      .prepare("SELECT * FROM provider_connections WHERE id = ?")
+      .get(observation.connectionId);
+    if (
+      !raw ||
+      !fresh() ||
+      rowDigest(raw) !== observation.rowDigest ||
+      policySnapshot(db) !== observation.policyRaw
+    )
+      return false;
+    const row = toRecord(raw);
+    if (!hasAdvancedCodexWindows(evidence, observation, row)) return false;
+    const data = toRecord(rowToCamel(row)?.providerSpecificData);
+    const cooldowns = { ...toRecord(data.codexScopeRateLimitedUntil) };
+    const sources = { ...toRecord(data.codexScopeRateLimitSource) };
+    if (
+      sources.codex !== "fallback" ||
+      Date.parse(String(cooldowns.codex)) !== observation.oldResetAt
+    )
+      return false;
+    const origins = { ...toRecord(data.codexScopePreflightWindow) };
+    delete cooldowns.codex;
+    delete sources.codex;
+    delete origins.codex;
+    db.prepare(
+      `UPDATE provider_connections SET provider_specific_data = ?, updated_at = ? WHERE id = ?`
+    ).run(
+      JSON.stringify({
+        ...data,
+        codexScopeRateLimitedUntil: cooldowns,
+        codexScopeRateLimitSource: sources,
+        codexScopePreflightWindow: origins,
+      }),
+      new Date().toISOString(),
+      observation.connectionId
+    );
+    return true;
+  })();
+  if (changed) invalidateDbCache("connections");
+  return changed;
 }

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -1,3 +1,8 @@
+import { getCodexRecoveryEvidence } from "@omniroute/open-sse/services/usage/codexRecoveryEvidence.ts";
+import {
+  captureCodexScopeRecovery,
+  reconcileCodexScopeRecovery,
+} from "@/lib/db/providers/codexAccountState";
 import {
   getProviderConnectionById,
   getProviderConnections,
@@ -909,10 +914,10 @@ async function fetchLiveProviderLimitsWithOptions(
         await syncToCloudIfEnabled();
       }
 
-      let usageData = sanitizeUsageQuotasForProvider(
-        conn.provider,
-        (await getUsageForProvider(conn as unknown as JsonRecord, options)) as JsonRecord
-      );
+      let codexRecovery = captureCodexScopeRecovery(conn as unknown as JsonRecord);
+      let rawUsage = await getUsageForProvider(conn as unknown as JsonRecord, options);
+      let recoveryEvidence = getCodexRecoveryEvidence(rawUsage);
+      let usageData = sanitizeUsageQuotasForProvider(conn.provider, rawUsage as JsonRecord);
 
       // Reactive 401 recovery (on-demand/force path only): an unauthorized usage
       // response means the access token is actually dead. Force ONE serialized
@@ -927,13 +932,16 @@ async function fetchLiveProviderLimitsWithOptions(
         if (forced.refreshed) {
           conn = forced.connection;
           await syncToCloudIfEnabled();
-          usageData = sanitizeUsageQuotasForProvider(
-            conn.provider,
-            (await getUsageForProvider(conn as unknown as JsonRecord, options)) as JsonRecord
-          );
+          codexRecovery = captureCodexScopeRecovery(conn as unknown as JsonRecord);
+          rawUsage = await getUsageForProvider(conn as unknown as JsonRecord, options);
+          recoveryEvidence = getCodexRecoveryEvidence(rawUsage);
+          usageData = sanitizeUsageQuotasForProvider(conn.provider, rawUsage as JsonRecord);
         }
       }
 
+      if (codexRecovery && reconcileCodexScopeRecovery(codexRecovery, recoveryEvidence)) {
+        conn = (await getProviderConnectionById(connectionId)) as unknown as ProviderConnectionLike;
+      }
       connection = conn;
       return { usage: usageData };
     });

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -923,7 +923,11 @@ function quotaPreflightUnavailableUntil(resetAt?: string | null): string {
 async function markQuotaPreflightAccountUnavailable(
   provider: string,
   connectionId: string,
-  preflight: { quotaPercent?: number; resetAt?: string | null },
+  preflight: {
+    quotaPercent?: number;
+    resetAt?: string | null;
+    blockingWindow?: { name: string; windowSeconds: number };
+  },
   requestedModel: string | null
 ): Promise<string> {
   const unavailableUntil = quotaPreflightUnavailableUntil(preflight.resetAt ?? null);
@@ -932,6 +936,11 @@ async function markQuotaPreflightAccountUnavailable(
       connectionId,
       model: requestedModel,
       rateLimitedUntil: unavailableUntil,
+      // A synthetic fallback deadline is not an observed quota-window reset.
+      quotaPreflightWindow:
+        preflight.resetAt && Date.parse(preflight.resetAt) === Date.parse(unavailableUntil)
+          ? preflight.blockingWindow
+          : undefined,
     });
     return unavailableUntil;
   }

--- a/tests/unit/codex-account-cooldown-write.test.ts
+++ b/tests/unit/codex-account-cooldown-write.test.ts
@@ -667,3 +667,152 @@ test("new preflight persistence cannot reclassify a still authoritative quota re
     before.providerSpecificData
   );
 });
+
+for (const intervening of ["genuine429", "newerPreflight"] as const) {
+  test(`late public-auth preflight cannot overwrite an intervening ${intervening}`, async () => {
+    const connection = await seedCodexConnection();
+    await providersDb.updateProviderConnection(connection.id, {
+      providerSpecificData: { quotaPreflightEnabled: true },
+    });
+    const { registerQuotaFetcher } = await import("../../open-sse/services/quotaPreflight.ts");
+    const { getProviderCredentialsWithQuotaPreflight } =
+      await import("../../src/sse/services/auth.ts");
+    const oldReset = Date.now() + 60_000;
+    const currentReset = intervening === "newerPreflight" ? oldReset + 600_000 : oldReset;
+    const currentIso = new Date(currentReset).toISOString();
+    let calls = 0;
+    let currentMetadata: unknown;
+    registerQuotaFetcher("codex", async () => {
+      calls++;
+      await codexAccount.persistCodexChildCooldown({
+        connectionId: connection.id,
+        model: "gpt-5.6-luna-max",
+        rateLimitedUntil: currentIso,
+        ...(intervening === "newerPreflight"
+          ? { quotaPreflightWindow: { name: "session", windowSeconds: 18000 } }
+          : {}),
+      });
+      currentMetadata = (await readConnection(connection.id)).providerSpecificData;
+      return {
+        used: 100,
+        total: 100,
+        percentUsed: 1,
+        resetAt: new Date(oldReset).toISOString(),
+        windows: {
+          session: {
+            percentUsed: 1,
+            resetAt: new Date(oldReset).toISOString(),
+            windowSeconds: 18000,
+          },
+        },
+      };
+    });
+    const result = await getProviderCredentialsWithQuotaPreflight(
+      "codex",
+      null,
+      null,
+      "gpt-5.6-luna-max"
+    );
+    assert.equal(result.allRateLimited, true);
+    assert.equal(calls, 1);
+    assert.deepEqual((await readConnection(connection.id)).providerSpecificData, currentMetadata);
+    await fetchRecovery(connection.id, {
+      rate_limit: {
+        limit_reached: false,
+        primary_window: {
+          used_percent: 10,
+          reset_at: (oldReset + 600_000) / 1000,
+          limit_window_seconds: 18000,
+        },
+        secondary_window: null,
+      },
+    });
+    assert.equal(
+      (await readConnection(connection.id)).providerSpecificData.codexScopeRateLimitedUntil.codex,
+      currentIso
+    );
+  });
+}
+
+for (const malformed of ["not-a-date", null, 12, { unknown: true }] as const) {
+  test(`late preflight preserves malformed scoped deadline ${JSON.stringify(malformed)} without a row write`, async () => {
+    const connection = await seedCodexConnection();
+    await providersDb.updateProviderConnection(connection.id, {
+      providerSpecificData: {
+        codexScopeRateLimitedUntil: { codex: malformed },
+        codexScopeRateLimitSource: { codex: "fallback" },
+        unrelated: { keep: true },
+      },
+    });
+    const before = core
+      .getDbInstance()
+      .prepare("SELECT * FROM provider_connections WHERE id = ?")
+      .get(connection.id);
+    await codexAccount.persistCodexChildCooldown({
+      connectionId: connection.id,
+      model: "gpt-5.6-luna-max",
+      rateLimitedUntil: new Date(Date.now() + 600_000).toISOString(),
+      quotaPreflightWindow: { name: "session", windowSeconds: 18000 },
+    });
+    assert.deepEqual(
+      core
+        .getDbInstance()
+        .prepare("SELECT * FROM provider_connections WHERE id = ?")
+        .get(connection.id),
+      before
+    );
+  });
+}
+
+test("validly expired scoped refusal permits fresh preflight provenance", async () => {
+  const connection = await seedCodexConnection();
+  await codexAccount.persistCodexChildCooldown({
+    connectionId: connection.id,
+    model: "gpt-5.6-luna-max",
+    rateLimitedUntil: new Date(Date.now() - 60_000).toISOString(),
+  });
+  const until = new Date(Date.now() + 600_000).toISOString();
+  await codexAccount.persistCodexChildCooldown({
+    connectionId: connection.id,
+    model: "gpt-5.6-luna-max",
+    rateLimitedUntil: until,
+    quotaPreflightWindow: { name: "session", windowSeconds: 18000 },
+  });
+  const after = await readConnection(connection.id);
+  assert.equal(after.providerSpecificData.codexScopeRateLimitedUntil.codex, until);
+  assert.deepEqual(
+    (
+      (after.providerSpecificData as Record<string, unknown>).codexScopePreflightWindow as Record<
+        string,
+        unknown
+      >
+    ).codex,
+    { name: "session", windowSeconds: 18000, resetAt: until }
+  );
+});
+
+for (const malformedMap of [null, [], "unknown"] as const) {
+  test(`preflight preserves an unknown scope map ${JSON.stringify(malformedMap)}`, async () => {
+    const connection = await seedCodexConnection();
+    await providersDb.updateProviderConnection(connection.id, {
+      providerSpecificData: { codexScopeRateLimitedUntil: malformedMap, unrelated: { keep: true } },
+    });
+    const before = core
+      .getDbInstance()
+      .prepare("SELECT * FROM provider_connections WHERE id = ?")
+      .get(connection.id);
+    await codexAccount.persistCodexChildCooldown({
+      connectionId: connection.id,
+      model: "gpt-5.6-luna-max",
+      rateLimitedUntil: new Date(Date.now() + 600_000).toISOString(),
+      quotaPreflightWindow: { name: "session", windowSeconds: 18000 },
+    });
+    assert.deepEqual(
+      core
+        .getDbInstance()
+        .prepare("SELECT * FROM provider_connections WHERE id = ?")
+        .get(connection.id),
+      before
+    );
+  });
+}

--- a/tests/unit/codex-account-cooldown-write.test.ts
+++ b/tests/unit/codex-account-cooldown-write.test.ts
@@ -316,3 +316,354 @@ test("concurrent Codex and Spark child cooldown writes retain both scopes", asyn
   });
   assert.deepEqual(persisted.providerSpecificData.unrelated, { retained: true });
 });
+
+type RecoveryPayload = Record<string, unknown>;
+async function seedRecovery() {
+  const connection = await seedCodexConnection();
+  const oldReset = new Date(Date.now() + 60_000).toISOString();
+  const newReset = new Date(Date.now() + 600_000).toISOString();
+  const sparkReset = new Date(Date.now() + 900_000).toISOString();
+  await codexAccount.persistCodexChildCooldown({
+    connectionId: connection.id,
+    model: "gpt-5.6-luna-max",
+    rateLimitedUntil: oldReset,
+    quotaPreflightWindow: { name: "session", windowSeconds: 604800 },
+  });
+  await codexAccount.persistCodexChildCooldown({
+    connectionId: connection.id,
+    model: "gpt-5.3-codex-spark",
+    rateLimitedUntil: sparkReset,
+  });
+  const window = {
+    used_percent: 14,
+    reset_at: Date.parse(newReset) / 1000,
+    limit_window_seconds: 604800,
+  };
+  const payload: RecoveryPayload = {
+    plan_type: "pro",
+    rate_limit: {
+      limit_reached: false,
+      primary_window: window,
+      secondary_window: null,
+    },
+  };
+  return { connection, oldReset, newReset, sparkReset, window, payload };
+}
+
+async function fetchRecovery(
+  id: string,
+  payload: RecoveryPayload,
+  duringFetch?: () => Promise<void>
+) {
+  const originalFetch = globalThis.fetch;
+  let requests = 0;
+  globalThis.fetch = async (input) => {
+    assert.equal(String(input), "https://chatgpt.com/backend-api/wham/usage");
+    requests++;
+    await duringFetch?.();
+    return Response.json(payload);
+  };
+  try {
+    const limits = await import("../../src/lib/usage/providerLimits.ts");
+    return await limits.fetchLiveProviderLimits(id);
+  } finally {
+    globalThis.fetch = originalFetch;
+    assert.equal(requests, 1);
+  }
+}
+
+test("fresh same-scope usage after the recorded preflight window advances retires only that fallback", async () => {
+  const { connection, payload, sparkReset } = await seedRecovery();
+  const before = await readConnection(connection.id);
+  await fetchRecovery(connection.id, payload);
+  const after = await readConnection(connection.id);
+  assert.deepEqual(after.providerSpecificData.codexScopeRateLimitedUntil, { spark: sparkReset });
+  assert.deepEqual(after.providerSpecificData.codexScopeRateLimitSource, { spark: "fallback" });
+  assert.deepEqual(
+    (after.providerSpecificData as Record<string, unknown>).codexScopePreflightWindow,
+    {}
+  );
+  for (const key of ["testStatus", "rateLimitedUntil", "errorCode", "backoffLevel"] as const)
+    assert.equal(after[key], before[key]);
+  assert.deepEqual(after.providerSpecificData.unrelated, before.providerSpecificData.unrelated);
+  const { captureCodexScopeRecovery } =
+    await import("../../src/lib/db/providers/codexAccountState.ts");
+  assert.equal(captureCodexScopeRecovery(after as unknown as Record<string, unknown>), null);
+});
+
+for (const variant of ["recent429", "quota_reset", "quota_response"] as const) {
+  test(`ordinary ${variant} invalidates preflight provenance and healthy usage cannot erase its block`, async () => {
+    const { connection, payload, oldReset } = await seedRecovery();
+    const state = await import("../../src/lib/db/providers/codexAccountState.ts");
+    if (variant === "recent429")
+      await codexAccount.persistCodexChildCooldown({
+        connectionId: connection.id,
+        model: "gpt-5.6-luna-max",
+        rateLimitedUntil: oldReset,
+      });
+    else
+      await state.updateCodexScopedQuotaState(
+        connection.id,
+        "codex",
+        variant === "quota_reset"
+          ? { rateLimitedUntil: oldReset, rateLimitSource: "quota_reset" }
+          : { quotaState: { observedAt: new Date().toISOString() } }
+      );
+    const before = await readConnection(connection.id);
+    assert.deepEqual(
+      (before.providerSpecificData as Record<string, unknown>).codexScopePreflightWindow,
+      {}
+    );
+    await fetchRecovery(connection.id, payload);
+    assert.deepEqual(
+      (await readConnection(connection.id)).providerSpecificData,
+      before.providerSpecificData
+    );
+  });
+}
+
+for (const mutation of [
+  "missingFlag",
+  "stringFlag",
+  "exhaustedFlag",
+  "missingUsed",
+  "stringUsed",
+  "negativeUsed",
+  "missingReset",
+  "missingDuration",
+  "missingSecondary",
+  "missingPrimary",
+  "bothNull",
+  "secondExhausted",
+  "sameReset",
+  "differentDuration",
+] as const) {
+  test(`uncertain or nonadvanced raw quota ${mutation} preserves the scoped refusal`, async () => {
+    const { connection, payload, window, oldReset } = await seedRecovery();
+    const rate = payload.rate_limit as Record<string, unknown>;
+    if (mutation === "missingFlag") delete rate.limit_reached;
+    if (mutation === "stringFlag") rate.limit_reached = "false";
+    if (mutation === "exhaustedFlag") rate.limit_reached = true;
+    if (mutation === "missingUsed") delete (window as Partial<typeof window>).used_percent;
+    if (mutation === "stringUsed") (window as Record<string, unknown>).used_percent = "14";
+    if (mutation === "negativeUsed") window.used_percent = -1;
+    if (mutation === "missingReset") delete (window as Partial<typeof window>).reset_at;
+    if (mutation === "missingDuration")
+      delete (window as Partial<typeof window>).limit_window_seconds;
+    if (mutation === "missingSecondary") delete rate.secondary_window;
+    if (mutation === "missingPrimary") delete rate.primary_window;
+    if (mutation === "bothNull") rate.primary_window = null;
+    if (mutation === "secondExhausted") rate.secondary_window = { ...window, used_percent: 100 };
+    if (mutation === "sameReset") window.reset_at = Date.parse(oldReset) / 1000;
+    if (mutation === "differentDuration") window.limit_window_seconds = 18000;
+    const before = await readConnection(connection.id);
+    await fetchRecovery(connection.id, payload);
+    const after = await readConnection(connection.id);
+    assert.deepEqual(after.providerSpecificData, before.providerSpecificData);
+  });
+}
+
+test("a healthy unchanged second window and review/Spark siblings do not prevent normal-window recovery", async () => {
+  const { connection, payload, window, oldReset, sparkReset } = await seedRecovery();
+  (payload.rate_limit as Record<string, unknown>).secondary_window = {
+    ...window,
+    limit_window_seconds: 18000,
+    reset_at: Date.parse(oldReset) / 1000,
+  };
+  payload.code_review_rate_limit = { limit_reached: true };
+  payload.additional_rate_limits = [
+    { limit_name: "GPT-5.3-Codex-Spark", rate_limit: { limit_reached: true } },
+  ];
+  await fetchRecovery(connection.id, payload);
+  assert.deepEqual(
+    (await readConnection(connection.id)).providerSpecificData.codexScopeRateLimitedUntil,
+    { spark: sparkReset }
+  );
+});
+
+for (const level of ["connection", "provider", "global"] as const) {
+  test(`${level} effective remaining-quota cutoff still blocks recovery`, async () => {
+    const { connection, payload } = await seedRecovery();
+    if (level === "connection")
+      await providersDb.updateProviderConnection(connection.id, {
+        quotaWindowThresholds: { session: 90 },
+      });
+    else {
+      const { updateSettings } = await import("../../src/lib/db/settings.ts");
+      await updateSettings({
+        resilienceSettings: {
+          quotaPreflight:
+            level === "provider"
+              ? { providerWindowDefaults: { codex: { session: 90 } } }
+              : { defaultThresholdPercent: 90 },
+        },
+      });
+    }
+    const before = await readConnection(connection.id);
+    await fetchRecovery(connection.id, payload);
+    assert.deepEqual(
+      (await readConnection(connection.id)).providerSpecificData,
+      before.providerSpecificData
+    );
+  });
+}
+
+for (const mutation of ["credentials", "policy", "sameUntil429"] as const) {
+  test(`concurrent ${mutation} changes defeat the captured row/policy CAS`, async () => {
+    const { connection, payload, oldReset } = await seedRecovery();
+    await fetchRecovery(connection.id, payload, async () => {
+      if (mutation === "credentials")
+        await providersDb.updateProviderConnection(connection.id, {
+          accessToken: "changed-test-token",
+        });
+      if (mutation === "policy") {
+        const { updateSettings } = await import("../../src/lib/db/settings.ts");
+        await updateSettings({
+          resilienceSettings: { quotaPreflight: { defaultThresholdPercent: 3 } },
+        });
+      }
+      if (mutation === "sameUntil429")
+        await codexAccount.persistCodexChildCooldown({
+          connectionId: connection.id,
+          model: "gpt-5.6-luna-max",
+          rateLimitedUntil: oldReset,
+        });
+    });
+    assert.equal(
+      (await readConnection(connection.id)).providerSpecificData.codexScopeRateLimitedUntil.codex,
+      oldReset
+    );
+  });
+}
+
+test("expired observations and display-only quota objects cannot authorize recovery", async () => {
+  const { connection, payload, oldReset } = await seedRecovery();
+  const state = await import("../../src/lib/db/providers/codexAccountState.ts");
+  const evidence = await import("../../open-sse/services/usage/codexRecoveryEvidence.ts");
+  const observed = state.captureCodexScopeRecovery(
+    await providersDb.getProviderConnectionById(connection.id)
+  );
+  assert.ok(observed);
+  assert.equal(
+    evidence.getCodexRecoveryEvidence({ limitReached: false, quotas: { session: { used: 0 } } }),
+    null
+  );
+  assert.equal(state.reconcileCodexScopeRecovery(observed, null), false);
+  const usage = {};
+  evidence.retainCodexRecoveryEvidence(payload, usage);
+  assert.equal(
+    state.reconcileCodexScopeRecovery(
+      { ...observed, startedAt: observed.startedAt - 31_000 },
+      evidence.getCodexRecoveryEvidence(usage)
+    ),
+    false
+  );
+  assert.equal(
+    (await readConnection(connection.id)).providerSpecificData.codexScopeRateLimitedUntil.codex,
+    oldReset
+  );
+});
+
+test("actual Codex quota parsing and preflight preserve the blocking window identity through persistence", async () => {
+  const { connection, oldReset } = await seedRecovery();
+  const { fetchCodexQuota } = await import("../../open-sse/services/codexQuotaFetcher.ts");
+  const { registerQuotaFetcher, preflightQuota } =
+    await import("../../open-sse/services/quotaPreflight.ts");
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    Response.json({
+      rate_limit: {
+        limit_reached: false,
+        primary_window: {
+          used_percent: 95,
+          reset_at: Date.parse(oldReset) / 1000,
+          limit_window_seconds: 604800,
+        },
+        secondary_window: null,
+      },
+    });
+  let quota;
+  try {
+    quota = await fetchCodexQuota(connection.id, {
+      accessToken: "test-token",
+      requestedModel: "gpt-5.6-luna-max",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.ok(quota);
+  registerQuotaFetcher("codex-recovery-test", async () => quota);
+  const blocked = await preflightQuota(
+    "codex-recovery-test",
+    connection.id,
+    {},
+    {
+      resolveMinRemainingPercent: () => 10,
+    }
+  );
+  assert.equal(blocked.proceed, false);
+  assert.equal(blocked.resetAt, oldReset);
+  assert.deepEqual(blocked.blockingWindow, { name: "session", windowSeconds: 604800 });
+  await codexAccount.persistCodexChildCooldown({
+    connectionId: connection.id,
+    model: "gpt-5.6-luna-max",
+    rateLimitedUntil: oldReset,
+    quotaPreflightWindow: blocked.blockingWindow,
+  });
+  const data = (await readConnection(connection.id)).providerSpecificData as Record<
+    string,
+    unknown
+  >;
+  assert.deepEqual((data.codexScopePreflightWindow as Record<string, unknown>).codex, {
+    name: "session",
+    windowSeconds: 604800,
+    resetAt: oldReset,
+  });
+});
+
+test("connection cutoff takes precedence over restrictive provider/global defaults", async () => {
+  const { connection, payload, sparkReset } = await seedRecovery();
+  const { updateSettings } = await import("../../src/lib/db/settings.ts");
+  await updateSettings({
+    resilienceSettings: {
+      quotaPreflight: {
+        defaultThresholdPercent: 95,
+        providerWindowDefaults: { codex: { session: 90 } },
+      },
+    },
+  });
+  await providersDb.updateProviderConnection(connection.id, {
+    quotaWindowThresholds: { session: 10 },
+  });
+  await fetchRecovery(connection.id, payload);
+  assert.deepEqual(
+    (await readConnection(connection.id)).providerSpecificData.codexScopeRateLimitedUntil,
+    { spark: sparkReset }
+  );
+});
+
+test("new preflight persistence cannot reclassify a still authoritative quota reset", async () => {
+  const { connection, payload, oldReset } = await seedRecovery();
+  const { updateCodexScopedQuotaState } =
+    await import("../../src/lib/db/providers/codexAccountState.ts");
+  await updateCodexScopedQuotaState(connection.id, "codex", {
+    rateLimitedUntil: oldReset,
+    rateLimitSource: "quota_reset",
+  });
+  await codexAccount.persistCodexChildCooldown({
+    connectionId: connection.id,
+    model: "gpt-5.6-luna-max",
+    rateLimitedUntil: oldReset,
+    quotaPreflightWindow: { name: "session", windowSeconds: 604800 },
+  });
+  const before = await readConnection(connection.id);
+  assert.deepEqual(
+    (before.providerSpecificData as Record<string, unknown>).codexScopePreflightWindow,
+    {}
+  );
+  await fetchRecovery(connection.id, payload);
+  assert.deepEqual(
+    (await readConnection(connection.id)).providerSpecificData,
+    before.providerSpecificData
+  );
+});


### PR DESCRIPTION
Codex child cooldowns created by quota preflight can outlive the quota window that caused the block. Fresh usage currently updates quota display/cache while the persisted child cooldown continues excluding the account before another preflight can run.

This change records the blocking preflight window and uses strict successful live-usage evidence to reconcile only an obsolete normal-Codex preflight fallback. Recovery requires the same window duration, an advanced reset, adequate headroom across every normal window, and unchanged connection/policy snapshots inside the SQLite transaction. Generic provider refusals, authoritative quota resets, incomplete responses, and other scopes retain their existing protection. Legacy fallback rows without preflight provenance require operator diagnosis.

Late preflight publication also refuses to overwrite active or malformed scoped state inside the transaction, preserving newer provider refusals and newer preflight results. The public-auth race and malformed-state regressions fail before that guard and pass afterward.

Validation against v3.8.50 source (`5458026c216f77a3da68ea49152dc33470cfe2cb`): the public usage and preflight-persistence regressions fail before the change; 88 initial focused checks pass; after the ordering correction, all47 cases in the existing cooldown module pass, including actual public-auth ordering regressions. Core type checking, changed-file ESLint, and documentation checks pass. Independent concurrency review and current-release integration remain pending; this is a draft, not merge-ready. Full suite/build gates have not been run for the current release target.

⚠️ base-red inherited: #12732. The active release target has advanced independently from the tested installed-release anchor; this draft preserves the narrow source change for review without rebasing unrelated changes into the deployment candidate.
