### PR TITLE
fix(compression): pass a URL object when spawning the LLMLingua worker

### DIFF
--- a/changelog.d/fixes/llmlingua-worker-spawn.md
+++ b/changelog.d/fixes/llmlingua-worker-spawn.md
@@ -1,0 +1,1 @@
+- fix(compression): spawn the LLMLingua worker with a file URL object so compression actually runs instead of silently failing open on Node

--- a/open-sse/services/compression/engines/llmlingua/worker.ts
+++ b/open-sse/services/compression/engines/llmlingua/worker.ts
@@ -234,7 +234,12 @@ function ensureWorker(): Worker {
 
   const { workerFile, execArgv } = resolveWorkerFile();
   const absoluteWorkerFile = path.resolve(workerFile);
-  const w = new Worker(pathToFileURL(absoluteWorkerFile).href, { execArgv });
+  // Pass the URL OBJECT, not `.href`. `new Worker()` treats a plain string as a
+  // filesystem path, so a "file://..." string is looked up literally and throws
+  // ERR_WORKER_PATH (a string arg must start with ./ or ../). Only a URL instance
+  // is interpreted as a file: URL. Spawn failures are swallowed by pump()'s catch,
+  // so getting this wrong silently disables compression instead of erroring.
+  const w = new Worker(pathToFileURL(absoluteWorkerFile), { execArgv });
 
   w.on("message", (reply: WorkerReply) => {
     const entry = pending.get(reply.id);

--- a/tests/unit/compression/llmlingua-worker-spawn-12822.test.ts
+++ b/tests/unit/compression/llmlingua-worker-spawn-12822.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression guard for #12822: the LLMLingua worker must actually spawn on Node.
+ *
+ * Root cause: `new Worker(pathToFileURL(file).href, ...)` passes a STRING. Node treats a
+ * string argument as a filesystem path (it must start with ./ or ../), so a "file://..."
+ * string is looked up literally and throws ERR_WORKER_PATH. Only a URL INSTANCE is
+ * interpreted as a file: URL.
+ *
+ * Why it was invisible: pump() wraps ensureWorker() in `catch {}` and fails open, so the
+ * spawn crash silently degraded every compression call to a passthrough instead of erroring.
+ *
+ * This test asserts the Node contract directly against a real Worker, so it fails on the
+ * old `.href` spelling and passes on the URL object.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Worker } from "node:worker_threads";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const WORKER_SRC = path.resolve(
+  here,
+  "../../../open-sse/services/compression/engines/llmlingua/worker.ts"
+);
+
+function spawnWith(arg: string | URL): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let w: Worker;
+    try {
+      w = new Worker(arg, {});
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    w.on("error", reject);
+    w.on("exit", () => resolve());
+  });
+}
+
+test("a file: URL STRING is rejected by node:worker_threads (the #12822 crash)", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-worker-"));
+  const child = path.join(dir, "child.mjs");
+  fs.writeFileSync(child, "process.exit(0);\n");
+
+  await assert.rejects(
+    () => spawnWith(pathToFileURL(child).href),
+    (err: NodeJS.ErrnoException) => err.code === "ERR_WORKER_PATH",
+    "passing .href must fail — this is exactly what shipped and was swallowed by the fail-open catch"
+  );
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("a file: URL OBJECT spawns cleanly", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-worker-"));
+  const child = path.join(dir, "child.mjs");
+  fs.writeFileSync(child, "process.exit(0);\n");
+
+  await spawnWith(pathToFileURL(child));
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("worker.ts passes the URL object, not .href", () => {
+  const code = fs.readFileSync(WORKER_SRC, "utf8");
+  assert.ok(
+    /new Worker\(\s*pathToFileURL\([A-Za-z0-9_]+\)\s*,/.test(code),
+    "ensureWorker must pass the URL instance to new Worker()"
+  );
+  assert.ok(
+    !/new Worker\(\s*pathToFileURL\([A-Za-z0-9_]+\)\.href/.test(code),
+    "ensureWorker must not pass pathToFileURL(...).href — that throws ERR_WORKER_PATH"
+  );
+});


### PR DESCRIPTION
`ensureWorker()` called `new Worker(pathToFileURL(absoluteWorkerFile).href, { execArgv })`, which passes a **string**. `node:worker_threads` treats a string argument as a filesystem path and requires it to start with `./` or `../`; only a `URL` **instance** is interpreted as a `file:` URL. So the `"file://..."` text was looked up literally as a relative path and the spawn threw `ERR_WORKER_PATH`.

The failure was silent. `pump()` wraps `ensureWorker()` in a bare `catch {}` and fails open, so every compression call quietly degraded to a passthrough while still reporting success — the worst shape for this bug, since nothing in the logs or the response says compression did not happen.

Confirmed against a real `Worker` on Node 24, isolated from this codebase:

```
href string -> ERR_WORKER_PATH
URL object  -> OK
```

## The change

One argument: drop `.href` and pass the `URL` object.

`pathToFileURL` stays — the sibling test `llmlingua-worker-resolution.test.ts` asserts this file never touches `import.meta.url` or `createRequire` (both die in the standalone webpack bundle), and `pathToFileURL` is a pure path→URL converter with neither dependency. Passing the raw path instead would also work on Node, but the URL form is what keeps spaces and non-ASCII in the install path unambiguous.

## Test

`tests/unit/compression/llmlingua-worker-spawn-12822.test.ts` asserts the source does not spawn with `.href`, and separately proves the runtime contract by spawning both spellings against a real worker file — so it stays honest if the call is ever reshaped rather than just matching text.

## Verification

```
llmlingua-worker-spawn-12822 + llmlingua-worker-resolution + llmlingua-failopen   21 passed
npx tsc -p tsconfig.typecheck-core.json --noEmit    clean
npx eslint <changed files>                           clean
```

Fixes #12822
