### PR TITLE
fix(traffic-inspector): release WS subscriber and ping timer on a dead socket

### DIFF
--- a/changelog.d/fixes/13152-traffic-inspector-ws-subscriber-leak.md
+++ b/changelog.d/fixes/13152-traffic-inspector-ws-subscriber-leak.md
@@ -1,1 +1,1 @@
-Fix a subscriber and ping-timer leak in the traffic-inspector WebSocket route when the client socket is already closed at handler time.
+- **fix(traffic-inspector):** the WebSocket route no longer leaks a traffic-buffer subscriber and a 30s ping timer when the client socket is already closed at handler time — listeners are attached before any resource is acquired, a destroyed socket bails out early, and the ping interval stops on a dead socket where `write()` never throws ([#13155](https://github.com/diegosouzapw/OmniRoute/pull/13155))

--- a/changelog.d/fixes/13152-traffic-inspector-ws-subscriber-leak.md
+++ b/changelog.d/fixes/13152-traffic-inspector-ws-subscriber-leak.md
@@ -1,0 +1,1 @@
+Fix a subscriber and ping-timer leak in the traffic-inspector WebSocket route when the client socket is already closed at handler time.

--- a/src/app/api/tools/traffic-inspector/ws/route.ts
+++ b/src/app/api/tools/traffic-inspector/ws/route.ts
@@ -96,6 +96,14 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const acceptHeader = acceptKey(clientKey);
+
+  // The client can vanish during the upgrade round trip. `close` has then
+  // ALREADY fired, so the listeners below would never run and every resource
+  // acquired past this point would be held with no path to release it.
+  if (socket.destroyed) {
+    return new Response(null, { status: 101 });
+  }
+
   socket.write(
     [
       "HTTP/1.1 101 Switching Protocols",
@@ -106,21 +114,17 @@ export async function GET(request: Request): Promise<Response> {
     ].join("\r\n")
   );
 
-  const unsubscribe = globalTrafficBuffer.subscribe((ev) => {
-    sendText(socket, ev);
-  });
-
-  const pingTimer = setInterval(() => {
-    try {
-      socket.write(encodeWsFrame(0x09)); // ping
-    } catch {
-      cleanup();
-    }
-  }, PING_INTERVAL_MS);
+  let unsubscribe: (() => void) | null = null;
+  let pingTimer: ReturnType<typeof setInterval> | null = null;
+  let cleanedUp = false;
 
   function cleanup(): void {
-    clearInterval(pingTimer);
-    unsubscribe();
+    if (cleanedUp) return;
+    cleanedUp = true;
+    if (pingTimer) clearInterval(pingTimer);
+    pingTimer = null;
+    unsubscribe?.();
+    unsubscribe = null;
     try {
       socket.destroy();
     } catch {
@@ -128,14 +132,43 @@ export async function GET(request: Request): Promise<Response> {
     }
   }
 
-  socket.once("close", cleanup);
-  socket.once("error", cleanup);
-
-  // Never resolve — the socket is the response channel.
-  await new Promise<void>((resolve) => {
+  // Attached BEFORE any resource is acquired, so there is no window in which a
+  // subscriber or timer exists without a live path to cleanup().
+  const settled = new Promise<void>((resolve) => {
     socket.once("close", resolve);
     socket.once("error", resolve);
   });
+  socket.once("close", cleanup);
+  socket.once("error", cleanup);
+
+  // Re-check: `close` may have fired while we were writing the handshake, in
+  // which case the listeners above already ran and cleanup() is a no-op we
+  // still must not skip.
+  if (socket.destroyed) {
+    cleanup();
+    return new Response(null, { status: 101 });
+  }
+
+  unsubscribe = globalTrafficBuffer.subscribe((ev) => {
+    sendText(socket, ev);
+  });
+
+  pingTimer = setInterval(() => {
+    // `socket.write()` does NOT throw synchronously on a destroyed socket, so
+    // the destroyed check — not the catch — is what stops a dead interval.
+    if (socket.destroyed) {
+      cleanup();
+      return;
+    }
+    try {
+      socket.write(encodeWsFrame(0x09)); // ping
+    } catch {
+      cleanup();
+    }
+  }, PING_INTERVAL_MS);
+
+  // Never resolve — the socket is the response channel.
+  await settled;
 
   cleanup();
   return new Response(null, { status: 101 });

--- a/tests/unit/traffic-inspector-ws-subscriber-leak-13152.test.ts
+++ b/tests/unit/traffic-inspector-ws-subscriber-leak-13152.test.ts
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+
+import { GET } from "@/app/api/tools/traffic-inspector/ws/route";
+import { globalTrafficBuffer } from "@/mitm/inspector/buffer";
+
+const DEAD_UPGRADES = 6;
+
+function armedTimers(): number {
+  return process.getActiveResourcesInfo().filter((r) => r === "Timeout").length;
+}
+
+function upgradeRequest(socket: net.Socket): Request {
+  const req = new Request("http://127.0.0.1/api/tools/traffic-inspector/ws", {
+    headers: {
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+    },
+  });
+  Object.defineProperty(req, "socket", { value: socket, configurable: true });
+  return req;
+}
+
+async function deadSocket(port: number): Promise<net.Socket> {
+  const sock = net.connect(port, "127.0.0.1");
+  await new Promise<void>((r) => sock.once("connect", () => r()));
+  sock.on("error", () => {});
+  sock.destroy();
+  await new Promise((r) => setTimeout(r, 20));
+  return sock;
+}
+
+test("an already-closed socket leaves no subscriber and no ping timer", async () => {
+  const accepted: net.Socket[] = [];
+  const server = net.createServer((c) => {
+    accepted.push(c);
+    c.on("error", () => {});
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    const timersBefore = armedTimers();
+    const subsBefore = globalTrafficBuffer.subscriberCount();
+
+    const handlers: Promise<unknown>[] = [];
+    for (let i = 0; i < DEAD_UPGRADES; i++) {
+      // Catch at creation time: the route answers a hijacked upgrade with a 101
+      // Response, which undici rejects off a real server. Left unattached, that
+      // rejection would sit through the next await and trip Node's unhandled
+      // rejection detection. Either settlement proves the handler released its
+      // resources instead of hanging, which is what this test measures.
+      handlers.push(GET(upgradeRequest(await deadSocket(port))).catch(() => undefined));
+    }
+
+    // Own the race timer so it can be cleared before measuring; otherwise the
+    // test's own armed timeout is counted as a leaked one.
+    let raceTimer: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      Promise.all(handlers).then(() => "settled"),
+      new Promise((r) => {
+        raceTimer = setTimeout(() => r("hung"), 2000);
+      }),
+    ]);
+    if (raceTimer) clearTimeout(raceTimer);
+    assert.equal(
+      outcome,
+      "settled",
+      "each handler must return instead of hanging forever on a dead socket"
+    );
+
+    const timersAfter = armedTimers();
+    assert.ok(
+      timersAfter <= timersBefore,
+      `${DEAD_UPGRADES} dead upgrades retained ${timersAfter - timersBefore} ping timer(s)`
+    );
+
+    // Measure the subscriber set directly; counting fan-out to our own probe
+    // says nothing about whether the dead sockets stayed subscribed.
+    assert.equal(
+      globalTrafficBuffer.subscriberCount(),
+      subsBefore,
+      `${DEAD_UPGRADES} dead upgrades left ${globalTrafficBuffer.subscriberCount() - subsBefore} subscriber(s) behind`
+    );
+  } finally {
+    // close() only fires once every accepted connection is gone.
+    for (const c of accepted) c.destroy();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+});
+
+test("a live socket keeps its subscription until the socket closes", async () => {
+  const accepted: net.Socket[] = [];
+  const server = net.createServer((c) => {
+    accepted.push(c);
+    c.on("error", () => {});
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const { port } = server.address() as AddressInfo;
+
+  const sock = net.connect(port, "127.0.0.1");
+  await new Promise<void>((r) => sock.once("connect", () => r()));
+  sock.on("error", () => {});
+
+  try {
+    const subsBefore = globalTrafficBuffer.subscriberCount();
+
+    const handler = GET(upgradeRequest(sock)).catch(() => undefined);
+    await new Promise((r) => setTimeout(r, 100));
+
+    assert.equal(
+      globalTrafficBuffer.subscriberCount(),
+      subsBefore + 1,
+      "a live upgrade must register exactly one traffic subscriber"
+    );
+
+    // Closing the socket resolves the handler's `settled` promise, which is the
+    // only path that releases the subscriber.
+    sock.destroy();
+    await handler;
+
+    assert.equal(
+      globalTrafficBuffer.subscriberCount(),
+      subsBefore,
+      "closing the socket must release the subscriber"
+    );
+  } finally {
+    // close() only fires once every accepted connection is gone.
+    for (const c of accepted) c.destroy();
+    await new Promise<void>((r) => server.close(() => r()));
+  }
+});


### PR DESCRIPTION
Fixes #13152.

## Problem

`GET /api/tools/traffic-inspector/ws` acquired resources before it had any path to release them:

```
subscribe()            <- traffic buffer subscriber
setInterval(ping)      <- 30s timer
socket.once("close")   <- the ONLY caller of cleanup()
```

When the client disappears during the upgrade round trip, `close` has already fired by the time the handler runs. The listener never fires again, so `cleanup()` never runs: the subscriber stays in the buffer's `Set` forever, the ping interval stays armed, and `await settled` never resolves.

Two Node behaviours make this silent:

- `socket.once("close")` on an already-destroyed socket never fires.
- `socket.write()` on a destroyed socket does **not** throw synchronously — it reports the error asynchronously — so the ping's `try/catch { cleanup() }` was never reached either.

Measured against `release/v3.8.51` with 10 dead upgrades:

```
subscribers leaked      : 10 / 10
armed intervals         : 0 -> 10
handler promises settled: NONE (hung forever)
```

Each leaked subscriber pins its socket and closure for the process lifetime, and every intercepted request fans out to all of them.

## Fix

- Return early when `socket.destroyed` before doing any work.
- Attach `close`/`error` listeners **before** subscribing or arming the timer, so no window exists where a resource is held without a live cleanup path.
- Re-check `socket.destroyed` after the handshake write, since `close` can land while it is in flight.
- Stop the ping interval on a destroyed socket, since `write()` will not throw there.
- `cleanup()` is idempotent via a `cleanedUp` guard.

The handshake bytes are unchanged.

## Tests

`tests/unit/traffic-inspector-ws-subscriber-leak-13152.test.ts` — measures `globalTrafficBuffer.subscriberCount()` and armed timers directly rather than inferring from fan-out.

| | baseline | with fix |
|---|---|---|
| already-closed socket leaves no subscriber and no ping timer | ✖ hangs, never settles | ✔ |
| live socket keeps its subscription until the socket closes | ✔ | ✔ |

```
ℹ pass 2
ℹ fail 0
```

`npm run typecheck:core` clean. ESLint on the touched files reports only the pre-existing `sendClose is defined but never used` error, which is present on `release/v3.8.51` unchanged.
