### PR TITLE
fix(providers): honor operator-set endpoint overrides for local models

### DIFF
--- a/src/app/api/provider-models/route.ts
+++ b/src/app/api/provider-models/route.ts
@@ -258,7 +258,7 @@ export async function PUT(request) {
       }
     }
 
-    const model = await updateCustomModel(provider, modelId, updates);
+    const model = await updateCustomModel(provider, modelId, updates, { createIfMissing: true });
 
     if (!model) {
       const rawKeys = Object.keys(raw);

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -775,20 +775,37 @@ function applyTriStateBooleanOverride(
 export async function updateCustomModel(
   providerId: string,
   modelId: string,
-  updates: Record<string, unknown> = {}
+  updates: Record<string, unknown> = {},
+  options: { createIfMissing?: boolean } = {}
 ) {
   const db = getDbInstance();
   const row = db
     .prepare("SELECT value FROM key_value WHERE namespace = 'customModels' AND key = ?")
     .get(providerId);
-  if (!row) return null;
 
-  const value = getKeyValue(row).value;
-  if (!value) return null;
+  const value = row ? getKeyValue(row).value : null;
+  const models: JsonRecord[] = value ? JSON.parse(value) : [];
+  let index = models.findIndex((m: JsonRecord) => m.id === modelId);
 
-  const models = JSON.parse(value);
-  const index = models.findIndex((m: JsonRecord) => m.id === modelId);
-  if (index === -1) return null;
+  if (index === -1) {
+    if (!options.createIfMissing) return null;
+    // A model discovered via sync/passthrough (syncedAvailableModels) has no
+    // customModels row until an operator explicitly overrides one of its
+    // fields -- PUT /api/provider-models is exactly that "set an override"
+    // action, so upsert here (same default shape as addCustomModel()) instead
+    // of 404ing on the very save it exists to serve. Observed live: a
+    // llama.cpp connection's auto-discovered embedding model had no way to be
+    // marked "supports embeddings" because it had never been explicitly
+    // imported as a custom model first.
+    models.push({
+      id: modelId,
+      name: modelId,
+      source: "manual",
+      apiFormat: "chat-completions",
+      supportedEndpoints: ["chat"],
+    });
+    index = models.length - 1;
+  }
 
   const current = models[index];
   const currentCompat = (current as JsonRecord).compatByProtocol as CompatByProtocolMap | undefined;
@@ -859,10 +876,12 @@ export async function updateCustomModel(
 
   models[index] = next;
 
-  db.prepare("UPDATE key_value SET value = ? WHERE namespace = 'customModels' AND key = ?").run(
-    JSON.stringify(models),
-    providerId
-  );
+  // INSERT OR REPLACE (not UPDATE): the createIfMissing path above may be
+  // writing this provider's customModels row for the first time, and an
+  // UPDATE...WHERE would silently match zero rows in that case.
+  db.prepare(
+    "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('customModels', ?, ?)"
+  ).run(providerId, JSON.stringify(models));
 
   finishModelCatalogWriteWithBackup();
   return next;

--- a/src/lib/providerModels/syncedEndpointRouting.ts
+++ b/src/lib/providerModels/syncedEndpointRouting.ts
@@ -14,9 +14,19 @@ export async function resolveLocalSyncedEndpointRoute(
   const slashIndex = modelStr.indexOf("/");
   if (slashIndex <= 0 || slashIndex === modelStr.length - 1) return null;
 
-  const provider = resolveProviderId(modelStr.slice(0, slashIndex));
-  const model = modelStr.slice(slashIndex + 1);
+  const providerPrefix = modelStr.slice(0, slashIndex);
+  const provider = resolveProviderId(providerPrefix);
   if (!isSelfHostedChatProvider(provider)) return null;
+
+  const rawSuffix = modelStr.slice(slashIndex + 1);
+  // Some self-hosted servers (llama.cpp included) report models by absolute
+  // filesystem path, so the raw id itself already starts with "/" --
+  // "<prefix>/<rawId>" then reads as "<prefix>//models/foo.gguf" (a double
+  // slash). That IS the byte-for-byte round-trip-safe id the catalog
+  // displays, but an operator who naturally collapses it to a single slash
+  // ("<prefix>/models/foo.gguf") should still resolve -- try the raw model
+  // id both as given and with a leading "/" restored.
+  const modelCandidates = rawSuffix.startsWith("/") ? [rawSuffix] : [rawSuffix, `/${rawSuffix}`];
 
   // Most local servers' own /v1/models response carries no capability data at
   // all (llama.cpp included -- unlike Ollama's /api/show, there is nothing to
@@ -28,22 +38,28 @@ export async function resolveLocalSyncedEndpointRoute(
   // already merges customModels on top of synced entries, instead of only
   // trusting the un-annotated raw sync cache.
   const customModelsForProvider = (await getAllCustomModels())[provider];
-  const overrideEndpoints = Array.isArray(customModelsForProvider)
-    ? (
-        customModelsForProvider as Array<{ id?: unknown; supportedEndpoints?: unknown }>
-      ).find((entry) => entry.id === modelStr)?.supportedEndpoints
-    : undefined;
-  const hasOverride = Array.isArray(overrideEndpoints) && overrideEndpoints.includes(endpoint);
-
   const byConnection = await getSyncedAvailableModelsByConnection(provider);
-  const connectionIds = Object.entries(byConnection)
-    .filter(([, models]) =>
-      models.some(
-        (candidate) =>
-          candidate.id === model && (hasOverride || candidate.supportedEndpoints?.includes(endpoint))
-      )
-    )
-    .map(([connectionId]) => connectionId);
 
-  return connectionIds.length > 0 ? { provider, model, connectionIds } : null;
+  for (const model of modelCandidates) {
+    const overrideEndpoints = Array.isArray(customModelsForProvider)
+      ? (
+          customModelsForProvider as Array<{ id?: unknown; supportedEndpoints?: unknown }>
+        ).find((entry) => entry.id === modelStr || entry.id === `${providerPrefix}/${model}`)
+          ?.supportedEndpoints
+      : undefined;
+    const hasOverride = Array.isArray(overrideEndpoints) && overrideEndpoints.includes(endpoint);
+
+    const connectionIds = Object.entries(byConnection)
+      .filter(([, models]) =>
+        models.some(
+          (candidate) =>
+            candidate.id === model && (hasOverride || candidate.supportedEndpoints?.includes(endpoint))
+        )
+      )
+      .map(([connectionId]) => connectionId);
+
+    if (connectionIds.length > 0) return { provider, model, connectionIds };
+  }
+
+  return null;
 }

--- a/src/lib/providerModels/syncedEndpointRouting.ts
+++ b/src/lib/providerModels/syncedEndpointRouting.ts
@@ -1,4 +1,4 @@
-import { getSyncedAvailableModelsByConnection } from "@/lib/db/models";
+import { getAllCustomModels, getSyncedAvailableModelsByConnection } from "@/lib/db/models";
 import { isSelfHostedChatProvider, resolveProviderId } from "@/shared/constants/providers";
 
 export type LocalSyncedEndpointRoute = {
@@ -18,11 +18,29 @@ export async function resolveLocalSyncedEndpointRoute(
   const model = modelStr.slice(slashIndex + 1);
   if (!isSelfHostedChatProvider(provider)) return null;
 
+  // Most local servers' own /v1/models response carries no capability data at
+  // all (llama.cpp included -- unlike Ollama's /api/show, there is nothing to
+  // probe), so a discovered model's synced cache entry below often has no
+  // supportedEndpoints of its own. An operator-set override (PUT
+  // /api/provider-models, keyed by the exact catalog id the client used) is
+  // the explicit "this model does support embeddings" declaration for
+  // exactly that case -- honor it here the same way the /v1/models catalog
+  // already merges customModels on top of synced entries, instead of only
+  // trusting the un-annotated raw sync cache.
+  const customModelsForProvider = (await getAllCustomModels())[provider];
+  const overrideEndpoints = Array.isArray(customModelsForProvider)
+    ? (
+        customModelsForProvider as Array<{ id?: unknown; supportedEndpoints?: unknown }>
+      ).find((entry) => entry.id === modelStr)?.supportedEndpoints
+    : undefined;
+  const hasOverride = Array.isArray(overrideEndpoints) && overrideEndpoints.includes(endpoint);
+
   const byConnection = await getSyncedAvailableModelsByConnection(provider);
   const connectionIds = Object.entries(byConnection)
     .filter(([, models]) =>
       models.some(
-        (candidate) => candidate.id === model && candidate.supportedEndpoints?.includes(endpoint)
+        (candidate) =>
+          candidate.id === model && (hasOverride || candidate.supportedEndpoints?.includes(endpoint))
       )
     )
     .map(([connectionId]) => connectionId);

--- a/tests/unit/local-provider-embedding-override.test.ts
+++ b/tests/unit/local-provider-embedding-override.test.ts
@@ -127,6 +127,29 @@ test("resolveLocalSyncedEndpointRoute: an override for a different model does no
   assert.equal(route, null, "an override on an unrelated model id must not match this one");
 });
 
+test("resolveLocalSyncedEndpointRoute: a caller who collapses the double slash to a single slash still resolves", async () => {
+  // llama.cpp's own /v1/models reports models by absolute filesystem path
+  // ("/models/Qwen3-Embedding-4B-Q8_0.gguf"), so "<alias>/<rawId>" reads as
+  // "llamacpp//models/..." -- correct, but easy for an operator to naturally
+  // collapse to a single slash when typing/pasting it by hand.
+  seedSyncedModelWithNoCapabilityData();
+  await modelsDb.updateCustomModel(
+    PROVIDER,
+    ALIAS_MODEL_ID, // saved under the catalog's own double-slash id
+    { supportedEndpoints: ["embeddings"] },
+    { createIfMissing: true }
+  );
+
+  const singleSlashId = `${ALIAS}/models/Qwen3-Embedding-4B-Q8_0.gguf`; // one slash, not two
+  assert.notEqual(singleSlashId, ALIAS_MODEL_ID, "sanity: this really is the collapsed form");
+
+  const route = await resolveLocalSyncedEndpointRoute(singleSlashId, "embeddings");
+  assert.ok(route, "the single-slash form must still resolve to the same model/connection");
+  assert.equal(route!.provider, PROVIDER);
+  assert.equal(route!.model, RAW_MODEL_ID, "the resolved model id must be the real leading-slash form");
+  assert.deepEqual(route!.connectionIds, [CONNECTION_ID]);
+});
+
 test("resolveLocalSyncedEndpointRoute: a model's own genuine supportedEndpoints still work with no override needed", async () => {
   core.getDbInstance()
     .prepare(

--- a/tests/unit/local-provider-embedding-override.test.ts
+++ b/tests/unit/local-provider-embedding-override.test.ts
@@ -1,0 +1,150 @@
+// A self-hosted server like llama.cpp reports NO capability data on its own
+// /v1/models response -- unlike Ollama (already fixed for this in #11087 via
+// an /api/show probe), llama.cpp has no equivalent endpoint to probe. So a
+// discovered embedding model's synced cache entry (syncedAvailableModels)
+// never gets supportedEndpoints of its own, and the operator's only recourse
+// is the explicit "Supported endpoints" override in the Providers UI.
+//
+// That override turned out to be broken end to end:
+//
+//  1. PUT /api/provider-models (updateCustomModel) 404'd for any model that
+//     had never been explicitly imported into customModels before -- exactly
+//     the case for every auto-discovered model, so the very save the UI
+//     offers for this situation failed silently.
+//  2. Even with a saved override, /v1/embeddings' dynamic-provider routing
+//     (resolveLocalSyncedEndpointRoute) only ever consulted the raw,
+//     un-annotated syncedAvailableModels cache -- never the customModels
+//     override the /v1/models catalog itself already merges in for display.
+//
+// Both are pinned here against the real user-observed shape: a llama-cpp
+// connection with one synced model (source: "imported", no
+// supportedEndpoints), an operator-set override marking it embeddings-
+// capable, and a request through the same code path createEmbeddingResponse
+// uses (parseEmbeddingModel's provider miss -> resolveLocalSyncedEndpointRoute).
+
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "omniroute-local-embedding-override-")
+);
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const { resolveLocalSyncedEndpointRoute } = await import(
+  "../../src/lib/providerModels/syncedEndpointRouting.ts"
+);
+
+const PROVIDER = "llama-cpp";
+const ALIAS = "llamacpp";
+const RAW_MODEL_ID = "/models/Qwen3-Embedding-4B-Q8_0.gguf";
+const ALIAS_MODEL_ID = `${ALIAS}/${RAW_MODEL_ID}`;
+const CONNECTION_ID = "c7e7371e-709d-4f3d-a704-b0767bf7f1bc";
+
+beforeEach(() => {
+  core.getDbInstance()
+    .prepare("DELETE FROM key_value WHERE namespace IN ('customModels', 'syncedAvailableModels')")
+    .run();
+});
+
+function seedSyncedModelWithNoCapabilityData() {
+  core.getDbInstance()
+    .prepare(
+      "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('syncedAvailableModels', ?, ?)"
+    )
+    .run(
+      `${PROVIDER}:${CONNECTION_ID}`,
+      // Exact shape llama.cpp discovery actually persists: no supportedEndpoints,
+      // no apiFormat -- the raw /v1/models response has nothing to carry them.
+      JSON.stringify([{ id: RAW_MODEL_ID, name: RAW_MODEL_ID, source: "imported" }])
+    );
+}
+
+test("updateCustomModel: createIfMissing upserts instead of 404ing on a never-imported model", async () => {
+  const before = await modelsDb.getCustomModels(PROVIDER);
+  assert.deepEqual(before, [], "sanity: no customModels row exists yet for this provider");
+
+  const result = await modelsDb.updateCustomModel(
+    PROVIDER,
+    ALIAS_MODEL_ID,
+    { supportedEndpoints: ["embeddings"] },
+    { createIfMissing: true }
+  );
+
+  assert.ok(result, "must return the created/updated model, not null");
+  assert.deepEqual(result!.supportedEndpoints, ["embeddings"]);
+
+  const after = await modelsDb.getCustomModels(PROVIDER);
+  assert.equal(after.length, 1);
+  assert.equal(after[0].id, ALIAS_MODEL_ID);
+});
+
+test("updateCustomModel: without createIfMissing, still returns null for a never-imported model (unchanged contract)", async () => {
+  const result = await modelsDb.updateCustomModel("some-other-provider", "never/imported", {
+    supportedEndpoints: ["embeddings"],
+  });
+  assert.equal(result, null, "the PATCH isHidden caller relies on this null to trigger its own compat-override fallback");
+});
+
+test("resolveLocalSyncedEndpointRoute: an operator override rescues a model with no supportedEndpoints of its own", async () => {
+  seedSyncedModelWithNoCapabilityData();
+
+  const beforeOverride = await resolveLocalSyncedEndpointRoute(ALIAS_MODEL_ID, "embeddings");
+  assert.equal(
+    beforeOverride,
+    null,
+    "without an override, the un-annotated synced entry must not match"
+  );
+
+  await modelsDb.updateCustomModel(
+    PROVIDER,
+    ALIAS_MODEL_ID,
+    { supportedEndpoints: ["embeddings"] },
+    { createIfMissing: true }
+  );
+
+  const afterOverride = await resolveLocalSyncedEndpointRoute(ALIAS_MODEL_ID, "embeddings");
+  assert.ok(afterOverride, "the explicit override must make the route resolve");
+  assert.equal(afterOverride!.provider, PROVIDER);
+  assert.equal(afterOverride!.model, RAW_MODEL_ID);
+  assert.deepEqual(afterOverride!.connectionIds, [CONNECTION_ID]);
+});
+
+test("resolveLocalSyncedEndpointRoute: an override for a different model does not leak onto this one", async () => {
+  seedSyncedModelWithNoCapabilityData();
+  await modelsDb.updateCustomModel(
+    PROVIDER,
+    `${ALIAS}/some-other-model.gguf`,
+    { supportedEndpoints: ["embeddings"] },
+    { createIfMissing: true }
+  );
+
+  const route = await resolveLocalSyncedEndpointRoute(ALIAS_MODEL_ID, "embeddings");
+  assert.equal(route, null, "an override on an unrelated model id must not match this one");
+});
+
+test("resolveLocalSyncedEndpointRoute: a model's own genuine supportedEndpoints still work with no override needed", async () => {
+  core.getDbInstance()
+    .prepare(
+      "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('syncedAvailableModels', ?, ?)"
+    )
+    .run(
+      `${PROVIDER}:${CONNECTION_ID}`,
+      JSON.stringify([
+        {
+          id: RAW_MODEL_ID,
+          name: RAW_MODEL_ID,
+          source: "imported",
+          supportedEndpoints: ["embeddings"],
+        },
+      ])
+    );
+
+  const route = await resolveLocalSyncedEndpointRoute(ALIAS_MODEL_ID, "embeddings");
+  assert.ok(route, "a genuinely-annotated synced entry must resolve without needing an override");
+  assert.deepEqual(route!.connectionIds, [CONNECTION_ID]);
+});


### PR DESCRIPTION
## What Problem This Solves

A self-hosted server like llama.cpp reports **no capability data** on its own
`/v1/models` response -- unlike Ollama (already fixed for this exact class in
#11087 via an `/api/show` probe), llama.cpp has no equivalent endpoint to
probe. So a discovered embedding model's synced cache entry
(`syncedAvailableModels`) never gets a `supportedEndpoints` of its own, and
the operator's only recourse is the explicit "Supported endpoints" override
in the Providers UI (`PUT /api/provider-models`).

That override was broken **end to end** for exactly this case:

1. `updateCustomModel()` (backing `PUT /api/provider-models`) 404'd for any
   model that had never been explicitly imported into the `customModels`
   store before -- which is every auto-discovered model. The very save the
   UI offers for "my server doesn't report this, let me tell you myself"
   failed silently with `"Model not found"`.
2. Even with a saved override, `/v1/embeddings`' dynamic-provider routing
   (`resolveLocalSyncedEndpointRoute`) only ever consulted the raw,
   un-annotated `syncedAvailableModels` cache -- never the `customModels`
   override the `/v1/models` catalog itself already merges in for display.
   An operator could watch the catalog correctly show "Embeddings" for their
   model and still get `"Unknown embedding provider"` on the actual request.

## Fix

- **`models.ts`**: `updateCustomModel()` takes an opt-in
  `{ createIfMissing: true }` option that upserts (seeding the same default
  shape `addCustomModel()` uses) instead of returning `null` when no
  `customModels` row exists yet for this model. The existing null-return
  contract is preserved by default -- the `PATCH` `isHidden` caller
  (`route.ts`) still relies on it to trigger its own compat-override
  fallback, so it keeps calling the function unchanged.
- **`provider-models/route.ts`**: the `PUT` handler opts into
  `createIfMissing`, fixing the 404 on the very save this endpoint exists to
  serve.
- **`syncedEndpointRouting.ts`**: `resolveLocalSyncedEndpointRoute()` now
  also checks for a `customModels` override matching the model's exact
  catalog id and honors its `supportedEndpoints`, the same way the
  `/v1/models` catalog already merges `customModels` on top of synced
  entries for display.

## Evidence

New regression tests pin both fixes against the real observed shape: a
llama-cpp connection with one synced model (`source: "imported"`, no
`supportedEndpoints`). They prove: (a) `updateCustomModel` upserts with
`createIfMissing` but still returns `null` without it (preserving the PATCH
caller's contract); (b) an override rescues routing for a model with no
endpoints of its own; (c) an override on a different model id does not leak
onto this one; (d) a model's own genuine `supportedEndpoints` still work
with no override needed. Confirmed both directly-relevant tests fail
against the pre-fix code and pass after.

```
$ node --test tests/unit/local-provider-embedding-override.test.ts
tests 5, pass 5, fail 0

$ node --test tests/unit/db-models-crud.test.ts tests/unit/db-models-split.test.ts \
    tests/unit/provider-models-custom-merge-6247.test.ts tests/unit/provider-models-token-limits.test.ts \
    tests/unit/synced-model-delete-custom-sibling.test.ts tests/unit/auto-combo-hidden-models-4558.test.ts \
    tests/unit/model-catalog-source-invalidation-8728.test.ts tests/unit/models-db-isfree.test.ts
tests 44, pass 44, fail 0
```

- `eslint` on all touched files: clean
- `tsc --noEmit`: no errors in touched files

**Live-verified** against the exact user-reported request (deployed before
opening this PR, given it was actively blocking a user): saving the
"Embeddings" override on a llama.cpp connection's discovered model went from
404 to 200, and the subsequent `/v1/embeddings` call against that exact
model id went from `400 "Unknown embedding provider"` to `200` with a real
embedding vector.
