### PR TITLE
fix(db): release process listeners when a node:sqlite adapter closes

### DIFF
--- a/changelog.d/fixes/13108-nodesqlite-process-listener-leak.md
+++ b/changelog.d/fixes/13108-nodesqlite-process-listener-leak.md
@@ -1,0 +1,1 @@
+Fix a process-listener leak in the node:sqlite adapter: closing an adapter left its `beforeExit`/`SIGINT`/`SIGTERM` handlers attached to `process`, pinning the adapter and its database handle for the lifetime of the run. #7494 fixed the same bug for the sql.js adapter only.

--- a/changelog.d/fixes/13108-nodesqlite-process-listener-leak.md
+++ b/changelog.d/fixes/13108-nodesqlite-process-listener-leak.md
@@ -1,1 +1,1 @@
-Fix a process-listener leak in the node:sqlite adapter: closing an adapter left its `beforeExit`/`SIGINT`/`SIGTERM` handlers attached to `process`, pinning the adapter and its database handle for the lifetime of the run. #7494 fixed the same bug for the sql.js adapter only.
+- **fix(db):** release the `beforeExit`/`SIGINT`/`SIGTERM` handlers when a `node:sqlite` adapter closes, so a closed adapter and its database handle are no longer pinned to `process` for the lifetime of the run — the same treatment #7494 gave the sql.js adapter.

--- a/src/lib/db/adapters/nodeSqliteAdapter.ts
+++ b/src/lib/db/adapters/nodeSqliteAdapter.ts
@@ -35,26 +35,34 @@ export async function createNodeSqliteAdapter(filePath: string): Promise<SqliteA
   }, CHECKPOINT_INTERVAL_MS);
   (checkpointTimer as unknown as NodeJS.Timeout).unref?.();
 
+  // Declared before gracefulClose so the close path can detach them. Without
+  // this, every closed adapter leaves three closures pinned on `process` --
+  // each holding this adapter and its DatabaseSync handle alive -- and short-
+  // lived adapters (POST /api/db-backups/import opens one per request) trip
+  // Node's MaxListenersExceededWarning. #7494 fixed exactly this for sql.js.
+  const onBeforeExit = () => {
+    adapter.close();
+  };
+  const onSignal = () => {
+    adapter.close();
+    process.exit(0);
+  };
+
   function gracefulClose() {
     clearInterval(checkpointTimer as unknown as NodeJS.Timeout);
     try {
       db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
     } catch {}
+    process.removeListener("beforeExit", onBeforeExit);
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
   }
 
   const adapter = createNodeSqliteAdapterFromDatabase(db, filePath, gracefulClose);
 
-  process.once("beforeExit", () => {
-    adapter.close();
-  });
-  process.once("SIGINT", () => {
-    adapter.close();
-    process.exit(0);
-  });
-  process.once("SIGTERM", () => {
-    adapter.close();
-    process.exit(0);
-  });
+  process.once("beforeExit", onBeforeExit);
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
 
   return adapter;
 }

