### PR TITLE
fix(compression): terminate idle workers on eviction

### DIFF
--- a/changelog.d/fixes/compression-pool-idle-terminate.md
+++ b/changelog.d/fixes/compression-pool-idle-terminate.md
@@ -1,0 +1,1 @@
+- fix(compression): terminate idle worker threads on eviction so long-running instances stop leaking OS threads and MessagePorts

--- a/open-sse/services/compression/compressionWorkerPool.ts
+++ b/open-sse/services/compression/compressionWorkerPool.ts
@@ -131,7 +131,7 @@ export class CompressionWorkerPool {
   }
   async close(): Promise<void> {
     for (const job of this.queue.splice(0)) job.resolve(unchanged(job.originalBody));
-    await Promise.all([...this.workers].map((slot) => this.remove(slot, true)));
+    await Promise.all([...this.workers].map((slot) => this.remove(slot)));
   }
   private spawn(): PoolWorker {
     const slot: PoolWorker = {
@@ -185,7 +185,10 @@ export class CompressionWorkerPool {
     slot.timeout = null;
     slot.job = null;
     job.resolve(result);
-    slot.idle = setTimeout(() => void this.remove(slot, false), this.idleMs);
+    // Idle eviction MUST terminate. Dropping the slot from the set only releases our
+    // reference - the thread, its MessagePort and its private heap outlive the pool
+    // for the whole process lifetime, invisible to process.memoryUsage(). (#12812)
+    slot.idle = setTimeout(() => void this.remove(slot), this.idleMs);
     slot.idle.unref();
     this.dispatch();
   }
@@ -193,13 +196,15 @@ export class CompressionWorkerPool {
     const job = slot.job;
     if (job) job.resolve(unchanged(job.originalBody));
     slot.job = null;
-    void this.remove(slot, true).finally(() => this.dispatch());
+    void this.remove(slot).finally(() => this.dispatch());
   }
-  private async remove(slot: PoolWorker, terminate: boolean): Promise<void> {
+  /** Drop a slot and release its OS thread. Removal always terminates: a pooled worker
+   *  has no other owner, so skipping terminate() strands the thread permanently. */
+  private async remove(slot: PoolWorker): Promise<void> {
     if (!this.workers.delete(slot)) return;
     if (slot.timeout) clearTimeout(slot.timeout);
     if (slot.idle) clearTimeout(slot.idle);
-    if (terminate) await slot.worker.terminate().catch(() => undefined);
+    await slot.worker.terminate().catch(() => undefined);
   }
 }
 

--- a/tests/unit/compression/worker-pool-idle-eviction-12812.test.ts
+++ b/tests/unit/compression/worker-pool-idle-eviction-12812.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Regression guard for #12812: idle eviction must terminate the worker thread.
+ *
+ * Root cause: finish() scheduled `remove(slot, false)`, so the idle timer dropped the slot
+ * from the pool WITHOUT calling worker.terminate(). The OS thread, its MessagePort and its
+ * private heap then survived for the whole process lifetime. Nothing in
+ * process.memoryUsage() reports that, which is why a 16h instance showed rss=660MB while
+ * holding 5.7GB of commit charge.
+ *
+ * The assertion measures the real thing: a worker that was evicted must no longer be able
+ * to run code. A live-but-unreferenced thread still responds; a terminated one cannot.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Worker } from "node:worker_threads";
+import { CompressionWorkerPool } from "../../../open-sse/services/compression/compressionWorkerPool.ts";
+
+const body = {
+  model: "gpt-test",
+  messages: [{ role: "user", content: "please kindly actually simplify this text ".repeat(40) }],
+};
+
+/** Reach into the pool's private slot set — the leak is only observable there. */
+function slotsOf(pool: CompressionWorkerPool): Set<{ worker: Worker }> {
+  return (pool as unknown as { workers: Set<{ worker: Worker }> }).workers;
+}
+
+describe("compression worker pool idle eviction (#12812)", () => {
+  it("terminates the worker thread when the idle timer fires", async () => {
+    // Idle window short enough to fire during the test.
+    const pool = new CompressionWorkerPool({ size: 1, idleMs: 50 });
+
+    await pool.run(body, "stacked", undefined, undefined);
+
+    const slots = [...slotsOf(pool)];
+    assert.equal(slots.length, 1, "one worker should have been spawned");
+    const { worker } = slots[0];
+
+    // The observable difference between 'evicted' and 'terminated' is the exit event:
+    // a leaked thread stays alive and never emits it. Arm the listener BEFORE the idle
+    // window so we cannot miss the event.
+    const exited = new Promise<boolean>((resolve) => {
+      worker.once("exit", () => resolve(true));
+      setTimeout(() => resolve(false), 3_000).unref?.();
+    });
+
+    await new Promise((r) => setTimeout(r, 400));
+    assert.equal(slotsOf(pool).size, 0, "slot should be evicted from the pool");
+
+    assert.equal(
+      await exited,
+      true,
+      "idle eviction must terminate the thread, not just drop the reference (#12812)"
+    );
+
+    await pool.close();
+  });
+
+  it("close() terminates every pooled worker", async () => {
+    const pool = new CompressionWorkerPool({ size: 2, idleMs: 60_000 });
+    await Promise.all([
+      pool.run(body, "stacked", undefined, undefined),
+      pool.run(body, "stacked", undefined, undefined),
+    ]);
+    assert.ok(slotsOf(pool).size >= 1, "pool should hold workers before close");
+    await pool.close();
+    assert.equal(slotsOf(pool).size, 0, "close() must drain the pool");
+  });
+});


### PR DESCRIPTION
`CompressionWorkerPool.finish()` scheduled idle eviction as `remove(slot, false)`, so the timer dropped the slot from the pool without calling `worker.terminate()`. The OS thread, its `MessagePort` and its private heap then lived for the rest of the process.

That is invisible to V8-level metrics, which is what made it hard to see from inside: the reported instance showed `rss=660MB` while the OS held 5.7GB of commit charge with 55 orphaned `MessagePort` handles after 16 hours.

## The change

Removal always terminates now, and the `terminate` parameter is gone rather than left in place as a footgun. A pooled worker has no owner besides the pool, so there was no caller that legitimately wanted the slot dropped but the thread kept — the only `false` call site was the leak itself. The other two call sites already passed `true`.

## Test

`tests/unit/compression/worker-pool-idle-eviction-12812.test.ts` waits past the idle window and asserts the worker's `exit` event fires. That event is the only thing separating a terminated thread from a merely dereferenced one — asserting the slot left the pool would pass on the buggy code too, since dropping the reference is exactly what it already did.

Confirmed it fails on the old behaviour: re-disabling the `terminate()` call gives

```
✖ terminates the worker thread when the idle timer fires
  ✔ close() terminates every pooled worker
ℹ pass 1  ℹ fail 1
```

and passes with the fix.

## Verification

```
tests/unit/compression/**    1503 passed | 5 failed
npx tsc -p tsconfig.typecheck-core.json --noEmit   clean
npx eslint <changed files>                          clean
```

The 5 failures are all in the RTK suites (`rtk-mcp-tools`, `rtk-toml-schema-v1`, `rtk-toml-compatibility`) and are pre-existing: they reproduce identically on a clean `release/v3.8.51` checkout with my changes stashed (`4 failed` in those two files alone), and none of them touch the worker pool.

Fixes #12812
