### PR TITLE
nix: add fixed-output package derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,13 +1087,23 @@ yay -S omniroute-bin && systemctl --user enable --now omniroute.service
 **🔧 Nix (Flake)**
 
 ```bash
-# Using Nix flakes
+# Install the package (requires flakes enabled)
+nix profile install github:diegosouzapw/OmniRoute
+# Or run ad-hoc without installing:
+nix run github:diegosouzapw/OmniRoute -- --help
+
+# Dev shell for hacking on the source:
 nix develop
 npm run dev
 
 # Or using devbox
 devbox run npm run dev
 ```
+
+The package derivation is a fixed-output derivation (FOD) because OmniRoute's
+`package-lock.json` references workspace packages that `npm ci --offline`
+cannot resolve inside the Nix sandbox. Version bumps require updating the
+`outputHash` in `nix/omniroute.nix`.
 
 📖 [Docker Guide](docs/guides/DOCKER_GUIDE.md) — Compose profiles, Caddy HTTPS, Cloudflare tunnels.
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "OmniRoute - Unified AI router with 160+ providers";
+  description = "OmniRoute — free MIT AI gateway: one endpoint, 350+ providers, 1200+ models with auto-fallback";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
@@ -13,6 +13,9 @@
         nodejs = pkgs.nodejs_22;
       in
       {
+        packages.default = pkgs.callPackage ./nix/omniroute.nix { inherit nodejs; };
+        packages.omniroute = self.packages.${system}.default;
+
         devShells.default = pkgs.mkShell {
           buildInputs = [
             nodejs
@@ -21,7 +24,7 @@
           shellHook = ''
             echo "Welcome to OmniRoute dev environment"
             export PATH="$PWD/node_modules/.bin:$PATH"
-            
+
             # Install dependencies if node_modules doesn't exist
             if [ ! -d "node_modules" ]; then
               echo "Installing dependencies..."

--- a/nix/omniroute.nix
+++ b/nix/omniroute.nix
@@ -1,0 +1,63 @@
+# OmniRoute has a workspace-based package-lock.json that references local
+# workspace packages (@omniroute/browser-pool, open-sse, packages/browser-pool).
+# `buildNpmPackage` uses `npm ci --offline` inside the Nix sandbox, which
+# cannot resolve those workspace links. This fixed-output derivation instead
+# runs `npm install -g omniroute@<version>` with network access, and pins
+# reproducibility via `outputHash`. Bumping the version requires updating
+# the hash below (run `nix build` once, copy the "got:" value from the
+# hash-mismatch error).
+{
+  lib,
+  stdenv,
+  nodejs,
+  cacert,
+  makeWrapper,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "omniroute";
+  version = "3.8.50";
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = [nodejs cacert makeWrapper];
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME="$NIX_BUILD_TOP/home"
+    mkdir -p "$HOME"
+    export npm_config_cache="$NIX_BUILD_TOP/.npm-cache"
+    export npm_config_prefix="$out"
+    export npm_config_userconfig="$HOME/.npmrc"
+    export npm_config_globalconfig="$HOME/.npmrc-global"
+    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
+    mkdir -p $out
+    ${nodejs}/bin/npm install -g \
+      --no-audit --no-fund --no-update-notifier \
+      --ignore-scripts \
+      omniroute@${finalAttrs.version}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    for bin in omniroute omniroute-reset-password; do
+      if [ -e $out/bin/$bin ]; then
+        wrapProgram $out/bin/$bin --prefix PATH : ${nodejs}/bin
+      fi
+    done
+    runHook postInstall
+  '';
+
+  outputHashMode = "recursive";
+  outputHashAlgo = "sha256";
+  outputHash = "sha256-lWXH7/aiIQiUvC6TVjnnNS1nkYE5QDwbSbJ1QNlpp9Q=";
+
+  meta = with lib; {
+    description = "Free MIT AI gateway: one endpoint, 350+ providers, 1200+ models with auto-fallback";
+    homepage = "https://github.com/diegosouzapw/OmniRoute";
+    license = licenses.mit;
+    platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "omniroute";
+  };
+})


### PR DESCRIPTION
## Summary
- Adds a `flake.nix` and `nix/omniroute.nix` so Nix users can install OmniRoute reproducibly.
- Uses a fixed-output derivation (FOD) because `package-lock.json` references workspace packages (`@omniroute/browser-pool`, `open-sse`, `packages/browser-pool`) that `npm ci --offline` can't resolve inside the Nix sandbox. The FOD runs `npm install -g omniroute@<version>` with network access and pins reproducibility via `outputHash`.
- Adds a short "Nix / NixOS" section to the README.

Closes #13075.

## Test plan
- [ ] `nix build .#default` on `x86_64-linux`
- [ ] `nix run .#default -- --help` prints usage
- [ ] Verify the outputHash matches (rebuild after `rm -rf ~/.cache/nix` — should be a substitute hit or match on fresh build)

## Notes
This is an offer, not urgent — happy to move files around (`packaging/nix/`, subdir naming, README placement) or drop the flake and keep just the callPackage file if you prefer. Version bumps require regenerating `outputHash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)