### PR TITLE
test(usage): pin fetcherProviders against supportedProviders

### DIFF
--- a/tests/unit/usage-provider-list-drift.test.ts
+++ b/tests/unit/usage-provider-list-drift.test.ts
@@ -1,0 +1,115 @@
+/**
+ * usage-provider-list-drift.test.ts
+ *
+ * `fetcherProviders.ts` and `supportedProviders.ts` are sibling pure-data lists
+ * that have to agree: the first says a provider has a wired
+ * `getUsageForProvider`, the second says the dashboard and server gates will
+ * accept its usage. A provider in the first but not the second computes a quota
+ * nobody asks for; one in the second but not the first is accepted and then
+ * falls through the dispatcher to `default: "Usage API not implemented"`.
+ *
+ * Nothing compared them, and that seam has now produced the same bug three
+ * times — #9603 (bailian: "fetcher existed, list entry missing"), #11722, and
+ * #12256 (openrouter credits, requested again in #13080 six days after the fix
+ * landed because the card had never appeared). `usage-families-split.test.ts`
+ * pins the dispatcher against `fetcherProviders.ts`, so the open-sse side
+ * cannot drift; this pins the other edge.
+ *
+ * Divergences are allowed but must be declared with a reason. An undeclared one
+ * is the bug.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { USAGE_FETCHER_PROVIDERS } =
+  await import("../../open-sse/services/usage/fetcherProviders.ts");
+const { USAGE_SUPPORTED_PROVIDERS } =
+  await import("../../open-sse/services/usage/supportedProviders.ts");
+
+/**
+ * Has a usage fetcher, deliberately not offered to the dashboard.
+ *
+ * These three predate this test and I could not establish intent from the tree,
+ * so they are pinned rather than "corrected" — the set may not grow silently,
+ * and converting any entry into a real dashboard listing is a call for someone
+ * who knows why it was left out. `xai-oauth`/`xao` *are* listed while the
+ * API-key `xai` is not, which reads like it could be deliberate.
+ */
+const FETCHER_WITHOUT_DASHBOARD_ENTRY = new Set(["opencode", "opencode-zen", "xai"]);
+
+/**
+ * Offered to the dashboard with no fetcher behind it.
+ *
+ * `xiaomi-mimo-token-plan` is inert rather than broken: it authenticates by API
+ * key and is absent from `PROVIDER_LIMITS_APIKEY_PROVIDERS`, so
+ * `isSupportedUsageConnection` refuses it before the dispatcher is ever
+ * reached. Listed here so the entry is understood as dead config instead of
+ * being "fixed" into a live path that would return "Usage API not implemented".
+ */
+const DASHBOARD_ENTRY_WITHOUT_FETCHER = new Set(["xiaomi-mimo-token-plan"]);
+
+const sorted = (values: Iterable<string>) => [...values].sort();
+
+test("every provider with a usage fetcher is offered to the dashboard", () => {
+  const supported = new Set(USAGE_SUPPORTED_PROVIDERS);
+  const undeclared = USAGE_FETCHER_PROVIDERS.filter(
+    (provider) => !supported.has(provider) && !FETCHER_WITHOUT_DASHBOARD_ENTRY.has(provider)
+  );
+
+  assert.deepEqual(
+    undeclared,
+    [],
+    "these providers have a getUsageForProvider implementation but are missing from " +
+      "USAGE_SUPPORTED_PROVIDERS, so their quota is computed and never requested. " +
+      "Add them there (and to PROVIDER_LIMITS_APIKEY_PROVIDERS if they authenticate " +
+      "by API key), or add them to FETCHER_WITHOUT_DASHBOARD_ENTRY with the reason."
+  );
+});
+
+test("every provider offered to the dashboard has a usage fetcher", () => {
+  const fetchers = new Set<string>(USAGE_FETCHER_PROVIDERS);
+  const undeclared = USAGE_SUPPORTED_PROVIDERS.filter(
+    (provider) => !fetchers.has(provider) && !DASHBOARD_ENTRY_WITHOUT_FETCHER.has(provider)
+  );
+
+  assert.deepEqual(
+    undeclared,
+    [],
+    "these providers are in USAGE_SUPPORTED_PROVIDERS with no dispatcher case, so " +
+      "getUsageForProvider returns 'Usage API not implemented'. Add a fetcher, drop " +
+      "the entry, or declare it in DASHBOARD_ENTRY_WITHOUT_FETCHER with the reason."
+  );
+});
+
+test("the declared divergences are the real ones, not stale", () => {
+  // Without this, an entry whose drift has since been fixed would sit in the
+  // allowlists forever, quietly excusing a future recurrence of the same id.
+  const supported = new Set(USAGE_SUPPORTED_PROVIDERS);
+  const fetchers = new Set<string>(USAGE_FETCHER_PROVIDERS);
+
+  assert.deepEqual(
+    sorted(USAGE_FETCHER_PROVIDERS.filter((p) => !supported.has(p))),
+    sorted(FETCHER_WITHOUT_DASHBOARD_ENTRY),
+    "FETCHER_WITHOUT_DASHBOARD_ENTRY lists an id that no longer diverges — remove it"
+  );
+  assert.deepEqual(
+    sorted(USAGE_SUPPORTED_PROVIDERS.filter((p) => !fetchers.has(p))),
+    sorted(DASHBOARD_ENTRY_WITHOUT_FETCHER),
+    "DASHBOARD_ENTRY_WITHOUT_FETCHER lists an id that no longer diverges — remove it"
+  );
+});
+
+test("neither list has duplicates", () => {
+  // A duplicated id makes the counts lie and hides a paste error in a 50-entry
+  // literal, which is how a wrong id survives review.
+  assert.deepEqual(
+    sorted(new Set(USAGE_FETCHER_PROVIDERS)),
+    sorted(USAGE_FETCHER_PROVIDERS),
+    "USAGE_FETCHER_PROVIDERS contains a duplicate"
+  );
+  assert.deepEqual(
+    sorted(new Set(USAGE_SUPPORTED_PROVIDERS)),
+    sorted(USAGE_SUPPORTED_PROVIDERS),
+    "USAGE_SUPPORTED_PROVIDERS contains a duplicate"
+  );
+});