--- a/tests/unit/nodesqlite-process-listener-leak-13108.test.ts
+++ b/tests/unit/nodesqlite-process-listener-leak-13108.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const { createNodeSqliteAdapter } = await import("../../src/lib/db/adapters/nodeSqliteAdapter.ts");
+
+const SIGNALS = ["beforeExit", "SIGINT", "SIGTERM"] as const;
+
+function counts(): Record<string, number> {
+  return Object.fromEntries(SIGNALS.map((s) => [s, process.listenerCount(s)]));
+}
+
+function delta(before: Record<string, number>, after: Record<string, number>) {
+  return Object.fromEntries(SIGNALS.map((s) => [s, after[s] - before[s]]));
+}
+
+test("closing a node:sqlite adapter releases its process listeners (#13108)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "omniroute-dbleak-"));
+  const before = counts();
+
+  try {
+    // Short-lived adapters are a real pattern: POST /api/db-backups/import
+    // opens one per request purely to validate the uploaded file.
+    const N = 12;
+    for (let i = 0; i < N; i++) {
+      const adapter = await createNodeSqliteAdapter(join(dir, `probe-${i}.sqlite`));
+      adapter.close();
+    }
+
+    const leaked = delta(before, counts());
+    for (const signal of SIGNALS) {
+      assert.equal(
+        leaked[signal],
+        0,
+        `${N} open+close cycles retained ${leaked[signal]} "${signal}" listener(s) on process`
+      );
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an open node:sqlite adapter keeps its shutdown listeners registered (#13108)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "omniroute-dbleak-open-"));
+  const before = counts();
+  let adapter: Awaited<ReturnType<typeof createNodeSqliteAdapter>> | null = null;
+
+  try {
+    adapter = await createNodeSqliteAdapter(join(dir, "open.sqlite"));
+
+    // The fix must not detach eagerly: these handlers are what checkpoint the
+    // WAL on Ctrl-C, so they have to stay armed for as long as the db is open.
+    const armed = delta(before, counts());
+    for (const signal of SIGNALS) {
+      assert.equal(armed[signal], 1, `an open adapter must keep its "${signal}" handler`);
+    }
+  } finally {
+    adapter?.close();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

`createNodeSqliteAdapter` registers three process-level handlers per adapter and never removes them:

```ts
process.once("beforeExit", () => { adapter.close(); });
process.once("SIGINT",  () => { adapter.close(); process.exit(0); });
process.once("SIGTERM", () => { adapter.close(); process.exit(0); });
```

`adapter.close()` clears the checkpoint timer and checkpoints the WAL, but the three closures stay attached to `process`, each keeping the adapter and its `DatabaseSync` handle reachable for the lifetime of the run.

#7494 fixed exactly this for the sql.js adapter — `sqljsAdapter.ts` ends `gracefulClose()` by detaching its three listeners, with a comment explaining that otherwise "a closed adapter's whole closure stays pinned in memory forever by these 3 process-level listeners". The node:sqlite adapter — the default driver on Node whenever better-sqlite3 is unavailable, notably the packaged Electron app — never got the same treatment.

## Why it is reachable

`POST /api/db-backups/import` opens a throwaway adapter per request to validate the uploaded file, and closes it correctly on every branch. The close is not the problem — the close does not release the listeners. Every import request permanently adds three.

## Fix

Hoist the handlers into named references so `gracefulClose()` can detach them, matching `sqljsAdapter.ts`.

## Tests

**Test 1** opens and closes 12 adapters and asserts the process listener count returns to its starting value. On the old code:

```
AssertionError: 12 open+close cycles retained 12 "beforeExit" listener(s) on process
```

A standalone repro of both adapters side by side shows the contrast, including Node's own warning:

```
after 20 sql.js  open+close: { beforeExit: 0,  SIGINT: 0,  SIGTERM: 0  }
after 20 node:sqlite open+close: { beforeExit: 20, SIGINT: 20, SIGTERM: 20 }

MaxListenersExceededWarning: 11 beforeExit listeners added to [process]
```

**Test 2** pins the opposite direction: an adapter that is still open must keep its handlers armed, since they are what checkpoints the WAL on Ctrl-C. It passes both before and after, so a fix that detached eagerly would be caught rather than silently accepted.

Result: **1 fail / 1 pass** before, **2 pass** after. `tsc --noEmit` clean.

## Note on the suite

`tests/unit/cli-sqlite-construction-fallback-8826.test.ts` fails in my environment with `ERR_INVALID_MODULE_SPECIFIER` on a `\C:\...` fixture path. It fails identically on a clean `release/v3.8.51` checkout with my change stashed, so it is a pre-existing Windows path issue in that test, unrelated to this PR. The rest of the sqlite/adapter/driver suites: 58 pass.

Fixes #13108
