### PR TITLE
fix(logging): prefer the pipeline over the raw bodies in call-log storage and detail enrichment

### DIFF
--- a/changelog.d/fixes/13147-bodies-first-artifact.md
+++ b/changelog.d/fixes/13147-bodies-first-artifact.md
@@ -1,0 +1,1 @@
+- **fix(logging):** keep the provider exchange rather than the raw client bodies when a call log exceeds its size budget, and show that recovered payload in the request-detail panel instead of replacing it with the stored response body ([#13147](https://github.com/diegosouzapw/OmniRoute/pull/13147)) — thanks @maxmad64bis

--- a/src/lib/usage/callLogArtifacts.ts
+++ b/src/lib/usage/callLogArtifacts.ts
@@ -17,6 +17,17 @@ const OMITTED_FOR_SIZE_LIMIT = "[omitted: call log artifact size limit exceeded]
 const STREAM_CHUNKS_OMITTED_FOR_SIZE_LIMIT =
   "[stream chunks omitted: call log artifact size limit exceeded]";
 
+/**
+ * True for a placeholder a size-limit fallback wrote in place of a real
+ * payload. Consumers that fall back from one artifact field to another
+ * (`maybeEnrichCompletedDetail`) must treat a marker as absent: it is a
+ * non-empty string, so a bare truthiness check happily "recovers" it and
+ * overwrites the real value it was meant to stand in for.
+ */
+export function isSizeLimitOmissionMarker(value: unknown): boolean {
+  return value === OMITTED_FOR_SIZE_LIMIT || value === STREAM_CHUNKS_OMITTED_FOR_SIZE_LIMIT;
+}
+
 // The error is the only field that says *why* a request failed, and it is
 // typically ~90 bytes next to the multi-hundred-KB bodies that trip the cap.
 // Dropping it made a size-limited row undiagnosable: a provider outage, a local
@@ -182,33 +193,49 @@ function buildMinimalArtifactForSizeLimit(artifact: CallLogArtifact) {
   };
 }
 
-function serializeFinalSizeLimitFallback(artifact: CallLogArtifact, maxBytes: number): string {
-  const withSummary = JSON.stringify(buildMinimalArtifactForSizeLimit(artifact));
-  if (Buffer.byteLength(withSummary) <= maxBytes) {
-    return withSummary;
-  }
-
-  // The summary alone exceeded the cap (pathological). Keep the error so the
-  // row stays diagnosable, drop everything else including the summary body.
-  const errorOnly = JSON.stringify({
-    schemaVersion: artifact.schemaVersion,
-    _omniroute_truncated: true,
-    reason: SIZE_LIMIT_EXCEEDED_REASON,
+/**
+ * Fallback ladder for an artifact that does not fit its byte budget, ordered
+ * from "keeps the most" to "keeps the least": the first stage that fits wins.
+ *
+ * Ordering rule: drop the payload that most plausibly tripped the cap, and
+ * drop a payload that is *duplicated elsewhere in the artifact* before one
+ * that is unique. `pipeline` carries both sides of the exchange already
+ * translated (`clientRawRequest`/`providerRequest`/`providerResponse`/
+ * `clientResponse`), so evicting it to keep `requestBody` traded the whole
+ * upstream exchange -- including the only record of what the provider
+ * actually answered -- for a raw client prompt the pipeline already holds a
+ * translated copy of. Bodies go first now, and `pipeline` survives one stage
+ * longer; the previous order is still reached when dropping the bodies alone
+ * is not enough.
+ *
+ * Two consumers depend on that ordering, not just human diagnosis:
+ * `resolvePreviousResponseState` (db/responsesContinuationStore.ts) rebuilds
+ * `previous_response_id` history from `pipeline.clientRawRequest` /
+ * `pipeline.clientResponse` and returns null -- forcing the client to resend
+ * full history -- for any artifact whose pipeline was omitted; and
+ * `maybeEnrichCompletedDetail` (usage/completedRequestDetails.ts) reads
+ * `pipeline.providerResponse` in preference to `responseBody`.
+ */
+function buildSizeLimitStages(artifact: CallLogArtifact): Array<() => unknown> {
+  const omitBodies = <T extends object>(value: T) => ({
+    ...value,
+    requestBody: OMITTED_FOR_SIZE_LIMIT,
+    responseBody: OMITTED_FOR_SIZE_LIMIT,
     error: preserveErrorForSizeLimit(artifact.error),
   });
-  if (Buffer.byteLength(errorOnly) <= maxBytes) {
-    return errorOnly;
-  }
 
-  // Last resort: even the error-only payload did not fit. The error still
-  // rides along -- without it this row says only "something was too big",
-  // which is the state this change exists to remove.
-  return JSON.stringify({
-    schemaVersion: artifact.schemaVersion,
-    _omniroute_truncated: true,
-    reason: SIZE_LIMIT_EXCEEDED_REASON,
-    error: preserveErrorForSizeLimit(artifact.error),
-  });
+  return [
+    () => truncateArtifactForStorage(artifact),
+    // Bodies alone: worth a stage only when there is a pipeline to keep in
+    // exchange. Without one it produces the same bytes as the stage two lines
+    // below, so it is left out rather than costing a redundant stringify.
+    ...(artifact.pipeline ? [() => omitBodies(artifact)] : []),
+    () => omitOversizedPipeline(artifact),
+    () => omitBodies(omitOversizedPipeline(artifact)),
+    // The summary alone exceeded the cap (pathological). Keep the error so the
+    // row stays diagnosable, drop everything else including the summary body.
+    () => buildMinimalArtifactForSizeLimit(artifact),
+  ];
 }
 
 function serializeArtifactForStorage(artifact: CallLogArtifact): string {
@@ -227,27 +254,22 @@ function serializeArtifactForStorage(artifact: CallLogArtifact): string {
     return serialized;
   }
 
-  const truncated = JSON.stringify(truncateArtifactForStorage(artifact));
-  if (Buffer.byteLength(truncated) <= maxBytes) {
-    return truncated;
+  for (const buildStage of buildSizeLimitStages(artifact)) {
+    const candidate = JSON.stringify(buildStage());
+    if (Buffer.byteLength(candidate) <= maxBytes) {
+      return candidate;
+    }
   }
 
-  const withoutPipeline = JSON.stringify(omitOversizedPipeline(artifact));
-  if (Buffer.byteLength(withoutPipeline) <= maxBytes) {
-    return withoutPipeline;
-  }
-
-  const minimal = JSON.stringify({
-    ...omitOversizedPipeline(artifact),
-    requestBody: OMITTED_FOR_SIZE_LIMIT,
-    responseBody: OMITTED_FOR_SIZE_LIMIT,
+  // Last resort: not even the summary fit. The error still rides along --
+  // without it this row says only "something was too big", which is the state
+  // the size-limit fallbacks exist to remove.
+  return JSON.stringify({
+    schemaVersion: artifact.schemaVersion,
+    _omniroute_truncated: true,
+    reason: SIZE_LIMIT_EXCEEDED_REASON,
     error: preserveErrorForSizeLimit(artifact.error),
   });
-  if (Buffer.byteLength(minimal) <= maxBytes) {
-    return minimal;
-  }
-
-  return serializeFinalSizeLimitFallback(artifact, maxBytes);
 }
 
 export function writeCallArtifact(

--- a/src/lib/usage/completedRequestDetails.ts
+++ b/src/lib/usage/completedRequestDetails.ts
@@ -50,13 +50,14 @@ export function clearCompletedDetails() {
   completedDetails.clear();
 }
 
+function isUnset(value: unknown): boolean {
+  return value === undefined || value === null;
+}
+
 export function maybeEnrichCompletedDetail(updated: PendingRequestDetail, connectionId: string) {
   void (async () => {
     try {
-      const missingProvider =
-        updated.providerResponse === undefined || updated.providerResponse === null;
-      const missingClient = updated.clientResponse === undefined || updated.clientResponse === null;
-      if (!missingProvider && !missingClient) return;
+      if (!isUnset(updated.providerResponse) && !isUnset(updated.clientResponse)) return;
 
       const db = getDbInstance();
       const sinceIso = new Date(Date.now() - 30_000).toISOString();
@@ -67,24 +68,32 @@ export function maybeEnrichCompletedDetail(updated: PendingRequestDetail, connec
         .all(connectionId, updated.model, sinceIso) as Array<{ artifact_relpath: string | null }>;
       for (const row of rows) {
         if (!row.artifact_relpath) continue;
-        const { readCallArtifact } = await import("./callLogArtifacts");
+        const { readCallArtifact, isSizeLimitOmissionMarker } = await import("./callLogArtifacts");
         const art = readCallArtifact(row.artifact_relpath);
         if (art.state !== "ready" || !art.artifact) continue;
         const pipeline = art.artifact.pipeline as
           | { providerResponse?: unknown; clientResponse?: unknown }
           | undefined;
-        if (missingProvider && pipeline?.providerResponse) {
+        // pipeline.* first: it is the translated payload of one specific side.
+        // `responseBody` is a single coarse value handed to both sides, so it
+        // may only fill a side still empty AFTER the pipeline had its turn --
+        // testing emptiness once before the loop let it overwrite the payload
+        // just recovered, showing a provider payload as the client response.
+        if (isUnset(updated.providerResponse) && pipeline?.providerResponse) {
           updated.providerResponse = pipeline.providerResponse;
         }
-        if (missingClient && pipeline?.clientResponse) {
+        if (isUnset(updated.clientResponse) && pipeline?.clientResponse) {
           updated.clientResponse = pipeline.clientResponse;
         }
-        if (
-          (missingProvider && art.artifact.responseBody) ||
-          (missingClient && art.artifact.responseBody)
-        ) {
-          if (missingProvider) updated.providerResponse = art.artifact.responseBody;
-          if (missingClient) updated.clientResponse = art.artifact.responseBody;
+        // A size-limited artifact stores an omission marker string in place of
+        // the body. It is truthy, so recovering it here overwrites a real
+        // payload with "[omitted: ...]".
+        const responseBody = isSizeLimitOmissionMarker(art.artifact.responseBody)
+          ? null
+          : art.artifact.responseBody;
+        if (responseBody) {
+          if (isUnset(updated.providerResponse)) updated.providerResponse = responseBody;
+          if (isUnset(updated.clientResponse)) updated.clientResponse = responseBody;
         }
         if (updated.providerResponse || updated.clientResponse) {
           if (completedDetails.has(updated.id)) storeCompletedDetail(updated);

--- a/tests/unit/call-log-artifact-bodies-first.test.ts
+++ b/tests/unit/call-log-artifact-bodies-first.test.ts
@@ -1,0 +1,172 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { useDecollidedMigrationsDir } from "./helpers/decollidedMigrationsDir.ts";
+
+useDecollidedMigrationsDir();
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-call-log-bodies-first-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { writeCallArtifact, readCallArtifact, isSizeLimitOmissionMarker } = await import(
+  "../../src/lib/usage/callLogArtifacts.ts"
+);
+
+const OMITTED = "[omitted: call log artifact size limit exceeded]";
+const PIPELINE_MARKER = {
+  error: {
+    _omniroute_truncated: true,
+    reason: "call_log_artifact_size_limit_exceeded",
+  },
+};
+
+// Pin the budget env for determinism (save/restore idiom per
+// call-log-cap.test.ts:32/43-51); never hardcode bytes near 512 KB.
+const ORIGINAL_PIPELINE_MAX = process.env.CALL_LOG_PIPELINE_MAX_SIZE_KB;
+test.beforeEach(() => {
+  process.env.CALL_LOG_PIPELINE_MAX_SIZE_KB = "512";
+});
+test.afterEach(() => {
+  if (ORIGINAL_PIPELINE_MAX === undefined) delete process.env.CALL_LOG_PIPELINE_MAX_SIZE_KB;
+  else process.env.CALL_LOG_PIPELINE_MAX_SIZE_KB = ORIGINAL_PIPELINE_MAX;
+});
+
+function artifact(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 5 as const,
+    summary: {
+      id: `bodies-first-${Math.random().toString(16).slice(2)}`,
+      timestamp: new Date().toISOString(),
+      method: "POST",
+      path: "/v1/messages",
+      status: 200,
+      model: "openai/gpt-4.1",
+      requestedModel: null,
+    },
+    error: null,
+    ...overrides,
+  } as never;
+}
+
+function roundTrip(input: ReturnType<typeof artifact>) {
+  const relativePath = `bodies-first/${(input as { summary: { id: string } }).summary.id}.json`;
+  assert.ok(writeCallArtifact(input, relativePath), "artifact should be written");
+  const { artifact: stored, state } = readCallArtifact(relativePath);
+  assert.equal(state, "ready");
+  assert.ok(stored, "artifact should be readable");
+  return stored as unknown as Record<string, unknown>;
+}
+
+test("artifact bodies-first eviction", async (t) => {
+  await t.test("body overflow keeps pipeline.providerResponse", async () => {
+    // Fixture mirrors the observed shape (not a 900KB/tiny toy alone):
+    // requestBody O(200KB) next to a pipeline sized so the TOTAL just
+    // exceeds the cap. The bodies are what tripped the cap, so they go
+    // first and the pipeline survives.
+    const providerResponse = {
+      status: 200,
+      body: { data: "p".repeat(330 * 1024) },
+    };
+    const stored = roundTrip(
+      artifact({
+        requestBody: "r".repeat(200 * 1024),
+        responseBody: { output: "response" },
+        pipeline: {
+          providerRequest: { url: "https://provider.example/v1/messages", method: "POST" },
+          providerResponse,
+        },
+      })
+    );
+
+    assert.equal(stored.requestBody, OMITTED);
+    assert.equal(stored.responseBody, OMITTED);
+    // camelCase per requestLogger.ts:19.
+    assert.deepEqual(
+      (stored.pipeline as Record<string, unknown>).providerResponse,
+      providerResponse
+    );
+  });
+
+  await t.test("pipeline-only overflow keeps current behavior", async () => {
+    // Small bodies, huge pipeline: the pipeline is what tripped the cap,
+    // so it is replaced by the marker while the bodies are kept verbatim
+    // (same contract as call-log-cap.test.ts:597).
+    const requestBody = { payload: "request" };
+    const responseBody = { output: "response" };
+    const stored = roundTrip(
+      artifact({
+        requestBody,
+        responseBody,
+        pipeline: {
+          providerRequest: { body: "x".repeat(300 * 1024) },
+          providerResponse: { body: "y".repeat(300 * 1024) },
+        },
+      })
+    );
+
+    assert.deepEqual(stored.requestBody, requestBody);
+    assert.deepEqual(stored.responseBody, responseBody);
+    assert.deepEqual(stored.pipeline, PIPELINE_MARKER);
+  });
+
+  await t.test("both-large falls through to current minimal", async () => {
+    // Body AND pipeline each over budget: omitting the bodies alone still
+    // leaves the pipeline over budget, so the stored form is bodies
+    // omitted plus the pipeline marker.
+    const stored = roundTrip(
+      artifact({
+        requestBody: "r".repeat(600 * 1024),
+        responseBody: { output: "response" },
+        pipeline: {
+          providerRequest: { body: "x".repeat(600 * 1024) },
+          providerResponse: { body: "y".repeat(600 * 1024) },
+        },
+      })
+    );
+
+    assert.equal(stored.requestBody, OMITTED);
+    assert.equal(stored.responseBody, OMITTED);
+    assert.deepEqual(stored.pipeline, PIPELINE_MARKER);
+  });
+  await t.test("no pipeline: the stage is skipped, storage is unchanged", async () => {
+    // Without a pipeline there is nothing for the new stage to save, and its
+    // output would be byte-identical to the minimal stage below it -- it must
+    // not fire at all, so an artifact that never had a pipeline keeps exactly
+    // the shape it had before this change.
+    const stored = roundTrip(
+      artifact({
+        requestBody: "r".repeat(600 * 1024),
+        responseBody: { output: "response" },
+        error: { message: "upstream 500" },
+      })
+    );
+
+    assert.equal(stored.requestBody, OMITTED);
+    assert.equal(stored.responseBody, OMITTED);
+    assert.deepEqual(stored.error, { message: "upstream 500" });
+    assert.equal(stored.pipeline, undefined);
+  });
+
+  await t.test("an omitted body is detectable by consumers, not just truthy", async () => {
+    // maybeEnrichCompletedDetail (usage/completedRequestDetails.ts) falls back
+    // from pipeline.providerResponse to responseBody. The marker is a
+    // non-empty string, so a truthiness check "recovers" it and overwrites the
+    // pipeline payload this change exists to keep; the shared predicate is the
+    // contract that stops it.
+    const stored = roundTrip(
+      artifact({
+        requestBody: "r".repeat(200 * 1024),
+        responseBody: { output: "response" },
+        pipeline: { providerResponse: { status: 200, body: { data: "p".repeat(330 * 1024) } } },
+      })
+    );
+
+    assert.ok(stored.responseBody, "the marker is truthy -- that is the trap");
+    assert.equal(isSizeLimitOmissionMarker(stored.responseBody), true);
+    assert.equal(isSizeLimitOmissionMarker(stored.requestBody), true);
+    assert.equal(isSizeLimitOmissionMarker({ output: "response" }), false);
+    assert.equal(isSizeLimitOmissionMarker(null), false);
+  });
+});

--- a/tests/unit/completed-detail-pipeline-precedence.test.ts
+++ b/tests/unit/completed-detail-pipeline-precedence.test.ts
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { useDecollidedMigrationsDir } from "./helpers/decollidedMigrationsDir.ts";
+
+useDecollidedMigrationsDir();
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-completed-detail-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { writeCallArtifact } = await import("../../src/lib/usage/callLogArtifacts.ts");
+const { maybeEnrichCompletedDetail } = await import(
+  "../../src/lib/usage/completedRequestDetails.ts"
+);
+
+type PipelinePayloads = { providerResponse?: unknown; clientResponse?: unknown };
+
+function seedRow(id: string, connectionId: string, pipeline: PipelinePayloads | undefined) {
+  const relativePath = `precedence/${id}.json`;
+  const written = writeCallArtifact(
+    {
+      schemaVersion: 5,
+      summary: { id, timestamp: new Date().toISOString(), model: "openai/gpt-4.1" },
+      requestBody: { payload: "request" },
+      responseBody: { from: "responseBody" },
+      error: null,
+      ...(pipeline ? { pipeline } : {}),
+    } as never,
+    relativePath
+  );
+  assert.ok(written, "artifact should be written");
+
+  core
+    .getDbInstance()
+    .prepare(
+      `INSERT INTO call_logs (id, timestamp, method, path, status, model, provider, connection_id, detail_state, artifact_relpath)
+       VALUES (@id, @timestamp, 'POST', '/v1/chat/completions', 200, 'openai/gpt-4.1', 'openai', @connectionId, 'ready', @artifact)`
+    )
+    .run({ id, timestamp: new Date().toISOString(), connectionId, artifact: relativePath });
+}
+
+// maybeEnrichCompletedDetail is fire-and-forget (`void (async () => …)`), so the
+// assertion waits on the mutation instead of on a returned promise.
+async function enrich(id: string, connectionId: string) {
+  const detail = {
+    id,
+    model: "openai/gpt-4.1",
+    provider: "openai",
+    connectionId,
+    startedAt: Date.now(),
+    providerResponse: null,
+    clientResponse: null,
+  };
+  maybeEnrichCompletedDetail(detail as never, connectionId);
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline && detail.providerResponse === null) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return detail;
+}
+
+test("completed-detail enrichment prefers the pipeline over the body", async (t) => {
+  await t.test("a body does not overwrite a payload the pipeline already supplied", async () => {
+    // pipeline.* is the translated, per-side payload; responseBody is one coarse
+    // value assigned to BOTH sides. Reading the pipeline first and then letting
+    // the body overwrite it handed the panel the wrong side of the exchange --
+    // a provider payload shown as the client response, and vice versa.
+    const providerResponse = { from: "pipeline.providerResponse" };
+    const clientResponse = { from: "pipeline.clientResponse" };
+    seedRow("precedence-both", "conn-both", { providerResponse, clientResponse });
+
+    const detail = await enrich("precedence-both", "conn-both");
+
+    assert.deepEqual(detail.providerResponse, providerResponse);
+    assert.deepEqual(detail.clientResponse, clientResponse);
+  });
+
+  await t.test("the body still fills a side the pipeline left empty", async () => {
+    // The fallback itself must survive: with no pipeline at all, responseBody is
+    // the only payload the artifact carries and both sides take it.
+    seedRow("precedence-body-only", "conn-body-only", undefined);
+
+    const detail = await enrich("precedence-body-only", "conn-body-only");
+
+    assert.deepEqual(detail.providerResponse, { from: "responseBody" });
+    assert.deepEqual(detail.clientResponse, { from: "responseBody" });
+  });
+
+  await t.test("a half-filled pipeline keeps its side and the body fills the other", async () => {
+    seedRow("precedence-half", "conn-half", { providerResponse: { from: "pipeline.provider" } });
+
+    const detail = await enrich("precedence-half", "conn-half");
+
+    assert.deepEqual(detail.providerResponse, { from: "pipeline.provider" });
+    assert.deepEqual(detail.clientResponse, { from: "responseBody" });
+  });
+});


### PR DESCRIPTION
⚠️ base-red inherited: #12732

## Summary

A call log stores the same exchange twice: the raw client bodies, and `pipeline` — both sides translated, plus what the provider actually replied. Two places picked the wrong copy.

**Past the size budget**, the ladder dropped `pipeline` first, keeping a prompt it already had a copy of and losing the upstream answer. `resolvePreviousResponseState` (`src/lib/db/responsesContinuationStore.ts:91`) rebuilds `previous_response_id` history out of `pipeline`, so a long agentic conversation crossing the budget also lost server-side continuation and had to resend everything. The bodies go first now, and only when there's a pipeline to keep in exchange.

**In the request-detail panel**, `maybeEnrichCompletedDetail` reads the pipeline then falls back to `responseBody` — but it decided which sides were empty before reading anything, so the fallback overwrote what the pipeline had just supplied. `responseBody` is one value used for both sides, so the panel could show a provider payload as the client response. It's re-checked per side now. It ships here because the first fix makes it worse: the size-limit placeholder is a non-empty string, so it would have replaced a good payload with `"[omitted: ...]"`.

The ladder was five copy-pasted stringify/measure/return blocks over two functions; it's an ordered list and one loop now.

## Related Issues

Related to #12420 (overflow on large tool results), which stays open: the reporter says the request itself fails, and an oversized artifact never fails a request (`writeCallArtifact` catches and returns null). This changes which payload survives the cap, not the cap.

Same shape as #12095, which kept the `error` alive through this ladder.

## Validation

- [x] Change type: DB
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

71/71 — 10 new, 61 existing across `call-log-{size-limit-error,cap,stream-debug,artifact-worker,save-drain,oom-unbounded-5618}`, `log-export-runner` and `responses-continuation-store`, each suite run on its own. `typecheck:core` and `lint` exit 0, on the tip of `release/v3.8.51`.

## Tests Added Or Updated

`call-log-artifact-bodies-first.test.ts` — 5 cases: body-heavy overflow keeps `pipeline.providerResponse`; pipeline-heavy keeps today's shape; both-heavy falls through to today's minimal; no pipeline is stored exactly as before; a stored body is detectable as a placeholder, not merely truthy.

`completed-detail-pipeline-precedence.test.ts` — 3 cases, written first and red on the base (1 and 3 failing, 2 passing: an inverted precedence, not a broken fallback): a body doesn't overwrite a side the pipeline filled; it still fills a side no pipeline covered; a half-filled pipeline keeps its side.

## Coverage Notes

Old and new serialization replayed over every fixture in the existing suites: same bytes except on the one exercising the new rung, so no existing expectation needed touching.

## Reviewer Notes

The tradeoff: on a large 200 (big response body next to a big pipeline, e.g. agentic tool loops) the stored shape flips from bodies-kept/pipeline-dropped to bodies-dropped/pipeline-kept — only the pre-translation client payload is lost. Cost is one extra `JSON.stringify` on the oversize path, and only for artifacts with a pipeline; without one the new rung isn't in the list at all.

Left alone on purpose: the loop still stops as soon as either side is filled. No test proves that wrong and it predates this change.
