### PR TITLE
fix(cli-helper): clear the log stream timeout on the abort path

### DIFF
--- a/changelog.d/fixes/13113-logstream-timer-leak.md
+++ b/changelog.d/fixes/13113-logstream-timer-leak.md
@@ -1,1 +1,1 @@
-Fix a timer leak in `createLogStream`: `stop()` aborts the in-flight fetch and returns through the `signal.aborted` branch, which skipped `clearTimeout`, leaving an armed timer per stopped stream. The stream reader is now also cancelled when the read loop exits early.
+- **fix(cli-helper):** clear the `createLogStream` timeout on the abort path — `stop()` aborts the in-flight fetch and returned through the `signal.aborted` branch, which skipped `clearTimeout` and left an armed timer per stopped stream. The stream reader is now also cancelled when the read loop exits early.

--- a/changelog.d/fixes/13113-logstream-timer-leak.md
+++ b/changelog.d/fixes/13113-logstream-timer-leak.md
@@ -1,0 +1,1 @@
+Fix a timer leak in `createLogStream`: `stop()` aborts the in-flight fetch and returns through the `signal.aborted` branch, which skipped `clearTimeout`, leaving an armed timer per stopped stream. The stream reader is now also cancelled when the read loop exits early.

--- a/src/lib/cli-helper/log-streamer.ts
+++ b/src/lib/cli-helper/log-streamer.ts
@@ -38,30 +38,37 @@ export function createLogStream(options: LogStreamOptions = {}): LogStream {
 
         if (!response.ok) {
           controller.error(new Error(`HTTP ${response.status}: ${response.statusText}`));
-          clearTimeout(timeoutId);
           return;
         }
 
         if (!response.body) {
           controller.error(new Error("Response body is null"));
-          clearTimeout(timeoutId);
           return;
         }
 
         const reader = response.body.getReader();
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (signal.aborted) break;
-          controller.enqueue(value);
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (signal.aborted) break;
+            controller.enqueue(value);
+          }
+        } finally {
+          // Leaving the loop early (abort/throw) otherwise keeps the body locked
+          // and its socket held until GC.
+          await reader.cancel().catch(() => {});
         }
 
         controller.close();
-        clearTimeout(timeoutId);
       } catch (err) {
         if (signal.aborted) return; // Expected stop
         controller.error(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        // `stop()` aborts mid-fetch and returns through the `signal.aborted`
+        // branch above, so clearing the timer on the individual exit paths
+        // misses the one path stop() is built to take.
         clearTimeout(timeoutId);
       }
     },

--- a/tests/unit/logstream-timer-leak-13113.test.ts
+++ b/tests/unit/logstream-timer-leak-13113.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { createLogStream } from "../../src/lib/cli-helper/log-streamer.ts";
+
+function armedTimers(): number {
+  return process.getActiveResourcesInfo().filter((r) => r === "Timeout").length;
+}
+
+async function startServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  const open: http.ServerResponse[] = [];
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.write("log line\n");
+    // Deliberately left open: stop() must land while the stream is still live.
+    open.push(res);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    port,
+    close: async () => {
+      for (const res of open) res.end();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+test("stop() clears the stream timeout timer", async () => {
+  const server = await startServer();
+  try {
+    const before = armedTimers();
+
+    const streams = Array.from({ length: 8 }, () =>
+      createLogStream({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        follow: true,
+        // Long enough that a leaked timer is still armed when we measure.
+        timeout: 120_000,
+      })
+    );
+
+    // Begin consuming so start() runs and the fetch is in flight.
+    for (const s of streams) {
+      void s.stream
+        .getReader()
+        .read()
+        .catch(() => {});
+    }
+    await new Promise((r) => setTimeout(r, 300));
+
+    for (const s of streams) s.stop();
+    await new Promise((r) => setTimeout(r, 500));
+
+    const after = armedTimers();
+    assert.ok(
+      after <= before,
+      `stopping 8 streams retained ${after - before} armed timer(s) ` +
+        `(before=${before} after=${after}); stop() must clear the timeout`
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test("a stream that ends normally still clears its timer", async () => {
+  const finished = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("done\n");
+  });
+  await new Promise<void>((resolve) => finished.listen(0, "127.0.0.1", resolve));
+  const { port } = finished.address() as AddressInfo;
+
+  try {
+    const before = armedTimers();
+    const { stream } = createLogStream({
+      baseUrl: `http://127.0.0.1:${port}`,
+      follow: false,
+      timeout: 120_000,
+    });
+
+    const reader = stream.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.ok(
+      armedTimers() <= before,
+      "a normally-completed stream must not leave its timeout armed"
+    );
+  } finally {
+    await new Promise<void>((resolve) => finished.close(() => resolve()));
+  }
+});


### PR DESCRIPTION
## Problem

`createLogStream` (`src/lib/cli-helper/log-streamer.ts`) arms a timeout timer per stream and clears it on every exit path except one — the abort path, which is how `stop()` ends a stream.

```ts
const timeoutId = setTimeout(() => { ... }, timeout);

try {
  const response = await fetch(url, { signal, headers });
  ...
  while (true) {
    const { done, value } = await reader.read();
    if (done) break;
    if (signal.aborted) break;      // (2) reader never cancelled
    controller.enqueue(value);
  }
  controller.close();
  clearTimeout(timeoutId);
} catch (err) {
  if (signal.aborted) return;       // (1) clearTimeout skipped
  controller.error(...);
  clearTimeout(timeoutId);
}
```

**(1)** `stop()` calls `controller.abort()`, the in-flight `fetch`/`read` rejects with an AbortError, and the catch returns at `if (signal.aborted) return;` — before `clearTimeout`. Each stopped stream leaves an armed timer holding the stream-controller closure until it fires (30s default, caller-configurable and unbounded).

**(2)** `break` on `signal.aborted` exits the loop without `reader.cancel()`, so the body stays locked and its undici socket is held until GC.

## Why it matters

`follow: true` streams are long-lived and stopped explicitly — this is the normal lifecycle, not an edge case. A dashboard that restarts the log stream on filter changes arms one surviving timer per restart.

## Repro

8 follow-mode streams started against a server that keeps the response open, then stopped:

```
AssertionError: stopping 8 streams retained 8 armed timer(s) (before=0 after=8); stop() must clear the timeout
```

Measured with `process.getActiveResourcesInfo()`.

## Fix

Move `clearTimeout` into a `finally` so no exit path can skip it, and cancel the reader when the read loop exits early.

## Tests

- **Test 1** — the repro above: 8 streams stopped, armed-timer count must return to baseline. Fails before, passes after.
- **Test 2** — a stream that ends normally must also leave no armed timer. Passes both before and after, so a fix that cleared the timer too eagerly (breaking the real timeout) would be caught rather than silently accepted.

Result: **1 fail / 1 pass** before, **2 pass** after. `tsc -p tsconfig.json --noEmit` clean.

## Note on the surrounding suite

`tests/unit/cli-helper/*` shows 57 pass / 10 fail in my environment (config-generator, getHermesHome, tool-detector). Identical 57/10 on a clean `release/v3.8.51` checkout with my change stashed — pre-existing and unrelated to this PR.

Fixes #13113
