### PR TITLE
fix(resilience): non-SSE streaming and zero completion_tokens bypass response validation (#10404 follow-up)

### DIFF
--- a/changelog.d/fixes/13129-non-sse-zero-token-validation.md
+++ b/changelog.d/fixes/13129-non-sse-zero-token-validation.md
@@ -1,0 +1,1 @@
+- **fix(resilience):** non-SSE streaming responses (stream:true + application/json) and HTTP 200s reporting `completion_tokens: 0` with non-empty busy/error content no longer bypass combo response validation — empty/no-op completions fail over to the next target instead of being accepted ([#13129](https://github.com/diegosouzapw/OmniRoute/pull/13129)) - thanks @trespassmk

--- a/open-sse/services/combo/validateQuality.ts
+++ b/open-sse/services/combo/validateQuality.ts
@@ -294,7 +294,15 @@ export async function validateResponseQuality(
   if (isStreaming) {
     const contentType = response.headers.get("content-type") || "";
     if (!contentType.includes("text/event-stream")) {
-      return { valid: true };
+      // Issue #10404 follow-up: providers that honour stream:true but answer
+      // with application/json (gateway/shim providers such as ccwu/minimax-m3)
+      // used to short-circuit here as valid without ANY check — a 200 carrying
+      // content:null or completion_tokens:0 bypassed the JSON validation path
+      // below and the combo consumed an empty/no-op turn. Re-validate these
+      // bodies through the non-streaming JSON path instead. Callers pass a
+      // quality clone in, so buffering it here never disturbs the original
+      // response they forward to the client on a valid verdict.
+      return validateResponseQuality(response, false, log, responseValidation);
     }
 
     if (!response.body) {
@@ -780,6 +788,28 @@ export async function validateResponseQuality(
 
   if (!hasContent && !hasToolCalls) {
     return { valid: false, reason: "empty content and no tool_calls in response" };
+  }
+
+  // Issue #10404 follow-up (non-SSE path): some providers (e.g. the
+  // ccwu/minimax-m3 gateway during high load) answer HTTP 200 with
+  // finish_reason:"stop" and a busy/error MESSAGE string in content but
+  // completion_tokens:0 — hasContent above is true (non-empty prose), so the
+  // empty guard can't catch it, yet zero output tokens means no generation
+  // actually happened. Fail over to the next combo target. Gated on usage
+  // being present AND reporting a numeric 0 so providers that omit usage
+  // entirely (Anthropic-compatible shims, #12968) and reasoning_content-only
+  // turns (#3587: completion_tokens:0 there is a known-safe case) are never
+  // rejected by this check.
+  const usageRecord = json?.usage as Record<string, unknown> | undefined;
+  const reportedCompletionTokens =
+    usageRecord && typeof usageRecord.completion_tokens === "number"
+      ? (usageRecord.completion_tokens as number)
+      : -1;
+  if (reportedCompletionTokens === 0 && !hasToolCalls && !hasReasoningContent) {
+    return {
+      valid: false,
+      reason: "completion_tokens is 0 — no output generated",
+    };
   }
 
   // Issue #3587: Reasoning models (deepseek-v4-flash, nemotron, etc.) may consume

--- a/tests/unit/validate-response-quality.test.ts
+++ b/tests/unit/validate-response-quality.test.ts
@@ -45,7 +45,10 @@ test("returns valid=false for non-JSON non-SSE text", async () => {
 
 test("returns valid=false for Responses API bodies with no output items", async () => {
   const res = await validateResponseQuality(
-    makeResponse(JSON.stringify({ object: "response", status: "completed", output: [] }), "application/json"),
+    makeResponse(
+      JSON.stringify({ object: "response", status: "completed", output: [] }),
+      "application/json"
+    ),
     false,
     {}
   );
@@ -165,4 +168,105 @@ test("streaming OpenAI finish_reason-only chunk (no content delta) → invalid (
   const verdict = await validateResponseQuality(res, true, {});
   assert.strictEqual(verdict.valid, false);
   assert.match(verdict.reason ?? "", /streaming openai terminated with empty completion/);
+});
+
+// ── #10404 follow-up: non-SSE streaming + zero completion_tokens bypass validation ──
+//
+// Two gaps that #10404/PR #10744 left open in the JSON path:
+//  1. Providers that honour stream:true but answer with application/json
+//     (gateway/shim providers such as ccwu/minimax-m3) used to short-circuit
+//     as valid without ANY check.
+//  2. A busy/error MESSAGE string in content alongside completion_tokens:0 is
+//     non-empty (so the empty-content guard can't catch it) but represents no
+//     actual generation.
+
+function makeJsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+test("non-SSE streaming (stream:true + application/json) with content:null + completion_tokens:0 → invalid (#10404 follow-up)", async () => {
+  const res = makeJsonResponse({
+    choices: [{ message: { content: null }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 10199, completion_tokens: 0 },
+  });
+  const verdict = await validateResponseQuality(res, true, {});
+  assert.strictEqual(verdict.valid, false);
+  assert.match(verdict.reason ?? "", /empty content/i);
+});
+
+test("non-SSE streaming busy-message content + completion_tokens:0 → invalid (#10404 follow-up)", async () => {
+  const res = makeJsonResponse({
+    choices: [
+      {
+        message: {
+          content: "【资源繁忙通知】当前模型请求量较大，暂无可用资源，请稍后重试。",
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 10199, completion_tokens: 0 },
+  });
+  const verdict = await validateResponseQuality(res, true, {});
+  assert.strictEqual(verdict.valid, false);
+  assert.match(verdict.reason ?? "", /completion_tokens is 0/);
+});
+
+test("non-SSE streaming with real content + completion_tokens > 0 → valid", async () => {
+  const res = makeJsonResponse({
+    choices: [{ message: { content: "Hello from the model." }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 10, completion_tokens: 12 },
+  });
+  const verdict = await validateResponseQuality(res, true, {});
+  assert.strictEqual(verdict.valid, true);
+});
+
+test("non-SSE streaming without usage data → still valid (no false rejection for Anthropic-style shims, #12968)", async () => {
+  const res = makeJsonResponse({
+    choices: [{ message: { content: "Real answer." }, finish_reason: "stop" }],
+  });
+  const verdict = await validateResponseQuality(res, true, {});
+  assert.strictEqual(verdict.valid, true);
+});
+
+test("tool_calls-only response with completion_tokens:0 → valid (tool_calls count as output)", async () => {
+  const res = makeJsonResponse({
+    choices: [
+      {
+        message: {
+          content: null,
+          tool_calls: [{ id: "c1", type: "function", function: { name: "Bash", arguments: "{}" } }],
+        },
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 0 },
+  });
+  const verdict = await validateResponseQuality(res, false, {});
+  assert.strictEqual(verdict.valid, true);
+});
+
+test("non-streaming busy-message content + completion_tokens:0 → invalid (same #10404 follow-up guard)", async () => {
+  const res = makeJsonResponse({
+    choices: [{ message: { content: "资源繁忙，请稍后重试。" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 100, completion_tokens: 0 },
+  });
+  const verdict = await validateResponseQuality(res, false, {});
+  assert.strictEqual(verdict.valid, false);
+  assert.match(verdict.reason ?? "", /completion_tokens is 0/);
+});
+
+test("reasoning_content-only turn with completion_tokens:0 stays valid (guard, #3587 safe-zero case)", async () => {
+  const res = makeJsonResponse({
+    choices: [
+      {
+        message: { content: null, reasoning_content: "Tiny reasoning" },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { completion_tokens: 0, reasoning_tokens: 0 },
+  });
+  const verdict = await validateResponseQuality(res, false, {});
+  assert.strictEqual(verdict.valid, true);
 });


### PR DESCRIPTION
Follow-up to #10404 / PR #10744, which fixed the **SSE** path only. Two gaps in the response-quality JSON path let providers return HTTP 200 with no real output and still have the combo accept the turn instead of failing over to the next target.

## Gap 1 — non-SSE streaming bypasses all validation

`validateResponseQuality` short-circuited with `return { valid: true }` as soon as a `stream:true` response's content-type was not `text/event-stream`. A provider answering `stream:true` + `application/json` with `content:null` / `completion_tokens:0` (common with gateway/shim providers such as the `ccwu/minimax-m3` gateway) never reached the JSON content checks.

**Fix:** such bodies are re-validated through the non-streaming JSON path. Callers already pass a quality *clone* (see `executeTargetAttempt.ts`), so buffering the body here never disturbs the original response forwarded to the client on a valid verdict.

## Gap 2 — zero completion_tokens with non-null content not caught

The #10404 fix catches `content:null` + zero tokens. Some providers return a busy/error **message string** in `content` alongside `completion_tokens: 0` (e.g. `【资源繁忙通知】` from `ccwu/minimax-m3` during high load). `hasContent` is true for that prose, so the empty-content guard never fires and the no-op turn is accepted.

**Fix:** reject when `usage.completion_tokens === 0`, no `tool_calls`, and no `reasoning_content`. Gated on `usage` being **present and reporting a numeric 0** so:
- providers that omit `usage` entirely (Anthropic-compatible shims, cf. #12968) are never rejected, and
- `reasoning_content`-only turns keep the existing #3587 contract (`completion_tokens:0` there is a known-safe case — existing test `#3587 edge: completion_tokens=0 → safe`).

## Safety

- **SSE streams:** untouched — bounded-peek path unchanged.
- **Non-streaming:** only the new zero-token guard applies.
- **tool_calls-only:** excluded via `!hasToolCalls`.
- **Responses API:** returns before the changed branch.

## Tests

Added 8 unit tests in `tests/unit/validate-response-quality.test.ts` covering both gaps and the guards (null content + 0 tokens, busy-message + 0 tokens, real content + >0 tokens valid, missing `usage` stays valid, tool_calls-only + 0 tokens valid, non-streaming busy-message, reasoning-only + 0 tokens stays valid). All 60 validator/reasoning/streaming tests in the affected suites pass; eslint + `typecheck:core` clean on the changed files.

## Note for reviewers

The zero-token rejection assumes providers honestly report `completion_tokens`. If you'd prefer to also require `finish_reason === "stop"`, I can narrow the gate.