### PR DESCRIPTION
Test-only. No production file touched.

## Why

`open-sse/services/usage/fetcherProviders.ts` and `supportedProviders.ts` are sibling pure-data modules that have to agree, and nothing compared them:

- in `fetcherProviders` but not `supportedProviders` → the provider computes a quota nobody ever asks for, because `isSupportedUsageConnection` refuses the connection first
- in `supportedProviders` with no dispatcher case → accepted, then falls through to `default: "Usage API not implemented"`

That seam has now produced the same bug three times:

| | |
|---|---|
| #9603 | `"bailian-coding-plan", // #9603 UI gap — fetcher existed, list entry missing` — the comment is still in the list |
| #11722 | referenced in `providerPluginManifest.ts` for the same drift |
| #12256 | openrouter credits — and #13080 asked for them again **six days after the fix landed**, because the card had never appeared |

`usage-families-split.test.ts` already pins the dispatcher against `fetcherProviders`, so the open-sse side can't drift. This pins the other edge.

I found it the embarrassing way: I measured the openrouter gap on a checkout 291 commits stale, wrote the two-line fix, and only discovered @Mr-White had already landed it in #12256 when the rebase conflicted with his entries. The list drift was real; my instance of it wasn't. This is the part of that work that still has value.

## Current divergence, declared with reasons

Divergence stays allowed — it just has to be stated:

```
opencode, opencode-zen, xai   have a fetcher, not offered to the dashboard
xiaomi-mimo-token-plan        offered, no fetcher
```

**I have not "fixed" any of them, on purpose.** For the first three I could not establish intent from the tree — `xai-oauth`/`xao` are offered while the API-key `xai` is not, which reads like it may well be deliberate. Guessing would either break something intentional or paper over a real gap. They're pinned so the set can't grow silently, and converting any entry into a real listing is a call for whoever knows the reason.

`xiaomi-mimo-token-plan` I did chase down before writing it up, because "offered with no fetcher" sounds like a live 
defect: it authenticates by API key and is **absent from `PROVIDER_LIMITS_APIKEY_PROVIDERS`**, so `isSupportedUsageConnection` refuses it before the dispatcher is reached. **Dead config, not a live defect** — worth knowing before someone "fixes" it into a path that returns `"Usage API not implemented"`.

A third test fails if a declared divergence stops diverging, so the allowlists can't go stale and quietly excuse a future recurrence of the same id.

## Verification

Mutations, each killed by the right test:

| mutation | fails |
|---|---|
| new fetcher, no dashboard entry | forward guard + stale check |
| dashboard entry, no fetcher | reverse guard + stale check |
| a declared divergence gets fixed | stale check alone |
| duplicate id in either list | duplicate test alone |

Worth noting on the first and last of those: my initial mutation run reported them as *surviving*, and that was wrong — my `perl` anchor assumed `"agentrouter"` was the last entry, which was true on my stale checkout and not on `dev`. The substitution silently no-op'd. Re-ran asserting the edit actually landed before trusting the result; both fail correctly.

- **105 related tests pass**, 0 fail — this file, `usage-families-split`, `provider-plugin-manifest`, `provider-limits*`
- `eslint` clean

One environment note in case it matters to anyone reproducing: `npx eslint` initially died with `Cannot find package '@eslint/compat'` because my `node_modules` predated it being added to `devDependencies`. Installed it with `--no-save`; `package.json` and the lockfile are untouched.
