### PR TITLE
fix(logs): dedupe a pending entry already persisted to call_logs

### DIFF
--- a/src/app/api/usage/call-logs/route.ts
+++ b/src/app/api/usage/call-logs/route.ts
@@ -112,6 +112,14 @@ export function buildCallLogListRows({
   const persistedIds = new Set(logs.map((log: any) => log.id).filter(Boolean));
 
   for (const detail of pendingDetails) {
+    // A request that just finished can be persisted to call_logs (landing in
+    // `logs`) a moment before its in-memory pending-tracker entry is removed
+    // -- without this check, that one id appeared in both `activeEntries`
+    // and `logs` in the same response, producing a duplicate React key in
+    // the request logger's table ("Encountered two children with the same
+    // key"). completedEntries already guards against this same race below;
+    // this mirrors it for the pending map too.
+    if (persistedIds.has(detail.id)) continue;
     activeEntries.push({
       id: detail.id,
       timestamp: new Date(detail.startedAt).toISOString(),

--- a/tests/unit/call-logs-correlation-sort.test.ts
+++ b/tests/unit/call-logs-correlation-sort.test.ts
@@ -128,3 +128,31 @@ test("buildCallLogListRows: dedupes completed in-memory entries already persiste
   // persisted row wins (no `completed` flag)
   assert.equal(rows[0].completed, undefined);
 });
+
+test("buildCallLogListRows: dedupes a pending in-memory entry already persisted to the DB", () => {
+  // A request that just finished can be persisted to call_logs a moment
+  // before its in-memory pending-tracker entry is removed. Without a guard,
+  // that one id appeared in both activeEntries and logs in the same
+  // response -- a duplicate React key in the request logger's table.
+  const now = 5_000_000;
+  const rows = buildCallLogListRows({
+    logs: [{ id: "dup-pending-1", timestamp: new Date(now - 1_000).toISOString() }],
+    connections: [],
+    pendingDetails: [
+      {
+        id: "dup-pending-1",
+        startedAt: now - 3_000,
+        provider: "openai",
+        model: "gpt-4o",
+        connectionId: "conn-1",
+      },
+    ],
+    completedDetails: [],
+    now,
+  });
+
+  assert.equal(rows.length, 1, "the id must appear exactly once, not once per source");
+  assert.equal(rows[0].id, "dup-pending-1");
+  // persisted row wins (no `active` flag)
+  assert.equal(rows[0].active, undefined);
+});


### PR DESCRIPTION
## What Problem This Solves

`/dashboard/logs` occasionally threw a React console error:

```
Encountered two children with the same key, `<id>`. Keys should be unique
so that components maintain their identity across updates. Non-unique
keys may cause children to be duplicated and/or omitted -- the behavior
is unsupported and could change in a future version.

    at RequestLoggerV2.tsx:1321:23  (<tr key={log.id}>)
```

## Root Cause

`buildCallLogListRows()` merges three sources into one API response:
in-flight ("pending") requests tracked in memory, recently-completed
in-memory entries, and persisted `call_logs` rows.

The completed-entries loop already guards against double-counting an id
that had already landed in the persisted rows or the pending map:

```ts
for (const detail of completedDetails) {
  if (persistedIds.has(detail.id) || pendingIds.has(detail.id)) continue;
  ...
```

The pending-entries loop had **no equivalent guard**. A request that just
finished can be written to `call_logs` a moment before its in-memory
pending-tracker entry is removed. In that window, the same id appeared in
both `activeEntries` and `logs` in a single response -- the exact
duplicate key React reported.

## Fix

Mirror the same `persistedIds.has(detail.id)` guard already used for
`completedEntries` onto the `pendingDetails` loop.

## Evidence

New regression test proves the id appears exactly once once both sources
report it, and that the persisted row wins (no stale `active: true`
flag). Confirmed it fails against the pre-fix code (returns 2 rows for
the same id) and passes after (1 row).

```
$ node --test tests/unit/call-logs-correlation-sort.test.ts
tests 5, pass 5, fail 0

$ node --test tests/unit/call-log-provider-display.test.ts tests/unit/request-logger-endpoints.test.ts
tests 40, pass 40, fail 0
```

- `eslint`: clean (3 pre-existing, unrelated `any` lint errors in the test
  file, confirmed present on unmodified `release/v3.8.51` too -- not
  touched by this PR)
- `tsc --noEmit`: no errors in touched files
