### PR TITLE
fix(media): parallel combo fan-out and cross-process log id collisions

### DIFF
--- a/open-sse/services/imageCombo.ts
+++ b/open-sse/services/imageCombo.ts
@@ -39,8 +39,8 @@ type ImageGenerationResult =
  *
  * 1. Resolve combo targets via resolveComboTargets.
  * 2. Filter to images-capable targets (those with an entry in the image registry).
- * 3. Iterate targets in priority order; for each target, resolve credentials and
- *    call handleImageGeneration. Return the first success or the last failure.
+ * 3. Run all images-capable targets concurrently (optional injected generator
+ *    for tests); first healthy success wins, terminal errors surface last.
  * 4. Attach combo name, selected target, and fallback count to response headers.
  */
 export async function executeImageCombo(
@@ -51,7 +51,8 @@ export async function executeImageCombo(
     policy: { apiKeyInfo?: { id?: string; name?: string } | null };
   },
   startTime: number,
-  log: typeof logger
+  log: typeof logger,
+  options?: { generateImage?: typeof handleImageGeneration }
 ): Promise<Response> {
   // 1. Resolve combo targets
   const combo = await getComboByName(comboName);
@@ -80,80 +81,123 @@ export async function executeImageCombo(
     );
   }
 
-  // 3. Iterate targets in priority order (first healthy target wins)
+  // 3. Run every images-capable target concurrently; first healthy success wins.
+  //
+  //    Sequential priority execution means a slow first target (an AI Horde
+  //    queue that can never fit the request budget, a provider that only
+  //    fails after its full timeout) blocks every sibling behind it, so a
+  //    starved-but-first provider turns a perfectly healthy combo into a
+  //    long failure. Fanning out removes that serialization: whoever answers
+  //    first wins, and a target that would have taken the full budget to fail
+  //    no longer pre-empts a sibling that could have succeeded in seconds.
+  //
+  //    We deliberately race the first success against "all settled" instead of
+  //    await-ing every target: once a success lands, the response returns
+  //    immediately while any still-running siblings unwind on their own (each
+  //    target self-bounds via its own timeout/abort). Promises that reject are
+  //    caught below, so a late sibling failure cannot become an unhandled
+  //    rejection after the caller already got a 200.
   let lastError: { status: number; error: string } | null = null;
+  let terminalError: { status: number; error: string } | null = null;
   let successResult: { data: unknown; provider: string; model: string } | null = null;
   let fallbackCount = 0;
   let selectedProvider = "";
   let selectedModel = "";
 
