### PR TITLE
fix(gamification): close the badge SSE stream when the signal is already aborted

### DIFF
--- a/changelog.d/fixes/13103-badge-sse-aborted-signal.md
+++ b/changelog.d/fixes/13103-badge-sse-aborted-signal.md
@@ -1,0 +1,1 @@
+Fix a timer leak in the badge notification SSE stream: when the request signal was already aborted before the stream started (a client that disconnects while the route is still awaiting auth), the abort listener never fired and both intervals ran for the lifetime of the process.

--- a/changelog.d/fixes/13103-badge-sse-aborted-signal.md
+++ b/changelog.d/fixes/13103-badge-sse-aborted-signal.md
@@ -1,1 +1,1 @@
-Fix a timer leak in the badge notification SSE stream: when the request signal was already aborted before the stream started (a client that disconnects while the route is still awaiting auth), the abort listener never fired and both intervals ran for the lifetime of the process.
+- **fix(gamification):** close the badge notification SSE stream when the request signal is already aborted before the stream starts — a client that disconnects while the route is still awaiting auth used to leave both the 2s unlock poll and the 15s heartbeat running for the lifetime of the process.

--- a/src/lib/gamification/notifications.ts
+++ b/src/lib/gamification/notifications.ts
@@ -110,6 +110,13 @@ export function createBadgeNotificationStream(
         }
       };
 
+      // A client that disconnects while the route is still awaiting auth
+      // arrives here already aborted, and "abort" will never fire again --
+      // the timers above would then run for the lifetime of the process.
+      if (signal?.aborted) {
+        cleanup();
+        return;
+      }
       if (signal) {
         signal.addEventListener("abort", cleanup);
       }

--- a/tests/unit/badge-sse-aborted-signal-13103.test.ts
+++ b/tests/unit/badge-sse-aborted-signal-13103.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { createBadgeNotificationStream } =
+  await import("../../src/lib/gamification/notifications.ts");
+
+/**
+ * Count timers created while `fn` runs and are still armed afterwards.
+ * The stream owns its handles privately, so this is the only way to observe them.
+ */
+async function withTimerAccounting<T>(
+  fn: () => Promise<T> | T
+): Promise<{ result: T; live: number }> {
+  const live = new Set<unknown>();
+  const realSet = globalThis.setInterval;
+  const realClear = globalThis.clearInterval;
+
+  globalThis.setInterval = ((...args: Parameters<typeof realSet>) => {
+    const handle = realSet(...args);
+    live.add(handle);
+    return handle;
+  }) as typeof realSet;
+
+  globalThis.clearInterval = ((handle: Parameters<typeof realClear>[0]) => {
+    if (handle !== undefined) live.delete(handle);
+    return realClear(handle);
+  }) as typeof realClear;
+
+  try {
+    const result = await fn();
+    // Let any pending abort/microtask cleanup run.
+    await new Promise((r) => setTimeout(r, 50));
+    // Stop whatever survived so a failing test cannot hang the runner.
+    for (const handle of live) realClear(handle as Parameters<typeof realClear>[0]);
+    return { result, live: live.size };
+  } finally {
+    globalThis.setInterval = realSet;
+    globalThis.clearInterval = realClear;
+  }
+}
+
+test("aborting after the stream starts clears both intervals (#13103)", async () => {
+  const controller = new AbortController();
+  const { live } = await withTimerAccounting(async () => {
+    createBadgeNotificationStream("key-normal", controller.signal);
+    controller.abort();
+  });
+  assert.equal(live, 0, "the normal lifecycle must clean up (baseline for the next test)");
+});
+
+test("a signal already aborted before start() must not leave timers running (#13103)", async () => {
+  const controller = new AbortController();
+  // The route awaits auth before building the stream, so a client that
+  // disconnects during that round-trip arrives here already aborted.
+  controller.abort();
+
+  const { live } = await withTimerAccounting(() => {
+    createBadgeNotificationStream("key-preaborted", controller.signal);
+  });
+
+  assert.equal(
+    live,
+    0,
+    `an already-aborted signal left ${live} interval(s) running for the lifetime of the process`
+  );
+});
+
+test("an already-aborted stream is closed rather than left enqueuing (#13103)", async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  const stream = createBadgeNotificationStream("key-closed", controller.signal);
+  const reader = stream.getReader();
+
+  // enqueue() into an unread stream only buffers -- it does not throw -- so a
+  // stream left open here would keep filling its queue with nobody draining it.
+  const { done } = await reader.read();
+  assert.equal(done, true, "the stream must be closed when the signal was already aborted");
+});


### PR DESCRIPTION
## Problem

`createBadgeNotificationStream` arms a 2s unlock poll and a 15s heartbeat, then registers cleanup with:

```ts
if (signal) {
  signal.addEventListener("abort", cleanup);
}
```

If the signal is **already aborted** when `start()` runs, that listener never fires and both intervals run for the lifetime of the process.

## Why it is reachable in production

`GET /api/gamification/notifications` awaits auth *before* building the stream:

```ts
const authErr = await requireManagementAuth(request);   // client can disconnect here
if (authErr) return authErr;
...
const stream = createBadgeNotificationStream(apiKeyId, request.signal);
```

A client that disconnects during that round-trip — page navigation, dashboard refresh, dropped connection — arrives with `request.signal.aborted === true`. Every such request permanently adds two timers.

`safeEnqueue` does not save it: enqueuing into a stream nobody reads only buffers, it does not throw, so `closed` is never set and the queue keeps growing alongside the timers.

## Fix

Check `signal.aborted` before arming and run the same `cleanup()` — the already-aborted case is now handled identically to the abort-later case. Seven lines, no behaviour change on the healthy path.

## Tests

Three tests that count live interval handles around the call:

1. **abort-later** — the healthy lifecycle. Passes *before* this fix too; it is there so a future change that breaks the normal path is still caught.
2. **already-aborted timers** — fails on the old code with `an already-aborted signal left 2 interval(s) running for the lifetime of the process`.
3. **already-aborted stream is closed** — fails on the old code by never reporting `done` (the assertion only lands after the 15s heartbeat, which is itself the evidence the stream was still live).

On the old code: **1 pass / 2 fail**. With the fix: **3 pass**, and test 3 drops from 15s to 0.8ms because the stream now closes immediately.

Full gamification + badge suite: **23/23 pass**. `tsc --noEmit` clean.

Fixes #13103

## Note

Found while auditing the WS/SSE layer after #13095. Same class — a teardown path that exists but is not reachable from every exit — but the missed path here is "the event already happened" rather than "this branch forgot to call it". The rest of the WS/SSE layer (`liveServer.ts`, the other `text/event-stream` routes, `embedWsProxy`) checked out clean.
