### PR TITLE
fix(translator): treat contentSchema and unevaluatedItems as schema slots

### DIFF
--- a/changelog.d/fixes/13110-schema-slot-keys.md
+++ b/changelog.d/fixes/13110-schema-slot-keys.md
@@ -1,0 +1,1 @@
+- **fix(translator):** `contentSchema` and `unevaluatedItems` are now treated as subschema positions by the tool-schema sanitizer, so a truncation placeholder in either is replaced with a permissive schema instead of being forwarded as a string ([#13110](https://github.com/diegosouzapw/OmniRoute/pull/13110))

--- a/open-sse/translator/helpers/schemaCoercion.ts
+++ b/open-sse/translator/helpers/schemaCoercion.ts
@@ -514,6 +514,13 @@ const SCHEMA_SLOT_KEYS = [
   "else",
   "unevaluatedProperties",
   "additionalItems",
+  // draft 2020-12 applicators whose value is a schema too. Without them a
+  // placeholder in either position falls through to the scalar branch at the
+  // bottom of the walker and is forwarded as a string, which is the shape this
+  // sanitizer exists to remove. The opencode plugin's own walker
+  // (@omniroute/opencode-plugin-v2/src/shared/gemini.ts) lists both.
+  "contentSchema",
+  "unevaluatedItems",
 ];
 
 function coerceIndexedObjectToArray(value: unknown): unknown[] | null {

--- a/tests/unit/translator/schema-slot-keys-drift.test.ts
+++ b/tests/unit/translator/schema-slot-keys-drift.test.ts
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stripInvalidSchemaConstructs } from "../../../open-sse/translator/helpers/schemaCoercion.ts";
+
+// Every draft 2020-12 keyword whose value is a schema rather than an annotation.
+// A placeholder in any of them has to become the permissive {}: forwarding the
+// string is invalid JSON Schema and is the 400 this sanitizer exists to prevent.
+const SCHEMA_SLOTS = [
+  "items",
+  "additionalProperties",
+  "propertyNames",
+  "contains",
+  "not",
+  "if",
+  "then",
+  "else",
+  "unevaluatedProperties",
+  "additionalItems",
+  "contentSchema",
+  "unevaluatedItems",
+];
+
+// Produced by logTruncation.ts once a schema is deeper than the log depth limit.
+const PLACEHOLDERS = ["[MaxDepth]", "[Truncated]", "[Circular]", "[Object]", "[Array]"];
+
+function strip(schema: unknown) {
+  return stripInvalidSchemaConstructs(schema) as Record<string, unknown>;
+}
+
+for (const key of SCHEMA_SLOTS) {
+  test(`a placeholder in ${key} becomes a permissive schema`, () => {
+    for (const placeholder of PLACEHOLDERS) {
+      const out = strip({ type: "object", [key]: placeholder });
+      assert.deepEqual(out[key], {}, `${key} kept ${placeholder}`);
+    }
+  });
+}
+
+test("every slot is covered by the same rule, none left behind", () => {
+  // The point of the list above is that it is complete. If a slot is dropped
+  // from the walker, the loop above catches it; this catches the reverse -- a
+  // slot handled by the walker but missing from this list would make the loop
+  // silently smaller.
+  const surviving = SCHEMA_SLOTS.filter((key) => {
+    const out = strip({ [key]: "[MaxDepth]" });
+    return typeof out[key] === "string";
+  });
+  assert.deepEqual(surviving, []);
+});
+
+test("a boolean schema is preserved, not widened", () => {
+  // `contentSchema: false` and `unevaluatedItems: false` are valid and
+  // restrictive; turning either into {} would invite the model to invent data.
+  for (const key of ["contentSchema", "unevaluatedItems"]) {
+    assert.equal(strip({ [key]: false })[key], false);
+    assert.equal(strip({ [key]: true })[key], true);
+  }
+});
+
+test("a nested subschema is still walked", () => {
+  const out = strip({
+    contentSchema: { type: "object", properties: { a: { enum: "[MaxDepth]" } } },
+    unevaluatedItems: { items: "[MaxDepth]" },
+  });
+  const content = out.contentSchema as Record<string, Record<string, unknown>>;
+  assert.deepEqual(content.properties.a, {}, "an invalid enum is dropped, leaving {}");
+  assert.deepEqual(out.unevaluatedItems, { items: {} });
+});
+
+test("a string that is not a placeholder is left alone", () => {
+  // Only the placeholder shape is coerced. Anything else stays exactly as it
+  // arrived, so a schema this sanitizer does not understand is forwarded rather
+  // than rewritten.
+  for (const key of ["contentSchema", "unevaluatedItems"]) {
+    assert.equal(strip({ [key]: "text/plain" })[key], "text/plain");
+  }
+});
+
+test("a property named like a slot keyword is not treated as one", () => {
+  // Property names live in their own space: a tool whose parameter is called
+  // contentSchema must keep its description string.
+  const out = strip({
+    type: "object",
+    properties: { contentSchema: "[MaxDepth]", unevaluatedItems: { type: "string" } },
+  });
+  const properties = out.properties as Record<string, unknown>;
+  assert.deepEqual(
+    properties.contentSchema,
+    {},
+    "a placeholder property value is still a schema slot"
+  );
+  assert.deepEqual(properties.unevaluatedItems, { type: "string" });
+});


### PR DESCRIPTION
## The bug

`stripInvalidSchemaConstructs()` replaces a truncation placeholder with the permissive `{}` in every position where a subschema belongs. Forwarding the string instead is invalid JSON Schema, and that 400 is the thing this sanitizer exists to prevent.

`SCHEMA_SLOT_KEYS` listed ten of the draft 2020-12 applicators and missed two. Measured on `release/v3.8.51`, feeding `{ type: "object", [key]: "[MaxDepth]" }` through the walker one keyword at a time:

| keyword | before |
| --- | --- |
| `items`, `additionalProperties`, `propertyNames`, `contains`, `not`, `if`, `then`, `else`, `unevaluatedProperties`, `additionalItems` | `{}` |
| `contentSchema` | **`"[MaxDepth]"`** |
| `unevaluatedItems` | **`"[MaxDepth]"`** |

Those two fall through to the scalar branch at the bottom of the walker — the one that deliberately leaves annotation keywords (`description`, `title`, `pattern`, `format`) as strings — and are forwarded untouched.

The placeholders are real: `logTruncation.ts` emits `[MaxDepth]`, `[Truncated]`, `[Circular]`, `[Object]` and `[Array]` once a schema is deeper than the log depth limit, and `SCHEMA_PLACEHOLDER_PATTERN` here matches all five.

## The repository already disagrees with itself

The opencode plugin's own walker lists both:

```ts
// @omniroute/opencode-plugin-v2/src/shared/gemini.ts
/** Keys whose value is itself a schema. */
const SCHEMA_VALUE_KEYS = [
  "items", "additionalItems", "contains", "not", "if", "then", "else",
  "propertyNames", "contentSchema", "unevaluatedItems", "unevaluatedProperties",
];
```

Two lists of the same thing, kept in step by hand. They agreed on ten entries and diverged on two, and nothing failed when they did — both files compile, both walkers answer, they just answer differently.

## The change

Two entries. Nothing else about those keywords changes: an object or array in either position was already recursed into by the fallback branch, a boolean is still preserved rather than widened to `{}` (`contentSchema: false` is restrictive and must stay so), and a string that is not a placeholder is still forwarded untouched.

## Tests

`tests/unit/translator/schema-slot-keys-drift.test.ts`, 17 tests. Rather than testing the two new keywords alone, it drives **all twelve** slots through all five placeholder shapes, so the next keyword to go missing fails here too. It also pins the three properties that keep the fix from being a widening: booleans preserved, non-placeholder strings untouched, and a *property* named `contentSchema` still treated as a property.

| mutation | result |
| --- | --- |
| remove both keys again | **3 fail** |
| remove only `unevaluatedItems` | **2 fail** |

The second mutation matters: it shows the coverage test is not an all-or-nothing check.

`tests/unit/translator/schema-coercion.test.ts`, `bailian-schema-validation`, `agentSkills-schemas` — 32 passed. `eslint --suppressions-location config/quality/eslint-suppressions.json` clean.

Independent of #13101 and #13104; different files.