-  for (const target of imageTargets) {
-    const { provider: targetProvider, model: targetModel } = parseImageModel(target.modelStr);
-    if (!targetProvider) {
-      lastError = { status: 400, error: `Invalid image model: ${target.modelStr}` };
-      fallbackCount += 1;
-      continue;
-    }
+  type ImageComboTarget = (typeof imageTargets)[number];
 
-    // Resolve provider credentials
-    let credentials = null;
+  let resolveFirstSuccess: (() => void) | null = null;
+  const firstSuccess = new Promise<void>((resolve) => {
+    resolveFirstSuccess = resolve;
+  });
+
+  const runTarget = async (target: ImageComboTarget): Promise<void> => {
     try {
-      credentials = await getProviderCredentialsWithQuotaPreflight(targetProvider);
-    } catch {
-      // DB unavailable — skip this target
-      lastError = { status: 502, error: `Failed to resolve credentials for ${targetProvider}` };
+      const { provider: targetProvider, model: targetModel } = parseImageModel(target.modelStr);
+      if (!targetProvider) {
+        lastError = { status: 400, error: `Invalid image model: ${target.modelStr}` };
+        fallbackCount += 1;
+        return;
+      }
+
+      // Resolve provider credentials
+      let credentials = null;
+      try {
+        credentials = await getProviderCredentialsWithQuotaPreflight(targetProvider);
+      } catch {
+        // DB unavailable — skip this target
+        lastError = { status: 502, error: `Failed to resolve credentials for ${targetProvider}` };
+        fallbackCount += 1;
+        return;
+      }
+
+      if (!credentials) {
+        lastError = { status: 400, error: `No credentials for image provider: ${targetProvider}` };
+        fallbackCount += 1;
+        return;
+      }
+
+      if (isAllRateLimitedCredentials(credentials)) {
+        lastError = {
+          status: 429,
+          error: `[${targetProvider}] All accounts rate limited`,
+        };
+        fallbackCount += 1;
+        return;
+      }
+
+      // Execute image generation for this target
+      const result = (await (options?.generateImage ?? handleImageGeneration)({
+        body: { ...body, model: target.modelStr },
+        credentials,
+        log,
+        signal: auth.request?.signal || null,
+      })) as ImageGenerationResult;
+
+      if (result.success) {
+        if (!successResult) {
+          await clearRecoveredProviderState(credentials);
+          selectedProvider = targetProvider;
+          selectedModel = target.modelStr;
+          successResult = {
+            data: result.data,
+            provider: targetProvider,
+            model: target.modelStr,
+          };
+          // Ring the bell — the caller may stop waiting on this result.
+          resolveFirstSuccess?.();
+        }
+        return;
+      }
+
+      // Classify the failure
+      const status = result.status || 500;
+      const error = typeof result.error === "string" ? result.error : "Image generation failed";
+      const failure = { status, error: `[${targetProvider}] ${error}` };
+      lastError = failure;
+
+      // Terminal failures (400 bad model, 403 banned, 401 missing key) are the
+      // most actionable signal when every target fails — keep one aside so it
+      // can surface instead of a generic 5xx/429.
+      if (status === 400 || status === 403 || status === 401) {
+        if (!terminalError) terminalError = failure;
+      }
       fallbackCount += 1;
-      continue;
-    }
-
-    if (!credentials) {
-      lastError = { status: 400, error: `No credentials for image provider: ${targetProvider}` };
+    } catch (err) {
+      // A late sibling may fail after the caller already got a 200 — record
+      // it so it can still surface if nothing else succeeds, and never leak
+      // the rejection after an early return.
+      const message =
+        err instanceof Error ? err.message : typeof err === "string" ? err : "Image generation failed";
+      if (!lastError) lastError = { status: 502, error: `[image combo] ${message}` };
       fallbackCount += 1;
-      continue;
     }
+  };
 
-    if (isAllRateLimitedCredentials(credentials)) {
-      lastError = {
-        status: 429,
-        error: `[${targetProvider}] All accounts rate limited`,
-      };
-      fallbackCount += 1;
-      continue;
-    }
-
-    // Execute image generation for this target
-    const result = (await handleImageGeneration({
-      body: { ...body, model: target.modelStr },
-      credentials,
-      log,
-      signal: auth.request?.signal || null,
-    })) as ImageGenerationResult;
-
-    if (result.success) {
-      await clearRecoveredProviderState(credentials);
-      selectedProvider = targetProvider;
-      selectedModel = target.modelStr;
-      successResult = {
-        data: result.data,
-        provider: targetProvider,
-        model: target.modelStr,
-      };
-      break;
-    }
-
-    // Classify the failure
-    const status = result.status || 500;
-    const error = typeof result.error === "string" ? result.error : "Image generation failed";
-
-    // Terminal failures (400 bad model, 403 banned, etc.) — stop iterating
-    // Non-terminal failures (429, 5xx) — try next target
-    if (status === 400 || status === 403 || status === 401) {
-      return errorResponse(status, `[${targetProvider}] ${error}`);
-    }
-
-    lastError = { status, error: `[${targetProvider}] ${error}` };
-    fallbackCount += 1;
-  }
+  const tasks = imageTargets.map((target) => runTarget(target));
+  // If a success lands first, stop waiting; if every target settles with no
+  // success, the error path below reports the most useful failure.
+  await Promise.race([firstSuccess, Promise.allSettled(tasks)]);
 
   // 4. Build response
   if (successResult) {
@@ -184,13 +228,16 @@ export async function executeImageCombo(
     return new Response(JSON.stringify(responseBody), { status: 200, headers });
   }
 
-  // All targets failed — return the last error
+  // All targets failed — prefer the terminal (400/403/401) error when one
+  // exists; it is the actionable misconfiguration signal. Fall back to the
+  // last failure otherwise.
+  const reportedError = terminalError ?? lastError;
   const errorPayload = toJsonErrorPayload(
-    lastError?.error || "All combo targets failed",
+    reportedError?.error || "All combo targets failed",
     "Image combo targets all failed"
   );
   return new Response(JSON.stringify(errorPayload), {
-    status: lastError?.status || 502,
+    status: reportedError?.status || 502,
     headers: { "Content-Type": "application/json" },
   });
 }

