### PR TITLE
feat(usage): show OpenRouter credit balance in Provider Quota

### DIFF
--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -89,6 +89,8 @@ const PROVIDER_LIMITS_APIKEY_PROVIDERS = new Set([
   "qwen-cloud-token-plan",
   // AgentRouter (New-API) console System Access Token + New-Api-User id (providerSpecificData)
   "agentrouter",
+  // OpenRouter API key → GET /api/v1/key + /api/v1/credits (USD balance, credit cap)
+  "openrouter",
 ]);
 const DEFAULT_PROVIDER_LIMITS_SYNC_INTERVAL_MINUTES = 70;
 const PROVIDER_LIMITS_AUTO_SYNC_SETTING_KEY = "provider_limits_auto_sync_last_run";
@@ -205,11 +207,7 @@ export async function refreshAndUpdateCredentials(
   connection: ProviderConnectionLike,
   opts: CredentialRefreshOptions = {}
 ) {
-  return refreshAndUpdateCredentialsWithResolver(
-    connection,
-    getCredentialRefreshExecutor,
-    opts
-  );
+  return refreshAndUpdateCredentialsWithResolver(connection, getCredentialRefreshExecutor, opts);
 }
 
 function isUsageAuthError(message: unknown): boolean {
@@ -396,7 +394,6 @@ export function shouldClearErrorStateOnValidProbe(
  * — keeps the connection locked, matching the kimi-coding partial-refresh
  * semantics.
  */
-
 
 /**
  * Is an explicit cooldown still in the future?

--- a/src/shared/constants/providers.ts
+++ b/src/shared/constants/providers.ts
@@ -75,7 +75,6 @@ export function getProviderConnectionFamilyIds(providerId: unknown): readonly st
 
 // Web / Cookie Providers
 
-
 // API Key Providers
 
 // Sub-categories within APIKEY_PROVIDERS (used by dashboard and catalog views).
@@ -145,7 +144,6 @@ export const AGGREGATOR_PROVIDER_IDS = new Set([
   "helixmind",
   "tabitoken",
   "logfare",
-
 ]);
 
 export const ENTERPRISE_CLOUD_PROVIDER_IDS = new Set([
@@ -539,6 +537,8 @@ export const USAGE_SUPPORTED_PROVIDERS = [
   "qwen-cloud-token-plan",
   // AgentRouter (New-API) console balance quota (consoleApiKey + newApiUserId)
   "agentrouter",
+  // OpenRouter /key + /credits USD balance (#13080 UI gap — fetcher existed, list entry missing)
+  "openrouter",
 ];
 
 // ── Zod validation, lazily on first AI_PROVIDERS access (perf: skips the walk

--- a/tests/unit/openrouter-provider-limits-13080.test.ts
+++ b/tests/unit/openrouter-provider-limits-13080.test.ts
@@ -1,0 +1,71 @@
+/**
+ * openrouter-provider-limits-13080.test.ts
+ *
+ * #13080 asked for a credit balance in Provider Quota. For OpenRouter the
+ * fetcher already computed one — `getOpenrouterUsage` returns a USD `credits`
+ * quota, `services/usage.ts` dispatches `case "openrouter"`, and
+ * USAGE_FETCHER_PROVIDERS declares it wired — but neither app-side gate listed
+ * it, so `isSupportedUsageConnection` refused every OpenRouter connection and
+ * the sync never asked. Same shape as #9603 (bailian) and #11722.
+ *
+ * The drift guard below is the part that matters: it is what makes the next
+ * instance of this fail loudly instead of shipping as a silently missing card.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { isSupportedUsageConnection } = await import("../../src/lib/usage/providerLimits.ts");
+const { USAGE_SUPPORTED_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+const { USAGE_FETCHER_PROVIDERS } = await import("../../open-sse/services/usage.ts");
+
+const conn = (provider: string, authType = "apikey") =>
+  ({ id: `c-${provider}`, provider, authType }) as never;
+
+test("an OpenRouter API-key connection reaches the usage sync", () => {
+  assert.ok(
+    (USAGE_FETCHER_PROVIDERS as readonly string[]).includes("openrouter"),
+    "precondition: openrouter is declared as having a wired usage fetcher"
+  );
+  assert.ok(isSupportedUsageConnection(conn("openrouter")));
+});
+
+test("both gates have to list it, not just one", () => {
+  // isSupportedUsageConnection is an AND of USAGE_SUPPORTED_PROVIDERS and, for
+  // apikey auth, PROVIDER_LIMITS_APIKEY_PROVIDERS. Adding only the first entry
+  // leaves the connection refused, so assert the membership that the boolean
+  // above cannot distinguish -- otherwise half the fix would look complete.
+  assert.ok((USAGE_SUPPORTED_PROVIDERS as readonly string[]).includes("openrouter"));
+
+  // An unknown provider is still refused, so the assertion above is not just
+  // "the function returns true for everything".
+  assert.equal(isSupportedUsageConnection(conn("not-a-provider")), false);
+  // And a listed provider on an auth type the apikey gate does not cover.
+  assert.equal(isSupportedUsageConnection(conn("openrouter", "basic")), false);
+});
+
+/**
+ * Providers that have a wired fetcher and are deliberately absent from the
+ * app-side list. Each entry needs a reason; an unexplained one is the bug this
+ * test exists to catch.
+ *
+ * These three predate #13080 and I could not establish from the tree whether
+ * they are intentional, so they are pinned rather than "fixed" -- the set may
+ * not grow silently, and a maintainer can convert any of them into a real
+ * entry (or a documented reason) without this test having guessed for them.
+ */
+const FETCHER_WITHOUT_APP_ENTRY = new Set(["opencode", "opencode-zen", "xai"]);
+
+test("no provider gains a usage fetcher without an app-side entry", () => {
+  const supported = new Set(USAGE_SUPPORTED_PROVIDERS as readonly string[]);
+  const unlisted = (USAGE_FETCHER_PROVIDERS as readonly string[]).filter(
+    (provider) => !supported.has(provider)
+  );
+
+  assert.deepEqual(
+    unlisted.slice().sort(),
+    [...FETCHER_WITHOUT_APP_ENTRY].sort(),
+    "a provider with a usage fetcher is missing from USAGE_SUPPORTED_PROVIDERS. " +
+      "Add it there (and to PROVIDER_LIMITS_APIKEY_PROVIDERS if its auth is an " +
+      "API key), or add it to FETCHER_WITHOUT_APP_ENTRY with the reason."
+  );
+});


### PR DESCRIPTION
Closes #13080 for OpenRouter.

## The balance was already being computed and thrown away

`getOpenrouterUsage` (`open-sse/services/usage/openrouter.ts`, #6842) returns a USD `credits` quota built from `/api/v1/key` + `/api/v1/credits`, `services/usage.ts` dispatches `case "openrouter"`, and `USAGE_FETCHER_PROVIDERS` — the file that calls itself the single source of truth for which providers have a wired fetcher — lists it.

Neither app-side gate did. Measured rather than read:

```
isSupportedUsageConnection({ provider: "openrouter", authType: "apikey" })  ->  false
isSupportedUsageConnection({ provider: "deepseek",   authType: "apikey" })  ->  true     (control)
```

So `syncProviderLimits` skipped every OpenRouter connection and nothing ever asked the fetcher for the number.

`isSupportedUsageConnection` is an AND, which is why this is two entries and not one:

- `USAGE_SUPPORTED_PROVIDERS` — `src/shared/constants/providers.ts`
- `PROVIDER_LIMITS_APIKEY_PROVIDERS` — `src/lib/usage/providerLimits.ts`, needed because OpenRouter authenticates by API key (`apikey/gateways.ts:106`)

Add only the first and the connection is still refused — which is what the second test pins, since the boolean alone can't tell the two apart.

## The recurring part

The allowlist already carries this scar twice:

```ts
// Alibaba Coding Plan triple-window quota (#9603 UI gap — fetcher existed, list entry missing)
"bailian-coding-plan",
```

and `providerPluginManifest.ts` references #11722 for the same drift. `usage-families-split.test.ts` pins the dispatcher against `USAGE_FETCHER_PROVIDERS`, so the *open-sse* side can't drift — but nothing pinned the app-side lists against it, which is the seam all three issues came through.

So the test also guards the class: a provider that gains a usage fetcher without an app-side entry now fails.

**Three providers are already in that state and I have not touched them** — `opencode`, `opencode-zen`, `xai`. I could not establish from the tree whether those omissions are deliberate (`xai-oauth`/`xao` *are* listed while the API-key `xai` is not, which looks like it could be intentional), so they are named in an explicit set rather than silently "fixed" or left invisible. The set can't grow without a reason; converting any of them into a real entry is a call for someone who knows the intent. Happy to file that separately if you'd like it tracked.

## Verification

Mutations, each killed by the right test:

| mutation | result |
|---|---|
| revert the `USAGE_SUPPORTED_PROVIDERS` entry | all 3 fail |
| revert **only** the apikey gate (half the fix) | only the reachability test fails |
| add a fetcher with no app-side entry | only the drift guard fails |

- **182 related tests pass**, 0 fail — `provider-limits*`, `provider-plugin-manifest`, `usage-families-split`, `agentrouter-quota-*`, `openrouter-*`
- `eslint` clean on all three files
- `tsc --noEmit` error count **identical to the base branch** (4836 both sides, none of them in these files — the repo's typecheck is already dirty, I just made sure I added nothing)

## One thing to skip while reading the diff

The pre-commit hook ran `prettier --write` over the files I staged and fixed pre-existing formatting drift in them. Not mine, and safe to ignore:

- `providerLimits.ts:207` — a call collapsed onto one line
- `providerLimits.ts:397`, `providers.ts:75`, `providers.ts:144` — stray blank lines removed

My actual change is four lines: two list entries with a comment each.

I did not verify against a live OpenRouter account — I don't have one with credits on it — so this is "the connection now reaches the fetcher, and the fetcher's own shaping is unchanged", not "I watched the card render a balance". The `credits` quota it emits already carries `currency: "USD"`, which `quotaParsing.ts` renders as a dollar figure (same path AgentRouter's balance took in #10078).
