### PR TITLE
fix(tailscale): prevent host-wide daemon termination

### DIFF
--- a/changelog.d/fixes/13105-tailscale-owned-daemon-stop.md
+++ b/changelog.d/fixes/13105-tailscale-owned-daemon-stop.md
@@ -1,0 +1,1 @@
+- **fix(tailscale):** Disabling the OmniRoute Funnel no longer terminates shared Tailscale daemons or active SSH sessions, and failed resets no longer report success ([#13105](https://github.com/diegosouzapw/OmniRoute/pull/13105)).

--- a/changelog.d/fixes/PENDING-tailscale-owned-daemon-stop.md
+++ b/changelog.d/fixes/PENDING-tailscale-owned-daemon-stop.md
@@ -1,0 +1,1 @@
+- **fix(tailscale):** Disabling the OmniRoute Funnel no longer terminates shared Tailscale daemons or active SSH sessions, and failed resets no longer report success ([#PENDING](https://github.com/diegosouzapw/OmniRoute/pull/PENDING)).

--- a/changelog.d/fixes/PENDING-tailscale-owned-daemon-stop.md
+++ b/changelog.d/fixes/PENDING-tailscale-owned-daemon-stop.md
@@ -1,1 +1,0 @@
-- **fix(tailscale):** Disabling the OmniRoute Funnel no longer terminates shared Tailscale daemons or active SSH sessions, and failed resets no longer report success ([#PENDING](https://github.com/diegosouzapw/OmniRoute/pull/PENDING)).

--- a/src/lib/tailscaleTunnel.ts
+++ b/src/lib/tailscaleTunnel.ts
@@ -59,6 +59,13 @@ type BinaryResolution = {
   managedInstall: boolean;
 };
 
+type ProcessIdentity = {
+  executable: string;
+  args: string[];
+};
+
+type ProcessIdentityReader = (pid: number) => Promise<ProcessIdentity | null>;
+
 type TailscaleLoginResult = { alreadyLoggedIn: true } | { authUrl: string };
 
 type TailscaleFunnelResult =
@@ -165,13 +172,23 @@ async function readStateFile(): Promise<PersistedTailscaleState> {
   }
 }
 
+async function readStateFileForUpdate(): Promise<PersistedTailscaleState> {
+  try {
+    const raw = await fsPromises.readFile(getStateFilePath(), "utf8");
+    return JSON.parse(raw) as PersistedTailscaleState;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
 async function writeStateFile(state: PersistedTailscaleState) {
   await ensureTailscaleDir();
   await fsPromises.writeFile(getStateFilePath(), JSON.stringify(state, null, 2) + "\n", "utf8");
 }
 
 async function updateStateFile(patch: Partial<PersistedTailscaleState>) {
-  const current = await readStateFile();
+  const current = await readStateFileForUpdate();
   await writeStateFile({
     ...current,
     ...patch,
@@ -192,8 +209,8 @@ async function readPidFile() {
 async function clearPidFile() {
   try {
     await fsPromises.unlink(getPidFilePath());
-  } catch {
-    // Ignore stale or missing pid files.
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }
 
@@ -202,8 +219,8 @@ function isProcessAlive(pid: number | null) {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
   }
 }
 
@@ -596,6 +613,8 @@ export async function startTailscaleDaemon({
     throw new Error("Sudo password required to start tailscaled");
   }
 
+  // Do not launch a private daemon if its ownership record cannot be read safely.
+  await readStateFileForUpdate();
   setCachedPassword(password);
   await ensureTailscaleDir();
 
@@ -704,15 +723,19 @@ export async function startTailscaleLogin({
   });
 }
 
-async function resetTailscaleFunnel(binaryPath: string) {
+async function runTailscaleFunnelReset(binaryPath: string) {
+  await execFileAsync(binaryPath, await buildTailscaleArgs("funnel", "--bg", "reset"), {
+    timeout: 5000,
+    windowsHide: true,
+    env: buildExecEnv(),
+  });
+}
+
+async function resetTailscaleFunnelBestEffort(binaryPath: string) {
   try {
-    await execFileAsync(binaryPath, await buildTailscaleArgs("funnel", "--bg", "reset"), {
-      timeout: 5000,
-      windowsHide: true,
-      env: buildExecEnv(),
-    });
+    await runTailscaleFunnelReset(binaryPath);
   } catch {
-    // Ignore stale or missing funnel state.
+    // Ignore stale pre-enable Funnel state. The strict disable path propagates errors.
   }
 }
 
@@ -724,7 +747,7 @@ export async function startTailscaleFunnel(
     throw new Error("Tailscale is not installed");
   }
 
-  await resetTailscaleFunnel(resolution.binaryPath);
+  await resetTailscaleFunnelBestEffort(resolution.binaryPath);
 
   const funnelArgs = await buildTailscaleArgs("funnel", "--bg", String(port));
 
@@ -792,8 +815,99 @@ export async function startTailscaleFunnel(
 
 export async function stopTailscaleFunnel() {
   const resolution = await resolveBinary();
-  if (!resolution.binaryPath) return;
-  await resetTailscaleFunnel(resolution.binaryPath);
+  if (!resolution.binaryPath) {
+    throw new Error("Tailscale is not installed");
+  }
+  await runTailscaleFunnelReset(resolution.binaryPath);
+}
+
+async function readProcessIdentity(pid: number): Promise<ProcessIdentity | null> {
+  // Linux exposes lossless argv tokens. Other platforms fail closed because their
+  // process listings reconstruct a lossy command string that cannot prove ownership.
+  if (getCurrentPlatform() !== "linux") return null;
+  try {
+    const [executable, commandLine] = await Promise.all([
+      fsPromises.readFile(`/proc/${pid}/comm`, "utf8"),
+      fsPromises.readFile(`/proc/${pid}/cmdline`),
+    ]);
+    return {
+      executable: executable.trim(),
+      args: commandLine
+        .toString("utf8")
+        .split("\0")
+        .filter((arg) => arg.length > 0),
+    };
+  } catch {
+    return null;
+  }
+}
+
+let processIdentityReader: ProcessIdentityReader = readProcessIdentity;
+
+export function __setTailscaleProcessIdentityReaderForTests(reader: ProcessIdentityReader) {
+  const previous = processIdentityReader;
+  processIdentityReader = reader;
+  return () => {
+    processIdentityReader = previous;
+  };
+}
+
+async function isManagedTailscaleDaemonProcess(pid: number) {
+  const identity = await processIdentityReader(pid);
+  if (!identity) return false;
+  return (
+    path.basename(identity.executable) === "tailscaled" &&
+    path.basename(identity.args[0] || "") === "tailscaled" &&
+    identity.args.includes(`--socket=${getTailscaleSocketPath()}`) &&
+    identity.args.includes(`--statedir=${getTailscaleDir()}`)
+  );
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessAlive(pid) && Date.now() < deadline) {
+    await sleep(100);
+  }
+  return !isProcessAlive(pid);
+}
+
+async function stopManagedTailscaleDaemon(pid: number, password: string) {
+  if (!isProcessAlive(pid)) return true;
+  if (!(await isManagedTailscaleDaemonProcess(pid))) return false;
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "EPERM" && code !== "ESRCH") throw error;
+  }
+
+  if (await waitForProcessExit(pid)) return true;
+  if (!password) {
+    throw new Error(`Managed tailscaled process ${pid} requires elevated permission to stop`);
+  }
+  if (!(await isManagedTailscaleDaemonProcess(pid))) return false;
+
+  await execFileWithPassword("sudo", ["-S", "kill", "-TERM", "--", String(pid)], password);
+  if (await waitForProcessExit(pid)) return true;
+  if (!(await isManagedTailscaleDaemonProcess(pid))) return false;
+
+  await execFileWithPassword("sudo", ["-S", "kill", "-KILL", "--", String(pid)], password);
+  if (!(await waitForProcessExit(pid))) {
+    throw new Error(`Managed tailscaled process ${pid} did not stop`);
+  }
+  return true;
+}
+
+async function clearManagedTailscaleDaemonState() {
+  try {
+    await fsPromises.unlink(getTailscaleSocketPath());
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  await clearPidFile();
+  await updateStateFile({ daemonPid: null });
+  invalidateSocketCache();
 }
 
 export async function stopTailscaleDaemon({
@@ -802,62 +916,18 @@ export async function stopTailscaleDaemon({
   sudoPassword?: string;
 } = {}) {
   const password = toNonEmptyString(sudoPassword) || getCachedPassword() || "";
+  const state = await readStateFile();
   const pid = await readPidFile();
+  const managedPid = pid && state.daemonPid === pid ? pid : null;
 
-  if (pid && isProcessAlive(pid)) {
-    try {
-      process.kill(pid, "SIGTERM");
-    } catch {
-      // Ignore non-owned or stale processes.
-    }
+  if (!managedPid) return;
+
+  // A PID can be reused after a crash or reboot. Revalidate the live command before
+  // every signal, and clear ownership evidence only after the process is confirmed gone.
+  if (!(await stopManagedTailscaleDaemon(managedPid, password))) {
+    throw new Error(`Refusing to stop unverified tailscaled process ${managedPid}`);
   }
-
-  await sleep(1000);
-
-  if (pid && isProcessAlive(pid) && password) {
-    try {
-      await runSudoShell(`kill ${Number(pid)}`, password);
-    } catch {
-      // Ignore fallback failures and keep trying generic process matches.
-    }
-  }
-
-  if (getCurrentPlatform() !== "win32") {
-    try {
-      await execFileAsync("pkill", ["-x", "tailscaled"], {
-        timeout: 3000,
-        windowsHide: true,
-        env: buildExecEnv(),
-      });
-    } catch {
-      // Ignore when the daemon is not running or not owned by this user.
-    }
-
-    if (password) {
-      try {
-        await runSudoShell("pkill -x tailscaled", password);
-      } catch {
-        // Ignore final privileged shutdown failures.
-      }
-    }
-  } else {
-    try {
-      await execFileAsync("net", ["stop", "Tailscale"], {
-        timeout: 10000,
-        windowsHide: true,
-        env: buildExecEnv(),
-      });
-    } catch {
-      // Ignore service stop failures on Windows.
-    }
-  }
-
-  await clearPidFile();
-  try {
-    await fsPromises.unlink(getTailscaleSocketPath());
-  } catch {
-    // Ignore missing sockets.
-  }
+  await clearManagedTailscaleDaemonState();
 }
 
 export async function enableTailscaleTunnel({
@@ -946,7 +1016,6 @@ export async function disableTailscaleTunnel({
 
   try {
     await stopTailscaleFunnel();
-    await stopTailscaleDaemon({ sudoPassword: normalizedPassword });
     await updateSettings({
       tailscaleEnabled: false,
       tailscaleUrl: "",
@@ -961,7 +1030,11 @@ export async function disableTailscaleTunnel({
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to disable Tailscale Funnel";
-    await updateStateFile({ lastError: message });
+    try {
+      await updateStateFile({ lastError: message });
+    } catch {
+      // Preserve unreadable ownership metadata and surface the original disable failure.
+    }
     throw error;
   }
 }

--- a/tests/unit/tailscaleTunnel-stop-owned.test.ts
+++ b/tests/unit/tailscaleTunnel-stop-owned.test.ts
@@ -1,0 +1,413 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { EventEmitter } from "node:events";
+import { createRequire, syncBuiltinESMExports } from "node:module";
+import { PassThrough } from "node:stream";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
+const modulePath = path.join(process.cwd(), "src/lib/tailscaleTunnel.ts");
+const originalExecFile = childProcess.execFile;
+const originalExecFileSync = childProcess.execFileSync;
+const originalSpawn = childProcess.spawn;
+const originalProcessKill = process.kill;
+const originalDataDir = process.env.DATA_DIR;
+const originalNoSudo = process.env.OMNIROUTE_NO_SUDO;
+
+let testDataDir = "";
+let externalCalls: Array<{ kind: string; command: string; args: string[] }> = [];
+let spawnImplementation: ((command: string, args: string[]) => unknown) | null = null;
+
+function installFailClosedProcessMocks() {
+  childProcess.execFile = (command, args, options, callback) => {
+    const normalizedArgs = Array.from(args ?? [], String);
+    externalCalls.push({ kind: "execFile", command: String(command), args: normalizedArgs });
+    const cb = typeof options === "function" ? options : callback;
+    cb?.(null, "", "");
+  };
+  childProcess.execFile[promisify.custom] = async (command, args) => {
+    const normalizedArgs = Array.from(args ?? [], String);
+    externalCalls.push({ kind: "execFile", command: String(command), args: normalizedArgs });
+    return { stdout: "", stderr: "" };
+  };
+  childProcess.execFileSync = (command, args) => {
+    const normalizedArgs = Array.from(args ?? [], String);
+    externalCalls.push({ kind: "execFileSync", command: String(command), args: normalizedArgs });
+    if (String(command) === "sh" && normalizedArgs.join(" ") === "-c command -v sudo") {
+      return Buffer.from("/usr/bin/sudo\n");
+    }
+    throw new Error("synchronous external process blocked by Tailscale shutdown safety test");
+  };
+  childProcess.spawn = (command, args) => {
+    const normalizedArgs = Array.from(args ?? [], String);
+    externalCalls.push({ kind: "spawn", command: String(command), args: normalizedArgs });
+    if (spawnImplementation) return spawnImplementation(String(command), normalizedArgs);
+    throw new Error("external process launch blocked by Tailscale shutdown safety test");
+  };
+  syncBuiltinESMExports();
+}
+
+async function importFresh(label: string) {
+  return import(`${pathToFileURL(modulePath).href}?case=${label}-${Date.now()}-${Math.random()}`);
+}
+
+async function writeDaemonOwnership(pidFilePid: number, statePid: number) {
+  const tailscaleDir = path.join(testDataDir, "tailscale");
+  await fs.mkdir(tailscaleDir, { recursive: true });
+  await fs.writeFile(path.join(tailscaleDir, ".tailscaled.pid"), `${pidFilePid}\n`, "utf8");
+  await fs.writeFile(
+    path.join(tailscaleDir, "state.json"),
+    `${JSON.stringify({ daemonPid: statePid }, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+function managedProcessIdentity(
+  overrides: { executable?: string; socket?: string; stateDir?: string } = {}
+) {
+  const tailscaleDir = path.join(testDataDir, "tailscale");
+  return {
+    executable: overrides.executable ?? "/usr/sbin/tailscaled",
+    args: [
+      "/usr/sbin/tailscaled",
+      `--socket=${overrides.socket ?? path.join(tailscaleDir, "tailscaled.sock")}`,
+      `--statedir=${overrides.stateDir ?? tailscaleDir}`,
+    ],
+  };
+}
+
+function createSuccessfulChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  queueMicrotask(() => child.emit("close", 0));
+  return child;
+}
+
+async function assertIdentityMismatch(
+  label: string,
+  overrides: { executable?: string; socket?: string; stateDir?: string }
+) {
+  const managedPid = 41006;
+  await writeDaemonOwnership(managedPid, managedPid);
+  const tunnel = await importFresh(label);
+  const restoreIdentityReader = tunnel.__setTailscaleProcessIdentityReaderForTests(async () =>
+    managedProcessIdentity(overrides)
+  );
+  const terminatingSignals: Array<NodeJS.Signals | number | undefined> = [];
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    assert.equal(pid, managedPid);
+    if (signal === 0) return true;
+    terminatingSignals.push(signal);
+    return true;
+  }) as typeof process.kill;
+
+  try {
+    await assert.rejects(
+      () => tunnel.stopTailscaleDaemon({ sudoPassword: "test-only" }),
+      /Refusing to stop unverified tailscaled process/
+    );
+  } finally {
+    restoreIdentityReader();
+  }
+
+  assert.deepEqual(terminatingSignals, []);
+  assert.deepEqual(externalCalls, []);
+  const state = JSON.parse(
+    await fs.readFile(path.join(testDataDir, "tailscale", "state.json"), "utf8")
+  );
+  assert.equal(state.daemonPid, managedPid);
+}
+
+test.beforeEach(async () => {
+  testDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "omniroute-tailscale-stop-"));
+  process.env.DATA_DIR = testDataDir;
+  delete process.env.OMNIROUTE_NO_SUDO;
+  externalCalls = [];
+  spawnImplementation = null;
+  installFailClosedProcessMocks();
+});
+
+test.afterEach(async () => {
+  process.kill = originalProcessKill;
+  childProcess.execFile = originalExecFile;
+  childProcess.execFileSync = originalExecFileSync;
+  childProcess.spawn = originalSpawn;
+  syncBuiltinESMExports();
+  if (originalDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = originalDataDir;
+  if (originalNoSudo === undefined) delete process.env.OMNIROUTE_NO_SUDO;
+  else process.env.OMNIROUTE_NO_SUDO = originalNoSudo;
+  await fs.rm(testDataDir, { recursive: true, force: true });
+});
+
+test("shutdown contains no broad process or service termination", async () => {
+  const source = await fs.readFile(modulePath, "utf8");
+  const stopStart = source.indexOf("async function isManagedTailscaleDaemonProcess");
+  const stopEnd = source.indexOf("export async function enableTailscaleTunnel");
+
+  assert.notEqual(stopStart, -1);
+  assert.notEqual(stopEnd, -1);
+  const stopSource = source.slice(stopStart, stopEnd);
+  assert.doesNotMatch(stopSource, /\bpkill\b|\bkillall\b|\bsystemctl\b|\blaunchctl\b|Stop-Service/);
+  assert.doesNotMatch(stopSource, /execFileAsync\(\s*["'](?:net|sc)["']\s*,\s*\[\s*["']stop["']/);
+  assert.doesNotMatch(stopSource, /runSudoShell/);
+  assert.doesNotMatch(stopSource, /\b(?:exec|execSync|execFileSync|spawnSync)\s*\(/);
+
+  const disableStart = source.indexOf("export async function disableTailscaleTunnel");
+  const installStart = source.indexOf("function createStreamLogger");
+  assert.notEqual(disableStart, -1);
+  assert.notEqual(installStart, -1);
+  assert.doesNotMatch(source.slice(disableStart, installStart), /stopTailscaleDaemon/);
+});
+
+test("no ownership record performs no process action", async () => {
+  const tunnel = await importFresh("no-ownership");
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | number }> = [];
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    killCalls.push({ pid, signal });
+    throw Object.assign(new Error("unexpected process signal"), { code: "ESRCH" });
+  }) as typeof process.kill;
+
+  await tunnel.stopTailscaleDaemon({ sudoPassword: "test-only" });
+
+  assert.deepEqual(killCalls, []);
+  assert.deepEqual(externalCalls, []);
+});
+
+test("matching private ownership signals only the exact recorded PID", async () => {
+  const managedPid = 41003;
+  await writeDaemonOwnership(managedPid, managedPid);
+  const tunnel = await importFresh("matching-ownership");
+  const restoreIdentityReader = tunnel.__setTailscaleProcessIdentityReaderForTests(async () =>
+    managedProcessIdentity()
+  );
+  let alive = true;
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | number }> = [];
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    assert.equal(pid, managedPid);
+    if (signal === 0) {
+      if (alive) return true;
+      throw Object.assign(new Error("missing"), { code: "ESRCH" });
+    }
+    killCalls.push({ pid, signal });
+    alive = false;
+    return true;
+  }) as typeof process.kill;
+
+  try {
+    await tunnel.stopTailscaleDaemon();
+  } finally {
+    restoreIdentityReader();
+  }
+
+  assert.deepEqual(killCalls, [{ pid: managedPid, signal: "SIGTERM" }]);
+  assert.deepEqual(externalCalls, []);
+  const state = JSON.parse(
+    await fs.readFile(path.join(testDataDir, "tailscale", "state.json"), "utf8")
+  );
+  assert.equal(state.daemonPid, null);
+});
+
+test("mismatched private ownership cannot signal either PID", async () => {
+  const statePid = 41004;
+  const pidFilePid = 41005;
+  await writeDaemonOwnership(pidFilePid, statePid);
+  const tunnel = await importFresh("mismatched-ownership");
+  const killCalls: Array<{ pid: number; signal?: NodeJS.Signals | number }> = [];
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    killCalls.push({ pid, signal });
+    return true;
+  }) as typeof process.kill;
+
+  await tunnel.stopTailscaleDaemon({ sudoPassword: "test-only" });
+
+  assert.deepEqual(killCalls, []);
+  assert.deepEqual(externalCalls, []);
+});
+
+test("reused PID with the wrong private socket is never signalled", async () => {
+  const tailscaleDir = path.join(testDataDir, "tailscale");
+  await assertIdentityMismatch("wrong-socket", {
+    socket: `${path.join(tailscaleDir, "tailscaled.sock")}.other`,
+  });
+});
+
+test("reused PID with the wrong private state directory is never signalled", async () => {
+  const tailscaleDir = path.join(testDataDir, "tailscale");
+  await assertIdentityMismatch("wrong-state-dir", {
+    stateDir: `${tailscaleDir}-backup`,
+  });
+});
+
+test(
+  "cleanup failure preserves PID and state ownership evidence",
+  { skip: process.platform === "win32" || process.getuid?.() === 0 },
+  async () => {
+    const managedPid = 41009;
+    await writeDaemonOwnership(managedPid, managedPid);
+    const tailscaleDir = path.join(testDataDir, "tailscale");
+    const socketPath = path.join(tailscaleDir, "tailscaled.sock");
+    await fs.writeFile(socketPath, "socket sentinel", "utf8");
+    const tunnel = await importFresh("cleanup-failure");
+    const restoreIdentityReader = tunnel.__setTailscaleProcessIdentityReaderForTests(async () =>
+      managedProcessIdentity()
+    );
+    let alive = true;
+    process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      assert.equal(pid, managedPid);
+      if (signal === 0) {
+        if (alive) return true;
+        throw Object.assign(new Error("missing"), { code: "ESRCH" });
+      }
+      alive = false;
+      return true;
+    }) as typeof process.kill;
+
+    await fs.chmod(tailscaleDir, 0o500);
+    try {
+      await assert.rejects(() => tunnel.stopTailscaleDaemon(), /EACCES|permission denied/i);
+    } finally {
+      restoreIdentityReader();
+      await fs.chmod(tailscaleDir, 0o700);
+    }
+
+    assert.equal(await fs.readFile(path.join(tailscaleDir, ".tailscaled.pid"), "utf8"), "41009\n");
+    assert.equal(
+      JSON.parse(await fs.readFile(path.join(tailscaleDir, "state.json"), "utf8")).daemonPid,
+      managedPid
+    );
+    assert.equal(await fs.readFile(socketPath, "utf8"), "socket sentinel");
+    assert.deepEqual(externalCalls, []);
+  }
+);
+
+test("password-backed shutdown uses exact sudo TERM argv", async () => {
+  const managedPid = 41007;
+  await writeDaemonOwnership(managedPid, managedPid);
+  const tunnel = await importFresh("sudo-term");
+  let alive = true;
+  let identityReads = 0;
+  const restoreIdentityReader = tunnel.__setTailscaleProcessIdentityReaderForTests(async () => {
+    identityReads += 1;
+    return managedProcessIdentity();
+  });
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    assert.equal(pid, managedPid);
+    if (!alive) throw Object.assign(new Error("missing"), { code: "ESRCH" });
+    if (signal === 0 || signal === "SIGTERM") {
+      throw Object.assign(new Error("permission denied"), { code: "EPERM" });
+    }
+    throw new Error(`unexpected signal ${String(signal)}`);
+  }) as typeof process.kill;
+  spawnImplementation = () => {
+    alive = false;
+    return createSuccessfulChild();
+  };
+
+  try {
+    await tunnel.stopTailscaleDaemon({ sudoPassword: "test-only" });
+  } finally {
+    restoreIdentityReader();
+  }
+
+  assert.equal(identityReads, 2);
+  assert.deepEqual(externalCalls, [
+    { kind: "execFileSync", command: "sh", args: ["-c", "command -v sudo"] },
+    {
+      kind: "spawn",
+      command: "sudo",
+      args: ["-S", "kill", "-TERM", "--", String(managedPid)],
+    },
+  ]);
+  const state = JSON.parse(
+    await fs.readFile(path.join(testDataDir, "tailscale", "state.json"), "utf8")
+  );
+  assert.equal(state.daemonPid, null);
+});
+
+test("password-backed shutdown revalidates identity before SIGKILL", async () => {
+  const managedPid = 41008;
+  await writeDaemonOwnership(managedPid, managedPid);
+  const tunnel = await importFresh("sudo-kill-revalidation");
+  let identityReads = 0;
+  const restoreIdentityReader = tunnel.__setTailscaleProcessIdentityReaderForTests(async () => {
+    identityReads += 1;
+    if (identityReads < 3) return managedProcessIdentity();
+    return managedProcessIdentity({ stateDir: `${path.join(testDataDir, "tailscale")}-reused` });
+  });
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    assert.equal(pid, managedPid);
+    if (signal === 0 || signal === "SIGTERM") {
+      throw Object.assign(new Error("permission denied"), { code: "EPERM" });
+    }
+    throw new Error(`unexpected signal ${String(signal)}`);
+  }) as typeof process.kill;
+  spawnImplementation = () => createSuccessfulChild();
+
+  try {
+    await assert.rejects(
+      () => tunnel.stopTailscaleDaemon({ sudoPassword: "test-only" }),
+      /Refusing to stop unverified tailscaled process/
+    );
+  } finally {
+    restoreIdentityReader();
+  }
+
+  assert.equal(identityReads, 3);
+  assert.deepEqual(
+    externalCalls.filter((call) => call.kind === "spawn"),
+    [
+      {
+        kind: "spawn",
+        command: "sudo",
+        args: ["-S", "kill", "-TERM", "--", String(managedPid)],
+      },
+    ]
+  );
+  const state = JSON.parse(
+    await fs.readFile(path.join(testDataDir, "tailscale", "state.json"), "utf8")
+  );
+  assert.equal(state.daemonPid, managedPid);
+});
+
+test("exact owned PID fails closed when elevation is required", async () => {
+  const managedPid = 41006;
+  await writeDaemonOwnership(managedPid, managedPid);
+  const tunnel = await importFresh("elevation-required");
+  const restoreIdentityReader = tunnel.__setTailscaleProcessIdentityReaderForTests(async () =>
+    managedProcessIdentity()
+  );
+  process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+    assert.equal(pid, managedPid);
+    if (signal === 0 || signal === "SIGTERM") {
+      throw Object.assign(new Error("permission denied"), { code: "EPERM" });
+    }
+    throw new Error(`unexpected signal ${String(signal)}`);
+  }) as typeof process.kill;
+
+  try {
+    await assert.rejects(
+      () => tunnel.stopTailscaleDaemon(),
+      /requires elevated permission to stop/
+    );
+  } finally {
+    restoreIdentityReader();
+  }
+
+  assert.deepEqual(externalCalls, []);
+  const state = JSON.parse(
+    await fs.readFile(path.join(testDataDir, "tailscale", "state.json"), "utf8")
+  );
+  assert.equal(state.daemonPid, managedPid);
+});

--- a/tests/unit/tailscaleTunnel.test.ts
+++ b/tests/unit/tailscaleTunnel.test.ts
@@ -3,6 +3,68 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createRequire, syncBuiltinESMExports } from "node:module";
+import { promisify } from "node:util";
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
+const originalExecFile = childProcess.execFile;
+const originalExecFileAsync = promisify(originalExecFile);
+const originalSpawn = childProcess.spawn;
+const originalProcessKill = process.kill;
+const blockedProcessActions: Array<{ kind: string; command: string; args: string[] }> = [];
+
+function isAllowedTestBinary(command: string) {
+  return command === path.join(TEST_DATA_DIR, "fake-tailscale.sh");
+}
+
+const guardedExecFile = (command, args, options, callback) => {
+  const normalizedCommand = String(command);
+  const normalizedArgs = Array.from(args ?? [], String);
+  if (!isAllowedTestBinary(normalizedCommand)) {
+    blockedProcessActions.push({
+      kind: "execFile",
+      command: normalizedCommand,
+      args: normalizedArgs,
+    });
+    const cb = typeof options === "function" ? options : callback;
+    cb?.(Object.assign(new Error("external command blocked by test"), { code: "EPERM" }));
+    return;
+  }
+  return originalExecFile(command, args, options, callback);
+};
+guardedExecFile[promisify.custom] = async (command, args, options) => {
+  const normalizedCommand = String(command);
+  const normalizedArgs = Array.from(args ?? [], String);
+  if (!isAllowedTestBinary(normalizedCommand)) {
+    blockedProcessActions.push({
+      kind: "execFile",
+      command: normalizedCommand,
+      args: normalizedArgs,
+    });
+    throw Object.assign(new Error("external command blocked by test"), { code: "EPERM" });
+  }
+  return originalExecFileAsync(command, args, options);
+};
+childProcess.execFile = guardedExecFile;
+childProcess.spawn = (command, args, options) => {
+  const normalizedCommand = String(command);
+  const normalizedArgs = Array.from(args ?? [], String);
+  if (!isAllowedTestBinary(normalizedCommand)) {
+    blockedProcessActions.push({ kind: "spawn", command: normalizedCommand, args: normalizedArgs });
+    throw Object.assign(new Error("external process blocked by test"), { code: "EPERM" });
+  }
+  return originalSpawn(command, args, options);
+};
+process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+  blockedProcessActions.push({
+    kind: "process.kill",
+    command: String(pid),
+    args: signal === undefined ? [] : [String(signal)],
+  });
+  throw Object.assign(new Error("process signal blocked by test"), { code: "EPERM" });
+}) as typeof process.kill;
+syncBuiltinESMExports();
 
 const TEST_DATA_DIR = await fs.mkdtemp(path.join(os.tmpdir(), "omniroute-tailscale-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
@@ -19,6 +81,7 @@ const originalEnv = {
   funnelStatusJson: process.env.TAILSCALE_TEST_FUNNEL_STATUS_JSON,
   funnelOutput: process.env.TAILSCALE_TEST_FUNNEL_OUTPUT,
   funnelExitCode: process.env.TAILSCALE_TEST_FUNNEL_EXIT_CODE,
+  funnelResetExitCode: process.env.TAILSCALE_TEST_FUNNEL_RESET_EXIT_CODE,
   loginOutput: process.env.TAILSCALE_TEST_LOGIN_OUTPUT,
   loginExitCode: process.env.TAILSCALE_TEST_LOGIN_EXIT_CODE,
 };
@@ -44,7 +107,7 @@ if [[ "$args" == *"status --json"* ]]; then
   exit 1
 fi
 if [[ "$args" == *"funnel --bg reset"* ]]; then
-  exit 0
+  exit "\${TAILSCALE_TEST_FUNNEL_RESET_EXIT_CODE:-0}"
 fi
 if [[ "$args" == *"funnel --bg "* ]]; then
   if [[ -n "$TAILSCALE_TEST_FUNNEL_OUTPUT" ]]; then
@@ -73,11 +136,13 @@ function resetTailscaleTestEnv(fakeBinaryPath: string) {
   delete process.env.TAILSCALE_TEST_FUNNEL_STATUS_JSON;
   delete process.env.TAILSCALE_TEST_FUNNEL_OUTPUT;
   delete process.env.TAILSCALE_TEST_FUNNEL_EXIT_CODE;
+  delete process.env.TAILSCALE_TEST_FUNNEL_RESET_EXIT_CODE;
   delete process.env.TAILSCALE_TEST_LOGIN_OUTPUT;
   delete process.env.TAILSCALE_TEST_LOGIN_EXIT_CODE;
 }
 
 test.beforeEach(async () => {
+  blockedProcessActions.length = 0;
   const fakeBinaryPath = await createFakeTailscaleBinary();
   resetTailscaleTestEnv(fakeBinaryPath);
   mitmManager.clearCachedPassword();
@@ -89,6 +154,10 @@ test.beforeEach(async () => {
 });
 
 test.after(async () => {
+  process.kill = originalProcessKill;
+  childProcess.execFile = originalExecFile;
+  childProcess.spawn = originalSpawn;
+  syncBuiltinESMExports();
   dbCore.resetDbInstance();
   mitmManager.clearCachedPassword();
   if (originalEnv.tailscaleBin === undefined) delete process.env.TAILSCALE_BIN;
@@ -104,6 +173,9 @@ test.after(async () => {
   else process.env.TAILSCALE_TEST_FUNNEL_OUTPUT = originalEnv.funnelOutput;
   if (originalEnv.funnelExitCode === undefined) delete process.env.TAILSCALE_TEST_FUNNEL_EXIT_CODE;
   else process.env.TAILSCALE_TEST_FUNNEL_EXIT_CODE = originalEnv.funnelExitCode;
+  if (originalEnv.funnelResetExitCode === undefined)
+    delete process.env.TAILSCALE_TEST_FUNNEL_RESET_EXIT_CODE;
+  else process.env.TAILSCALE_TEST_FUNNEL_RESET_EXIT_CODE = originalEnv.funnelResetExitCode;
   if (originalEnv.loginOutput === undefined) delete process.env.TAILSCALE_TEST_LOGIN_OUTPUT;
   else process.env.TAILSCALE_TEST_LOGIN_OUTPUT = originalEnv.loginOutput;
   if (originalEnv.loginExitCode === undefined) delete process.env.TAILSCALE_TEST_LOGIN_EXIT_CODE;
@@ -212,10 +284,58 @@ test("enableTailscaleTunnel stores the funnel URL and disableTailscaleTunnel cle
   assert.equal(settingsAfterEnable.tailscaleEnabled, true);
   assert.equal(settingsAfterEnable.tailscaleUrl, "https://omniroute-demo.tail123.ts.net");
 
+  const tailscaleDir = path.join(TEST_DATA_DIR, "tailscale");
+  const statePath = path.join(tailscaleDir, "state.json");
+  const pidPath = path.join(tailscaleDir, ".tailscaled.pid");
+  const socketPath = path.join(tailscaleDir, "tailscaled.sock");
+  const stateBeforeDisable = JSON.parse(await fs.readFile(statePath, "utf8"));
+  stateBeforeDisable.daemonPid = 41009;
+  await fs.writeFile(statePath, `${JSON.stringify(stateBeforeDisable, null, 2)}\n`, "utf8");
+  await fs.writeFile(pidPath, "41009\n", "utf8");
+  await fs.writeFile(socketPath, "private socket sentinel", "utf8");
+
   const disabled = await tailscaleTunnel.disableTailscaleTunnel();
   const settingsAfterDisable = await settingsDb.getSettings();
 
   assert.equal(disabled.success, true);
   assert.equal(settingsAfterDisable.tailscaleEnabled, false);
   assert.equal(settingsAfterDisable.tailscaleUrl, "");
+  assert.equal(JSON.parse(await fs.readFile(statePath, "utf8")).daemonPid, 41009);
+  assert.equal(await fs.readFile(pidPath, "utf8"), "41009\n");
+  assert.equal(await fs.readFile(socketPath, "utf8"), "private socket sentinel");
+  assert.deepEqual(blockedProcessActions, []);
+});
+
+test("disableTailscaleTunnel preserves enabled settings when Funnel reset fails", async () => {
+  await settingsDb.updateSettings({
+    tailscaleEnabled: true,
+    tailscaleUrl: "https://omniroute-demo.tail123.ts.net",
+  });
+  process.env.TAILSCALE_TEST_FUNNEL_RESET_EXIT_CODE = "1";
+
+  await assert.rejects(() => tailscaleTunnel.disableTailscaleTunnel());
+
+  const settingsAfterFailure = await settingsDb.getSettings();
+  assert.equal(settingsAfterFailure.tailscaleEnabled, true);
+  assert.equal(settingsAfterFailure.tailscaleUrl, "https://omniroute-demo.tail123.ts.net");
+  assert.deepEqual(blockedProcessActions, []);
+});
+
+test("disableTailscaleTunnel stops Funnel without overwriting malformed ownership state", async () => {
+  await settingsDb.updateSettings({
+    tailscaleEnabled: true,
+    tailscaleUrl: "https://omniroute-demo.tail123.ts.net",
+  });
+  const tailscaleDir = path.join(TEST_DATA_DIR, "tailscale");
+  const statePath = path.join(tailscaleDir, "state.json");
+  await fs.mkdir(tailscaleDir, { recursive: true });
+  await fs.writeFile(statePath, "{malformed", "utf8");
+
+  await assert.rejects(() => tailscaleTunnel.disableTailscaleTunnel(), SyntaxError);
+
+  const settingsAfterFailure = await settingsDb.getSettings();
+  assert.equal(settingsAfterFailure.tailscaleEnabled, false);
+  assert.equal(settingsAfterFailure.tailscaleUrl, "");
+  assert.equal(await fs.readFile(statePath, "utf8"), "{malformed");
+  assert.deepEqual(blockedProcessActions, []);
 });


### PR DESCRIPTION
## Summary

- stop disabling the OmniRoute Funnel from terminating shared Tailscale daemons and active Tailscale SSH sessions
- require matching private PID records plus exact Linux process identity before an explicit managed-daemon signal
- revalidate identity before privileged TERM/KILL escalation and preserve ownership evidence on ambiguity or cleanup failure
- make Funnel reset failures visible without clearing enabled settings
- make Tailscale tests fail closed against real process execution

## Root cause

`stopTailscaleDaemon()` used `pkill -x tailscaled`. The unit test for `disableTailscaleTunnel()` reached that real fallback, so broad unit and coverage runs terminated every user-owned `tailscaled` process on the host, including Tailscale SSH session children and unrelated egress daemons.

## Validation

- focused Tailscale tests: 18 passed
- `npm run typecheck:core`
- targeted ESLint and Prettier checks
- `npm run check:changelog-integrity`
- `git diff --check`

The broad suite was intentionally not run on this host because the released test is the incident trigger and concurrent broad suites caused severe disk I/O pressure.