--- a/open-sse/services/videoCombo.ts
+++ b/open-sse/services/videoCombo.ts
@@ -87,129 +87,187 @@ export async function executeVideoCombo(
     );
   }
 
+  // 3. Run every video-capable target concurrently; first healthy success wins.
+  //
+  //    Sequential priority execution means a slow first target (a provider
+  //    that only fails after its full timeout, a queue that cannot fit the
+  //    request budget) blocks every sibling behind it, so a starved-but-first
+  //    provider turns a perfectly healthy combo into a long failure. Fanning
+  //    out removes that serialization: whoever answers first wins, and a
+  //    target that would have taken the full budget to fail no longer
+  //    pre-empts a sibling that could have succeeded in seconds.
+  //
+  //    We race the first success against "all settled" instead of await-ing
+  //    every target: once a success lands, the response returns immediately
+  //    while any still-running siblings unwind on their own. Promises that
+  //    reject are caught below, so a late sibling failure cannot become an
+  //    unhandled rejection after the caller already got a 200.
   let lastError: { status: number; error: string } | null = null;
+  let terminalError: { status: number; error: string } | null = null;
   let fallbackCount = 0;
 
-  for (const { modelStr, resolved } of videoTargets) {
-    const { provider: targetProvider, model: targetModel, isCustomModel } = resolved;
-    if (!targetProvider) {
-      lastError = { status: 400, error: `Invalid video model: ${modelStr}` };
-      fallbackCount += 1;
-      continue;
-    }
+  let resolveFirstSuccess: (() => void) | null = null;
+  const firstSuccess = new Promise<void>((resolve) => {
+    resolveFirstSuccess = resolve;
+  });
 
-    // Prompt requirements are per-target: some combo targets (I2V models) are
-    // prompt-optional and others are not, so a missing prompt only rules out
-    // this target rather than the whole combo.
-    if (!isVideoPromptOptional(resolved)) {
-      const promptError = promptRequiredResponse(body);
-      if (promptError) {
-        lastError = { status: 400, error: `[${targetProvider}] Prompt is required` };
+  const runTarget = async (modelStr: string, resolved: VideoModelTarget): Promise<void> => {
+    try {
+      const { provider: targetProvider, model: targetModel, isCustomModel } = resolved;
+      if (!targetProvider) {
+        lastError = { status: 400, error: `Invalid video model: ${modelStr}` };
         fallbackCount += 1;
-        continue;
-      }
-    }
-
-    // Local providers (authType "none") carry no credential by default, but a
-    // configured per-connection override (e.g. a ComfyUI base URL) must still
-    // be honored, exactly as the direct route treats them.
-    const providerConfig = getVideoProvider(targetProvider);
-    let credentials = null;
-    if (providerConfig && providerConfig.authType !== "none") {
-      try {
-        credentials = await getProviderCredentialsWithQuotaPreflight(
-          resolveVideoCredentialProvider(targetProvider)
-        );
-      } catch {
-        lastError = { status: 502, error: `Failed to resolve credentials for ${targetProvider}` };
-        fallbackCount += 1;
-        continue;
+        return;
       }
 
-      if (!credentials) {
-        lastError = { status: 400, error: `No credentials for video provider: ${targetProvider}` };
-        fallbackCount += 1;
-        continue;
+      // Prompt requirements are per-target: some combo targets (I2V models) are
+      // prompt-optional and others are not, so a missing prompt only rules out
+      // this target rather than the whole combo.
+      if (!isVideoPromptOptional(resolved)) {
+        const promptError = promptRequiredResponse(body);
+        if (promptError) {
+          lastError = { status: 400, error: `[${targetProvider}] Prompt is required` };
+          fallbackCount += 1;
+          return;
+        }
       }
 
-      if (isAllRateLimitedCredentials(credentials)) {
-        lastError = { status: 429, error: `[${targetProvider}] All accounts rate limited` };
-        fallbackCount += 1;
-        continue;
-      }
-    } else if (isCustomModel) {
-      try {
-        credentials = await getProviderCredentialsWithQuotaPreflight(
-          targetProvider,
-          null,
-          null,
-          targetModel
-        );
-      } catch {
-        lastError = { status: 502, error: `Failed to resolve credentials for ${targetProvider}` };
-        fallbackCount += 1;
-        continue;
+      // Local providers (authType "none") carry no credential by default, but a
+      // configured per-connection override (e.g. a ComfyUI base URL) must still
+      // be honored, exactly as the direct route treats them.
+      const providerConfig = getVideoProvider(targetProvider);
+      let credentials = null;
+      if (providerConfig && providerConfig.authType !== "none") {
+        try {
+          credentials = await getProviderCredentialsWithQuotaPreflight(
+            resolveVideoCredentialProvider(targetProvider)
+          );
+        } catch {
+          lastError = { status: 502, error: `Failed to resolve credentials for ${targetProvider}` };
+          fallbackCount += 1;
+          return;
+        }
+
+        if (!credentials) {
+          lastError = { status: 400, error: `No credentials for video provider: ${targetProvider}` };
+          fallbackCount += 1;
+          return;
+        }
+
+        if (isAllRateLimitedCredentials(credentials)) {
+          lastError = { status: 429, error: `[${targetProvider}] All accounts rate limited` };
+          fallbackCount += 1;
+          return;
+        }
+      } else if (isCustomModel) {
+        try {
+          credentials = await getProviderCredentialsWithQuotaPreflight(
+            targetProvider,
+            null,
+            null,
+            targetModel
+          );
+        } catch {
+          lastError = { status: 502, error: `Failed to resolve credentials for ${targetProvider}` };
+          fallbackCount += 1;
+          return;
+        }
+
+        if (!credentials) {
+          lastError = {
+            status: 400,
+            error: `No credentials for custom video provider: ${targetProvider}`,
+          };
+          fallbackCount += 1;
+          return;
+        }
+
+        if (isAllRateLimitedCredentials(credentials)) {
+          lastError = { status: 429, error: `[${targetProvider}] All accounts rate limited` };
+          fallbackCount += 1;
+          return;
+        }
+      } else if (providerConfig?.authType === "none") {
+        credentials = await resolveLocalOverrideCredentials(targetProvider);
       }
 
-      if (!credentials) {
-        lastError = {
-          status: 400,
-          error: `No credentials for custom video provider: ${targetProvider}`,
-        };
-        fallbackCount += 1;
-        continue;
-      }
-
-      if (isAllRateLimitedCredentials(credentials)) {
-        lastError = { status: 429, error: `[${targetProvider}] All accounts rate limited` };
-        fallbackCount += 1;
-        continue;
-      }
-    } else if (providerConfig?.authType === "none") {
-      credentials = await resolveLocalOverrideCredentials(targetProvider);
-    }
-
-    const result: MediaGenerationResultLike = await handleVideoGeneration({
-      body: { ...body, model: modelStr },
-      credentials,
-      log,
-      ...(isCustomModel && { resolvedProvider: targetProvider }),
-    });
-
-    if (!isMediaGenerationFailure(result)) {
-      await clearRecoveredProviderState(credentials);
-      return successfulMediaGenerationResponse({
-        result: { data: result.data },
-        billingMode: "video",
-        provider: targetProvider,
-        model: modelStr,
-        startTime,
-        duration: body.duration,
-        strategy: "priority",
-        fallbackAttempts: fallbackCount,
+      const result: MediaGenerationResultLike = await handleVideoGeneration({
+        body: { ...body, model: modelStr },
+        credentials,
+        log,
+        ...(isCustomModel && { resolvedProvider: targetProvider }),
       });
+
+      if (!isMediaGenerationFailure(result)) {
+        await clearRecoveredProviderState(credentials);
+        // Attach the selected provider/model to a shared closure so the
+        // success path after the race can construct the response.
+        selectedProvider = targetProvider;
+        selectedModel = modelStr;
+        selectedResult = result;
+        selectedFallbackCount = fallbackCount;
+        resolveFirstSuccess?.();
+        return;
+      }
+
+      const status = (result as { status?: number }).status || 500;
+      const error =
+        typeof (result as { error?: unknown }).error === "string"
+          ? (result as { error: string }).error
+          : "Video generation failed";
+      const failure = { status, error: `[${targetProvider}] ${error}` };
+      lastError = failure;
+
+      // Terminal failures (400 bad model, 401 missing key, 403 banned) are the
+      // most actionable signal when every target fails — keep one aside so it
+      // can surface instead of a generic 5xx/429.
+      if (status === 400 || status === 401 || status === 403) {
+        if (!terminalError) terminalError = failure;
+      }
+      fallbackCount += 1;
+    } catch (err) {
+      // A late sibling may fail after the caller already got a 200 — record
+      // it so it can still surface if nothing else succeeds, and never leak
+      // the rejection after an early return.
+      const message =
+        err instanceof Error ? err.message : typeof err === "string" ? err : "Video generation failed";
+      if (!lastError) lastError = { status: 502, error: `[video combo] ${message}` };
+      fallbackCount += 1;
     }
+  };
 
-    const status = (result as { status?: number }).status || 500;
-    const error =
-      typeof (result as { error?: unknown }).error === "string"
-        ? (result as { error: string }).error
-        : "Video generation failed";
+  // Shared state for the first success captured inside runTarget
+  let selectedProvider = "";
+  let selectedModel = "";
+  let selectedResult: MediaGenerationResultLike | null = null;
+  let selectedFallbackCount = 0;
 
-    if (status === 400 || status === 401 || status === 403) {
-      return errorResponse(status, `[${targetProvider}] ${error}`);
-    }
+  const tasks = videoTargets.map(({ modelStr, resolved }) => runTarget(modelStr, resolved));
+  await Promise.race([firstSuccess, Promise.allSettled(tasks)]);
 
-    lastError = { status, error: `[${targetProvider}] ${error}` };
-    fallbackCount += 1;
+  if (selectedResult) {
+    return successfulMediaGenerationResponse({
+      result: { data: selectedResult.data },
+      billingMode: "video",
+      provider: selectedProvider,
+      model: selectedModel,
+      startTime,
+      duration: body.duration,
+      strategy: "priority",
+      fallbackAttempts: selectedFallbackCount,
+    });
   }
 
+  // All targets failed — prefer the terminal (400/401/403) error when one
+  // exists; it is the actionable misconfiguration signal. Fall back to the
+  // last failure otherwise.
+  const reportedError = terminalError ?? lastError;
   const errorPayload = toJsonErrorPayload(
-    lastError?.error || "All combo targets failed",
+    reportedError?.error || "All combo targets failed",
     "Video combo targets all failed"
   );
   return new Response(JSON.stringify(errorPayload), {
-    status: lastError?.status || 502,
+    status: reportedError?.status || 502,
     headers: { "Content-Type": "application/json" },
   });
 }

--- a/src/lib/usage/callLogs.ts
+++ b/src/lib/usage/callLogs.ts
@@ -132,9 +132,16 @@ type DeleteResult = {
 
 let logIdCounter = 0;
 
+// The id is a TEXT PRIMARY KEY across one shared SQLite file. Two OmniRoute
+// processes (dev checkout + globally-installed CLI, or two replicas) can
+// share the same DATA_DIR, so a bare `Date.now()-counter` collides the
+// moment both land on the same millisecond — the INSERT then fails with
+// "UNIQUE constraint failed: call_logs.id" and the call is never logged.
+// The pid makes the id unique per process while keeping the timestamp prefix
+// (still human-readable and sortable by creation time).
 function generateLogId() {
   logIdCounter++;
-  return `${Date.now()}-${logIdCounter}`;
+  return `${Date.now()}-${process.pid}-${logIdCounter}`;
 }
 
 async function resolveAccountName(connectionId: string | null | undefined) {

--- a/tests/unit/call-logs-session-tag.test.ts
+++ b/tests/unit/call-logs-session-tag.test.ts
@@ -41,6 +41,46 @@ test("saveCallLog persists sessionTag when explicitly supplied", async () => {
   assert.equal(row.session_tag, "sess-abc");
 });
 
+test("auto-generated call log ids embed the process pid and stay unique per process", async () => {
+  // Two OmniRoute processes (dev checkout + globally-installed CLI) can share
+  // one SQLite file. A bare `Date.now()-counter` id collides the moment both
+  // land on the same millisecond, so the INSERT fails with
+  // "UNIQUE constraint failed: call_logs.id" and the call is never logged.
+  // The pid makes ids unique per process; this guards the format + uniqueness.
+  const db = core.getDbInstance();
+
+  await callLogs.saveCallLog({
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "test-model",
+    provider: "test-provider",
+    duration: 100,
+    tokens: { in: 1, out: 1 },
+  });
+  await callLogs.saveCallLog({
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "test-model",
+    provider: "test-provider",
+    duration: 100,
+    tokens: { in: 1, out: 1 },
+  });
+
+  const rows = db
+    .prepare("SELECT id FROM call_logs ORDER BY rowid DESC LIMIT 2")
+    .all() as Array<{ id: string }>;
+  assert.equal(rows.length, 2, "both auto-id rows persisted");
+  const ids = rows.map((row) => row.id);
+  assert.notEqual(ids[0], ids[1], "two auto-generated ids must differ");
+  for (const id of ids) {
+    const parts = id.split("-");
+    assert.equal(parts.length, 3, `expected <ms>-<pid>-<counter>, got "${id}"`);
+    assert.equal(Number(parts[1]), process.pid, `id embeds the process pid: ${id}`);
+  }
+});
+
 test("saveCallLog stores NULL session_tag when absent (never synthesized)", async () => {
   const testId = `test-nosessiontag-${Date.now()}`;
 

--- a/tests/unit/combo/image-combo.test.ts
+++ b/tests/unit/combo/image-combo.test.ts
@@ -350,3 +350,62 @@ test("combo success keeps the OpenAI {created, data} wrapper and Codex defaults 
     globalThis.fetch = originalFetch;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Parallel fan-out — a slow failing first target must not block a healthy one
+// ---------------------------------------------------------------------------
+
+test("runs image targets concurrently: slow failing first target does not block fast healthy second target", async () => {
+  await createProviderConnection({
+    provider: "openai",
+    authType: "apikey",
+    apiKey: "sk-test",
+    name: "image-combo-openai",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {},
+  });
+  // gpt-image-2 is the priority (first) target; gpt-image-1-mini is the sibling.
+  await createCombo({
+    name: "parallel-img-combo",
+    strategy: "priority",
+    models: ["openai/gpt-image-2", "openai/gpt-image-1-mini"],
+  });
+
+  const log = createLog();
+  const start = Date.now();
+
+  const response = await executeImageCombo(
+    "parallel-img-combo",
+    { model: "parallel-img-combo", prompt: "a cat", n: 1 },
+    createMockAuth(),
+    Date.now(),
+    log,
+    {
+      generateImage: async ({ body: b }: { body: { model?: string } }) => {
+        const model = String(b?.model ?? "");
+        if (model.includes("gpt-image-2")) {
+          // Priority target plays the starved provider: it burns ~300ms and
+          // fails, while the sibling answers in a few ms.
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          return { success: false, status: 429, error: "slow provider unavailable" };
+        }
+        return {
+          success: true,
+          status: 200,
+          data: { created: 1, data: [{ url: "https://ok.example/x.png" }] },
+        };
+      },
+    }
+  );
+
+  const elapsed = Date.now() - start;
+
+  assert.equal(response.status, 200, "healthy sibling wins over slow first target");
+  const payload = await response.json();
+  assert.equal(payload.data[0].url, "https://ok.example/x.png");
+  assert.equal(response.headers.get("X-OmniRoute-Provider"), "openai");
+  // Finished well before the slow target's 300ms failure — proof of flush,
+  // not sequential waiting.
+  assert.ok(elapsed < 250, `parallel fan-out finished in ${elapsed}ms, expected << 300ms`);
+});


### PR DESCRIPTION
## Summary

Image and video combo strategies ran targets sequentially — a slow first target (e.g. AI Horde queue exhaustion) blocked every healthy sibling behind it. Both now fan out all targets concurrently via `Promise.race` against `Promise.allSettled`, so the first success wins immediately without waiting for slower siblings to finish.

Also fixes `call_logs` UNIQUE constraint collisions when two OmniRoute processes share the same SQLite `DATA_DIR` (dev + globally-installed CLI): the auto-generated id now embeds `process.pid` to guarantee uniqueness across processes.

Closes #13099

## Changes

- **`open-sse/services/imageCombo.ts`** — Replaced sequential for-loop with parallel `runTarget` + `Promise.race([firstSuccess, Promise.allSettled(tasks)])`. Terminal errors (400/401/403) surfaced when every target fails. Added `options?.generateImage` parameter for test injection.
- **`open-sse/services/videoCombo.ts`** — Same parallel fan-out pattern. Preserved per-target prompt-optional (I2V) and credential resolution variants.
- **`src/lib/usage/callLogs.ts`** — `generateLogId()` now returns `${Date.now()}-${process.pid}-${counter}` to avoid cross-process collisions.
- **`tests/unit/combo/image-combo.test.ts`** — New test asserting parallel fan-out completes well before a slow first target's failure window.
- **`tests/unit/call-logs-session-tag.test.ts`** — New test asserting auto-generated ids contain pid and are unique per process.

## Test results

All 16 relevant tests pass (image-combo: 10, call-logs: 6).

⚠️ base-red inherited: #12732
@diegosouzapw 
