### PR TITLE
fix(shared): support custom and synced models in quota combos

### DIFF
--- a/src/app/(dashboard)/dashboard/costs/quota-share/components/PoolWizard.tsx
+++ b/src/app/(dashboard)/dashboard/costs/quota-share/components/PoolWizard.tsx
@@ -478,6 +478,9 @@ export default function PoolWizard({
     const name = poolName.trim();
     if (connectionIds.length === 0 || !name) return [];
 
+    const group = groups.find((g) => g.id === groupId);
+    const effectiveGroupName = group?.name || name;
+
     const MAX_PER_PROVIDER = 3;
     return connectionIds
       .map((cid) => {
@@ -486,11 +489,11 @@ export default function PoolWizard({
         const allModels = getPreviewModels(conn.provider);
         const names = allModels
           .slice(0, MAX_PER_PROVIDER)
-          .map((m) => quotaModelName(name, conn.provider, m));
+          .map((m) => quotaModelName(effectiveGroupName, conn.provider, m));
         return { provider: conn.provider, names, totalModels: allModels.length };
       })
       .filter(Boolean) as Array<{ provider: string; names: string[]; totalModels: number }>;
-  }, [connectionIds, connections, poolName]);
+  }, [connectionIds, connections, poolName, groupId, groups]);
 
   // Flat list (for legacy single-provider path, kept for step-3 rendering simplicity)
   const previewNames = useMemo(

--- a/src/app/api/internal/codex-responses-ws/modelResolution.ts
+++ b/src/app/api/internal/codex-responses-ws/modelResolution.ts
@@ -15,6 +15,8 @@
  * See docs/reference/API_REFERENCE.md → "Responses over WebSocket (Codex)".
  */
 
+import { isQuotaModelName, parseQuotaModelName } from "@/lib/quota/quotaModelNaming";
+
 export interface ResolvedModelInfo {
   provider?: string;
   model?: string;
@@ -35,6 +37,17 @@ export async function resolveCodexWsModelInfo(
   requestedModel: string,
   resolve: ModelResolver
 ): Promise<ResolvedModelInfo> {
+  // Quota-shared model name (qtSd/<group>/<provider>/<model>) → unwrap underlying provider & model
+  if (isQuotaModelName(requestedModel)) {
+    const parsed = parseQuotaModelName(requestedModel);
+    if (parsed) {
+      return {
+        provider: parsed.provider,
+        model: parsed.model,
+      };
+    }
+  }
+
   const info = await resolve(requestedModel);
 
   // Already codex, or explicitly provider-prefixed → respect it.

--- a/src/app/api/internal/codex-responses-ws/route.ts
+++ b/src/app/api/internal/codex-responses-ws/route.ts
@@ -37,6 +37,7 @@ import { persistResponsesWsCallHistory } from "./history";
 import { applyResponsesWsCompression } from "./compression";
 import { getComboByName } from "@/lib/db/combos";
 import { getComboModelString } from "@/lib/combos/steps";
+import { isQuotaModelName } from "@/lib/quota/quotaModelNaming";
 import {
   buildManagedLeaseErrorResponse,
   isExclusiveLeaseManagedKey,
@@ -528,6 +529,13 @@ async function prepare(body: JsonRecord) {
   if ("error" in context) return context.error;
   const combo = await getComboByName(context.requestedModel).catch(() => null);
   if (combo) {
+    if (combo.strategy === "quota-share") {
+      return jsonError(
+        426,
+        "responses_websocket_http_fallback",
+        "Quota sharing requires the HTTP/SSE Responses transport for lease and quota coordination"
+      );
+    }
     const models = Array.isArray(combo.models) ? combo.models : [];
     if (models.some((model) => getComboModelString(model)?.startsWith("chatgpt-web-codex/"))) {
       return jsonError(
@@ -536,6 +544,13 @@ async function prepare(body: JsonRecord) {
         "This Combo contains ChatGPT Web (Codex) and must use the HTTP/SSE Responses transport"
       );
     }
+  }
+  if (isQuotaModelName(context.requestedModel)) {
+    return jsonError(
+      426,
+      "responses_websocket_http_fallback",
+      "Quota sharing requires the HTTP/SSE Responses transport for lease and quota coordination"
+    );
   }
   const upstream = await resolveCodexUpstreamContext(context);
   if ("error" in upstream) return upstream.error;

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -56,6 +56,17 @@ export type { SyncedAvailableModel } from "./models/synced";
 
 // ──────────────── Custom Models ────────────────
 
+function notifyQuotaCombosForProvider(providerId: string): void {
+  void (async () => {
+    try {
+      const { syncQuotaCombosForProvider } = await import("./quotaPools");
+      await syncQuotaCombosForProvider(providerId);
+    } catch {
+      // Non-fatal: quota combo sync errors should not break model operations
+    }
+  })();
+}
+
 export async function getCustomModels(providerId?: string) {
   const db = getDbInstance();
   if (providerId) {
@@ -241,6 +252,7 @@ export async function addCustomModel(
     "INSERT OR REPLACE INTO key_value (namespace, key, value) VALUES ('customModels', ?, ?)"
   ).run(providerId, JSON.stringify(models));
   finishModelCatalogWriteWithBackup();
+  notifyQuotaCombosForProvider(providerId);
   return model;
 }
 
@@ -361,6 +373,7 @@ export async function replaceCustomModels(
   }
 
   finishModelCatalogWriteWithBackup();
+  notifyQuotaCombosForProvider(providerId);
   return merged;
 }
 
@@ -404,6 +417,7 @@ export async function deleteImportedCustomModels(providerId: string): Promise<st
   );
   for (const modelId of removedIds) removeModelCompatOverride(providerId, modelId);
   finishModelCatalogWriteWithBackup();
+  notifyQuotaCombosForProvider(providerId);
   return removedIds;
 }
 
@@ -435,6 +449,7 @@ export async function removeCustomModel(providerId: string, modelId: string) {
 
   removeModelCompatOverride(providerId, modelId);
   finishModelCatalogWriteWithBackup();
+  notifyQuotaCombosForProvider(providerId);
   return true;
 }
 
@@ -615,6 +630,7 @@ export async function replaceSyncedAvailableModelsForConnection(
   const key = `${providerId}:${connectionId}`;
   const normalizedModels = normalizeSyncedAvailableModels(models, providerId);
   persistCanonicalSyncedAvailableModels(key, normalizedModels, normalizeSyncedAvailableModels);
+  notifyQuotaCombosForProvider(providerId);
   // Return the full unioned list for the provider
   return getSyncedAvailableModels(providerId);
 }
@@ -724,7 +740,10 @@ export async function deleteSyncedAvailableModelsForProvider(providerId: string)
     )
     .run(keyPrefix.length, keyPrefix);
   const changes = Number(result.changes || 0);
-  if (changes > 0) finishSyncedAvailableModelsWrite();
+  if (changes > 0) {
+    finishSyncedAvailableModelsWrite();
+    notifyQuotaCombosForProvider(providerId);
+  }
   return changes;
 }
 

--- a/src/lib/db/models.ts
+++ b/src/lib/db/models.ts
@@ -683,7 +683,10 @@ export async function removeSyncedAvailableModel(
   });
 
   removeModel();
-  if (removedAny) finishSyncedAvailableModelsWrite();
+  if (removedAny) {
+    finishSyncedAvailableModelsWrite();
+    notifyQuotaCombosForProvider(providerId);
+  }
   return removedAny;
 }
 
@@ -700,7 +703,10 @@ export async function deleteSyncedAvailableModelsForConnection(
   const result = db
     .prepare("DELETE FROM key_value WHERE namespace = 'syncedAvailableModels' AND key = ?")
     .run(key);
-  if (result.changes > 0) finishSyncedAvailableModelsWrite();
+  if (result.changes > 0) {
+    finishSyncedAvailableModelsWrite();
+    notifyQuotaCombosForProvider(providerId);
+  }
   return getSyncedAvailableModels(providerId);
 }
 
@@ -768,7 +774,10 @@ export async function pruneStaleSyncedAvailableModelsForProvider(
     )
     .run(`${keyPrefix}%`, ...allowedKeys);
   const changes = Number(result.changes || 0);
-  if (changes > 0) finishSyncedAvailableModelsWrite();
+  if (changes > 0) {
+    finishSyncedAvailableModelsWrite();
+    notifyQuotaCombosForProvider(providerId);
+  }
   return changes;
 }
 

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -50,7 +50,7 @@ async function removeQuotaCombosGuarded(poolId: string): Promise<void> {
   } catch (err) {
     console.warn(
       "[quota-pools] removeQuotaCombosForPool failed (non-fatal):",
-      (err as Error)?.message
+      (err as Error)?.message,
     );
   }
 }
@@ -151,7 +151,7 @@ function assertSingleProvider(connectionIds: string[]): void {
   const providers = rows.map((r) => r.provider).filter(Boolean);
   if (new Set(providers).size > 1) {
     throw new Error(
-      `A quota pool must use a single provider (got: ${[...new Set(providers)].join(", ")})`
+      `A quota pool must use a single provider (got: ${[...new Set(providers)].join(", ")})`,
     );
   }
 }
@@ -205,7 +205,7 @@ interface PoolConnectionRow {
 function getConnectionIds(poolId: string, fallbackConnectionId: string): string[] {
   const rows = getDb()
     .prepare<PoolConnectionRow>(
-      "SELECT connection_id FROM quota_pool_connections WHERE pool_id = ? ORDER BY created_at ASC"
+      "SELECT connection_id FROM quota_pool_connections WHERE pool_id = ? ORDER BY created_at ASC",
     )
     .all(poolId);
   if (rows.length > 0) {
@@ -236,7 +236,7 @@ function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
   // Batch allocations: 1 query for all pools
   const allocRows = db
     .prepare<AllocationRow>(
-      `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id IN (${ph})`
+      `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id IN (${ph})`,
     )
     .all(...poolIds);
   const allocsByPool = new Map<string, AllocationRow[]>();
@@ -252,7 +252,7 @@ function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
   // Batch connections: 1 query for all pools
   const connRows = db
     .prepare<{ pool_id: string; connection_id: string }>(
-      `SELECT pool_id, connection_id FROM quota_pool_connections WHERE pool_id IN (${ph}) ORDER BY created_at ASC`
+      `SELECT pool_id, connection_id FROM quota_pool_connections WHERE pool_id IN (${ph}) ORDER BY created_at ASC`,
     )
     .all(...poolIds);
   const connsByPool = new Map<string, string[]>();
@@ -279,7 +279,7 @@ function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
 function getAllocations(poolId: string): PoolAllocation[] {
   const rows = getDb()
     .prepare<AllocationRow>(
-      "SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id = ?"
+      "SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id = ?",
     )
     .all(poolId);
   return rows.map(rowToAllocation);
@@ -350,7 +350,7 @@ export function listPools(options?: { limit?: number; offset?: number }): {
 export function getPool(id: string): QuotaPool | null {
   const row = getDb()
     .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?"
+      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?",
     )
     .get(id);
   if (!row) return null;
@@ -384,12 +384,12 @@ export function createPool(input: PoolCreate): QuotaPool {
   const doCreate = database.transaction(() => {
     database
       .prepare(
-        "INSERT INTO quota_pools (id, connection_id, name, group_id, created_at) VALUES (?, ?, ?, ?, ?)"
+        "INSERT INTO quota_pools (id, connection_id, name, group_id, created_at) VALUES (?, ?, ?, ?, ?)",
       )
       .run(id, primaryConnectionId, input.name, groupId, now);
 
     const insertConn = database.prepare(
-      "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)"
+      "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)",
     );
     for (const connId of members) {
       insertConn.run(id, connId);
@@ -398,7 +398,7 @@ export function createPool(input: PoolCreate): QuotaPool {
     if (input.allocations && input.allocations.length > 0) {
       const insertAlloc = database.prepare(
         `INSERT INTO quota_allocations (pool_id, api_key_id, weight, cap_value, cap_unit, policy)
-         VALUES (?, ?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?, ?)`,
       );
       for (const alloc of input.allocations) {
         insertAlloc.run(
@@ -407,7 +407,7 @@ export function createPool(input: PoolCreate): QuotaPool {
           alloc.weight,
           alloc.capValue ?? null,
           alloc.capUnit ?? null,
-          alloc.policy
+          alloc.policy,
         );
       }
     }
@@ -422,7 +422,7 @@ export function createPool(input: PoolCreate): QuotaPool {
       group_id: groupId,
       created_at: now,
     },
-    getAllocations(id)
+    getAllocations(id),
   );
 
   // Phase B2: fire-and-forget combo sync; failures are logged but never thrown.
@@ -449,10 +449,9 @@ function allocationFingerprint(allocations: PoolAllocation[] = []): string {
 
 /** Idempotent pool management for automation and bounded CLI callers. */
 export function ensurePool(input: PoolCreate): EnsurePoolResult {
-  const members =
-    input.connectionIds && input.connectionIds.length > 0
-      ? input.connectionIds
-      : [input.connectionId];
+  const members = input.connectionIds && input.connectionIds.length > 0
+    ? input.connectionIds
+    : [input.connectionId];
   const groupId = input.groupId || "group-demo";
   const existing = listPools().items.find((pool) => {
     return pool.name === input.name && pool.groupId === groupId;
@@ -490,7 +489,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
   const database = getDb();
   const existing = database
     .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?"
+      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?",
     )
     .get(id);
   if (!existing) return null;
@@ -516,7 +515,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
       // Replace join rows.
       database.prepare("DELETE FROM quota_pool_connections WHERE pool_id = ?").run(id);
       const insertConn = database.prepare(
-        "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)"
+        "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)",
       );
       for (const connId of input.connectionIds) {
         insertConn.run(id, connId);
@@ -531,7 +530,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
       database.prepare("DELETE FROM quota_allocations WHERE pool_id = ?").run(id);
       const insertAlloc = database.prepare(
         `INSERT INTO quota_allocations (pool_id, api_key_id, weight, cap_value, cap_unit, policy)
-         VALUES (?, ?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?, ?)`,
       );
       for (const alloc of input.allocations) {
         insertAlloc.run(
@@ -540,7 +539,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
           alloc.weight,
           alloc.capValue ?? null,
           alloc.capUnit ?? null,
-          alloc.policy
+          alloc.policy,
         );
       }
     }
@@ -648,7 +647,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
   // without requiring a manual re-save. Persists the normalized weights.
   const totalWeight = allocations.reduce(
     (s, a) => s + (Number.isFinite(a.weight) ? a.weight : 0),
-    0
+    0,
   );
   const normalizedAllocations =
     totalWeight === 0 && allocations.length > 0
@@ -659,7 +658,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
   // Defensive: fall back to [poolId] (single-pool semantics) if pool not found.
   const targetPool = database
     .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?"
+      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?",
     )
     .get(poolId);
 
@@ -678,7 +677,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
   const doUpsert = database.transaction(() => {
     const insert = database.prepare(
       `INSERT INTO quota_allocations (pool_id, api_key_id, weight, cap_value, cap_unit, policy)
-       VALUES (?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?)`,
     );
     for (const pid of poolIdsInGroup) {
       database.prepare("DELETE FROM quota_allocations WHERE pool_id = ?").run(pid);
@@ -689,7 +688,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
           alloc.weight,
           alloc.capValue ?? null,
           alloc.capUnit ?? null,
-          alloc.policy
+          alloc.policy,
         );
       }
     }
@@ -706,13 +705,13 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
  * Returns pairs of { poolId, allocation }.
  */
 export function listAllocationsForApiKey(
-  apiKeyId: string
+  apiKeyId: string,
 ): Array<{ poolId: string; allocation: PoolAllocation }> {
   const rows = getDb()
     .prepare<AllocationRow>(
       `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy
        FROM quota_allocations
-       WHERE api_key_id = ?`
+       WHERE api_key_id = ?`,
     )
     .all(apiKeyId);
   return rows.map((row) => ({ poolId: row.pool_id, allocation: rowToAllocation(row) }));

--- a/src/lib/db/quotaPools.ts
+++ b/src/lib/db/quotaPools.ts
@@ -10,7 +10,7 @@
 
 import { getDbInstance } from "./core";
 import { clearApiKeyCaches } from "./apiKeys";
-import { invalidateModelCatalogCache } from "./readCache";
+import { getCachedProviderConnectionById, invalidateModelCatalogCache } from "./readCache";
 // Phase B2: auto-mint/prune quotaShared-* combos when pool allocations change.
 // Imported lazily (dynamic import in the hook) to avoid circular-dependency
 // risk between db/ and quota/ modules. Sync hooks are fire-and-forget; deletion
@@ -50,7 +50,7 @@ async function removeQuotaCombosGuarded(poolId: string): Promise<void> {
   } catch (err) {
     console.warn(
       "[quota-pools] removeQuotaCombosForPool failed (non-fatal):",
-      (err as Error)?.message,
+      (err as Error)?.message
     );
   }
 }
@@ -151,7 +151,7 @@ function assertSingleProvider(connectionIds: string[]): void {
   const providers = rows.map((r) => r.provider).filter(Boolean);
   if (new Set(providers).size > 1) {
     throw new Error(
-      `A quota pool must use a single provider (got: ${[...new Set(providers)].join(", ")})`,
+      `A quota pool must use a single provider (got: ${[...new Set(providers)].join(", ")})`
     );
   }
 }
@@ -205,7 +205,7 @@ interface PoolConnectionRow {
 function getConnectionIds(poolId: string, fallbackConnectionId: string): string[] {
   const rows = getDb()
     .prepare<PoolConnectionRow>(
-      "SELECT connection_id FROM quota_pool_connections WHERE pool_id = ? ORDER BY created_at ASC",
+      "SELECT connection_id FROM quota_pool_connections WHERE pool_id = ? ORDER BY created_at ASC"
     )
     .all(poolId);
   if (rows.length > 0) {
@@ -236,7 +236,7 @@ function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
   // Batch allocations: 1 query for all pools
   const allocRows = db
     .prepare<AllocationRow>(
-      `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id IN (${ph})`,
+      `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id IN (${ph})`
     )
     .all(...poolIds);
   const allocsByPool = new Map<string, AllocationRow[]>();
@@ -252,7 +252,7 @@ function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
   // Batch connections: 1 query for all pools
   const connRows = db
     .prepare<{ pool_id: string; connection_id: string }>(
-      `SELECT pool_id, connection_id FROM quota_pool_connections WHERE pool_id IN (${ph}) ORDER BY created_at ASC`,
+      `SELECT pool_id, connection_id FROM quota_pool_connections WHERE pool_id IN (${ph}) ORDER BY created_at ASC`
     )
     .all(...poolIds);
   const connsByPool = new Map<string, string[]>();
@@ -279,7 +279,7 @@ function batchBuildPools(rows: PoolRow[]): QuotaPool[] {
 function getAllocations(poolId: string): PoolAllocation[] {
   const rows = getDb()
     .prepare<AllocationRow>(
-      "SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id = ?",
+      "SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy FROM quota_allocations WHERE pool_id = ?"
     )
     .all(poolId);
   return rows.map(rowToAllocation);
@@ -350,7 +350,7 @@ export function listPools(options?: { limit?: number; offset?: number }): {
 export function getPool(id: string): QuotaPool | null {
   const row = getDb()
     .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?",
+      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?"
     )
     .get(id);
   if (!row) return null;
@@ -384,12 +384,12 @@ export function createPool(input: PoolCreate): QuotaPool {
   const doCreate = database.transaction(() => {
     database
       .prepare(
-        "INSERT INTO quota_pools (id, connection_id, name, group_id, created_at) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO quota_pools (id, connection_id, name, group_id, created_at) VALUES (?, ?, ?, ?, ?)"
       )
       .run(id, primaryConnectionId, input.name, groupId, now);
 
     const insertConn = database.prepare(
-      "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)",
+      "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)"
     );
     for (const connId of members) {
       insertConn.run(id, connId);
@@ -398,7 +398,7 @@ export function createPool(input: PoolCreate): QuotaPool {
     if (input.allocations && input.allocations.length > 0) {
       const insertAlloc = database.prepare(
         `INSERT INTO quota_allocations (pool_id, api_key_id, weight, cap_value, cap_unit, policy)
-         VALUES (?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?)`
       );
       for (const alloc of input.allocations) {
         insertAlloc.run(
@@ -407,7 +407,7 @@ export function createPool(input: PoolCreate): QuotaPool {
           alloc.weight,
           alloc.capValue ?? null,
           alloc.capUnit ?? null,
-          alloc.policy,
+          alloc.policy
         );
       }
     }
@@ -422,7 +422,7 @@ export function createPool(input: PoolCreate): QuotaPool {
       group_id: groupId,
       created_at: now,
     },
-    getAllocations(id),
+    getAllocations(id)
   );
 
   // Phase B2: fire-and-forget combo sync; failures are logged but never thrown.
@@ -449,9 +449,10 @@ function allocationFingerprint(allocations: PoolAllocation[] = []): string {
 
 /** Idempotent pool management for automation and bounded CLI callers. */
 export function ensurePool(input: PoolCreate): EnsurePoolResult {
-  const members = input.connectionIds && input.connectionIds.length > 0
-    ? input.connectionIds
-    : [input.connectionId];
+  const members =
+    input.connectionIds && input.connectionIds.length > 0
+      ? input.connectionIds
+      : [input.connectionId];
   const groupId = input.groupId || "group-demo";
   const existing = listPools().items.find((pool) => {
     return pool.name === input.name && pool.groupId === groupId;
@@ -489,7 +490,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
   const database = getDb();
   const existing = database
     .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?",
+      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?"
     )
     .get(id);
   if (!existing) return null;
@@ -515,7 +516,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
       // Replace join rows.
       database.prepare("DELETE FROM quota_pool_connections WHERE pool_id = ?").run(id);
       const insertConn = database.prepare(
-        "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)",
+        "INSERT OR IGNORE INTO quota_pool_connections (pool_id, connection_id) VALUES (?, ?)"
       );
       for (const connId of input.connectionIds) {
         insertConn.run(id, connId);
@@ -530,7 +531,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
       database.prepare("DELETE FROM quota_allocations WHERE pool_id = ?").run(id);
       const insertAlloc = database.prepare(
         `INSERT INTO quota_allocations (pool_id, api_key_id, weight, cap_value, cap_unit, policy)
-         VALUES (?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?)`
       );
       for (const alloc of input.allocations) {
         insertAlloc.run(
@@ -539,7 +540,7 @@ export function updatePool(id: string, input: PoolUpdate): QuotaPool | null {
           alloc.weight,
           alloc.capValue ?? null,
           alloc.capUnit ?? null,
-          alloc.policy,
+          alloc.policy
         );
       }
     }
@@ -647,7 +648,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
   // without requiring a manual re-save. Persists the normalized weights.
   const totalWeight = allocations.reduce(
     (s, a) => s + (Number.isFinite(a.weight) ? a.weight : 0),
-    0,
+    0
   );
   const normalizedAllocations =
     totalWeight === 0 && allocations.length > 0
@@ -658,7 +659,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
   // Defensive: fall back to [poolId] (single-pool semantics) if pool not found.
   const targetPool = database
     .prepare<PoolRow>(
-      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?",
+      "SELECT id, connection_id, name, group_id, created_at FROM quota_pools WHERE id = ?"
     )
     .get(poolId);
 
@@ -677,7 +678,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
   const doUpsert = database.transaction(() => {
     const insert = database.prepare(
       `INSERT INTO quota_allocations (pool_id, api_key_id, weight, cap_value, cap_unit, policy)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?)`
     );
     for (const pid of poolIdsInGroup) {
       database.prepare("DELETE FROM quota_allocations WHERE pool_id = ?").run(pid);
@@ -688,7 +689,7 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
           alloc.weight,
           alloc.capValue ?? null,
           alloc.capUnit ?? null,
-          alloc.policy,
+          alloc.policy
         );
       }
     }
@@ -705,14 +706,46 @@ export function upsertAllocations(poolId: string, allocations: PoolAllocation[])
  * Returns pairs of { poolId, allocation }.
  */
 export function listAllocationsForApiKey(
-  apiKeyId: string,
+  apiKeyId: string
 ): Array<{ poolId: string; allocation: PoolAllocation }> {
   const rows = getDb()
     .prepare<AllocationRow>(
       `SELECT pool_id, api_key_id, weight, cap_value, cap_unit, policy
        FROM quota_allocations
-       WHERE api_key_id = ?`,
+       WHERE api_key_id = ?`
     )
     .all(apiKeyId);
   return rows.map((row) => ({ poolId: row.pool_id, allocation: rowToAllocation(row) }));
+}
+
+/**
+ * Sync quota combos for all pools associated with a provider.
+ * Triggered when custom models or synced models change for that provider.
+ */
+export async function syncQuotaCombosForProvider(providerId: string): Promise<void> {
+  try {
+    const { items: pools } = listPools();
+    for (const pool of pools) {
+      let matches = false;
+      const connectionIds = pool.connectionIds?.length ? pool.connectionIds : [pool.connectionId];
+      for (const connId of connectionIds) {
+        if (!connId) continue;
+        const conn = (await getCachedProviderConnectionById(connId).catch(() => null)) as {
+          provider?: string;
+        } | null;
+        if (conn?.provider === providerId) {
+          matches = true;
+          break;
+        }
+      }
+      if (matches) {
+        void serializeQuotaComboMaintenance(pool.id, () => syncQuotaCombosGuarded(pool.id));
+      }
+    }
+  } catch (err) {
+    console.warn(
+      "[quota-pools] syncQuotaCombosForProvider failed (non-fatal):",
+      (err as Error)?.message
+    );
+  }
 }

--- a/src/lib/quota/quotaCombos.ts
+++ b/src/lib/quota/quotaCombos.ts
@@ -20,11 +20,7 @@ import {
   getComboByName,
   updateCombo,
 } from "@/lib/db/combos";
-import {
-  getCustomModels,
-  getSyncedAvailableModelsForConnection,
-  getSyncedAvailableModels,
-} from "@/lib/db/models";
+import { getCustomModels, getSyncedAvailableModelsForConnection } from "@/lib/db/models";
 import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry";
 import {
   quotaModelName,
@@ -117,9 +113,9 @@ function getProviderModelIds(provider: string): string[] {
  * Return the list of model IDs for a provider by unioning:
  * 1. Provider REGISTRY (same source /v1/models uses)
  * 2. Custom models configured for this provider in the database
- * 3. Synced models discovered from upstream for this connection/provider
+ * 3. Synced models discovered from upstream for this connection
  */
-async function resolveProviderModelIds(provider: string, connId?: string): Promise<string[]> {
+async function resolveProviderModelIds(provider: string, connId: string): Promise<string[]> {
   const modelIds = new Set<string>(getProviderModelIds(provider));
 
   try {
@@ -140,25 +136,10 @@ async function resolveProviderModelIds(provider: string, connId?: string): Promi
   }
 
   try {
-    if (connId) {
-      const syncedForConn = await getSyncedAvailableModelsForConnection(provider, connId);
-      if (Array.isArray(syncedForConn)) {
-        for (const m of syncedForConn) {
-          if (m?.id && typeof m.id === "string") {
-            const id = m.id.trim();
-            if (id) modelIds.add(id);
-          }
-        }
-      }
-    }
-    const syncedForProvider = await getSyncedAvailableModels(provider);
-    if (Array.isArray(syncedForProvider)) {
-      for (const m of syncedForProvider) {
-        if (m?.id && typeof m.id === "string") {
-          const id = m.id.trim();
-          if (id) modelIds.add(id);
-        }
-      }
+    const synced = await getSyncedAvailableModelsForConnection(provider, connId);
+    for (const model of synced) {
+      const id = model.id.trim();
+      if (id) modelIds.add(id);
     }
   } catch (err) {
     log.warn(
@@ -228,7 +209,6 @@ export async function syncQuotaCombos(poolId: string): Promise<void> {
     if (typeof provider !== "string" || provider.length === 0) continue;
 
     const modelIds = await resolveProviderModelIds(provider, connId);
-    if (modelIds.length === 0) continue;
 
     for (const modelId of modelIds) {
       // B4: use groupName (not pool.name) as the first arg so combos carry the group slug.

--- a/src/lib/quota/quotaCombos.ts
+++ b/src/lib/quota/quotaCombos.ts
@@ -20,6 +20,11 @@ import {
   getComboByName,
   updateCombo,
 } from "@/lib/db/combos";
+import {
+  getCustomModels,
+  getSyncedAvailableModelsForConnection,
+  getSyncedAvailableModels,
+} from "@/lib/db/models";
 import { REGISTRY } from "@omniroute/open-sse/config/providerRegistry";
 import {
   quotaModelName,
@@ -108,6 +113,63 @@ function getProviderModelIds(provider: string): string[] {
     .filter((id): id is string => id !== null && id.length > 0);
 }
 
+/**
+ * Return the list of model IDs for a provider by unioning:
+ * 1. Provider REGISTRY (same source /v1/models uses)
+ * 2. Custom models configured for this provider in the database
+ * 3. Synced models discovered from upstream for this connection/provider
+ */
+async function resolveProviderModelIds(provider: string, connId?: string): Promise<string[]> {
+  const modelIds = new Set<string>(getProviderModelIds(provider));
+
+  try {
+    const custom = await getCustomModels(provider);
+    if (Array.isArray(custom)) {
+      for (const m of custom) {
+        if (m && typeof m === "object" && typeof (m as { id?: unknown }).id === "string") {
+          const id = (m as { id: string }).id.trim();
+          if (id) modelIds.add(id);
+        }
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { err: (err as Error)?.message, provider },
+      "failed to load custom models for quota combos"
+    );
+  }
+
+  try {
+    if (connId) {
+      const syncedForConn = await getSyncedAvailableModelsForConnection(provider, connId);
+      if (Array.isArray(syncedForConn)) {
+        for (const m of syncedForConn) {
+          if (m?.id && typeof m.id === "string") {
+            const id = m.id.trim();
+            if (id) modelIds.add(id);
+          }
+        }
+      }
+    }
+    const syncedForProvider = await getSyncedAvailableModels(provider);
+    if (Array.isArray(syncedForProvider)) {
+      for (const m of syncedForProvider) {
+        if (m?.id && typeof m.id === "string") {
+          const id = m.id.trim();
+          if (id) modelIds.add(id);
+        }
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { err: (err as Error)?.message, provider, connId },
+      "failed to load synced models for quota combos"
+    );
+  }
+
+  return Array.from(modelIds);
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -165,7 +227,7 @@ export async function syncQuotaCombos(poolId: string): Promise<void> {
     const provider = connection.provider;
     if (typeof provider !== "string" || provider.length === 0) continue;
 
-    const modelIds = getProviderModelIds(provider);
+    const modelIds = await resolveProviderModelIds(provider, connId);
     if (modelIds.length === 0) continue;
 
     for (const modelId of modelIds) {

--- a/tests/unit/codex-responses-ws-model-resolution.test.ts
+++ b/tests/unit/codex-responses-ws-model-resolution.test.ts
@@ -60,3 +60,15 @@ test("genuinely non-codex model stays non-codex (bridge then rejects it)", async
   const info = await resolveCodexWsModelInfo("gpt-4o", resolver);
   assert.notEqual(info.provider, "codex");
 });
+
+test("quota-shared model id unwraps provider and model directly", async () => {
+  let calls = 0;
+  const resolver: ModelResolver = async (m) => {
+    calls += 1;
+    return { provider: "qtSd", model: m };
+  };
+  const info = await resolveCodexWsModelInfo("qtSd/omni/codex/gpt-5.6-luna", resolver);
+  assert.equal(info.provider, "codex");
+  assert.equal(info.model, "gpt-5.6-luna");
+  assert.equal(calls, 0, "should unwrap quota model without calling resolver");
+});

--- a/tests/unit/quota-combos-custom-and-synced.test.ts
+++ b/tests/unit/quota-combos-custom-and-synced.test.ts
@@ -91,3 +91,87 @@ test("syncQuotaCombos generates qtSd/ combos for synced models added to a connec
   assert.ok(combo, `combo "${expectedName}" must exist for synced model`);
   assert.equal(combo.strategy, "quota-share");
 });
+
+async function createTestConnection(provider: string, name: string) {
+  const connection = await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    name,
+    apiKey: `test-${name}`,
+  });
+  return String(connection.id);
+}
+
+async function waitForCombo(name: string, exists: boolean) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const combo = await combosDb.getComboByName(name);
+    if (Boolean(combo) === exists) return combo;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`Expected ${name} to ${exists ? "exist" : "be removed"}`);
+}
+
+test("synced models target only the connection that reported them", async () => {
+  const provider = "quota-test-provider";
+  const first = await createTestConnection(provider, "first");
+  const second = await createTestConnection(provider, "second");
+  const outside = await createTestConnection(provider, "outside");
+  await modelsDb.replaceSyncedAvailableModelsForConnection(provider, first, [{ id: "first-only" }]);
+  await modelsDb.replaceSyncedAvailableModelsForConnection(provider, second, [
+    { id: "second-only" },
+  ]);
+  await modelsDb.replaceSyncedAvailableModelsForConnection(provider, outside, [
+    { id: "outside-only" },
+  ]);
+  const pool = poolsDb.createPool({
+    connectionId: first,
+    connectionIds: [first, second],
+    name: "Scoped models",
+  });
+  await syncQuotaCombos(pool.id);
+  for (const [model, connectionId] of [
+    ["first-only", first],
+    ["second-only", second],
+  ]) {
+    const combo = await combosDb.getComboByName(quotaModelName("GroupDemo", provider, model));
+    assert.ok(combo);
+    assert.deepEqual(
+      (combo.models as Array<{ connectionId: string }>).map((step) => step.connectionId),
+      [connectionId]
+    );
+  }
+  assert.equal(
+    Boolean(await combosDb.getComboByName(quotaModelName("GroupDemo", provider, "outside-only"))),
+    false
+  );
+});
+
+test("removing the last custom model prunes a provider without registry models", async () => {
+  const provider = "quota-test-provider";
+  const connectionId = await createTestConnection(provider, "custom");
+  poolsDb.createPool({ connectionId, name: "Custom models" });
+  await modelsDb.addCustomModel(provider, "custom-only");
+  const name = quotaModelName("GroupDemo", provider, "custom-only");
+  await waitForCombo(name, true);
+  await modelsDb.removeCustomModel(provider, "custom-only");
+  await waitForCombo(name, false);
+});
+
+for (const operation of ["remove", "delete-connection", "prune"] as const) {
+  test(`${operation} automatically removes stale synced quota models`, async () => {
+    const provider = "glm";
+    const connectionId = await createTestConnection(provider, operation);
+    poolsDb.createPool({ connectionId, name: "Synced models" });
+    await modelsDb.replaceSyncedAvailableModelsForConnection(provider, connectionId, [
+      { id: "synced-only" },
+    ]);
+    const name = quotaModelName("GroupDemo", provider, "synced-only");
+    await waitForCombo(name, true);
+    if (operation === "remove") await modelsDb.removeSyncedAvailableModel(provider, "synced-only");
+    if (operation === "delete-connection")
+      await modelsDb.deleteSyncedAvailableModelsForConnection(provider, connectionId);
+    if (operation === "prune")
+      await modelsDb.pruneStaleSyncedAvailableModelsForProvider(provider, ["other-connection"]);
+    await waitForCombo(name, false);
+  });
+}

--- a/tests/unit/quota-combos-custom-and-synced.test.ts
+++ b/tests/unit/quota-combos-custom-and-synced.test.ts
@@ -1,0 +1,93 @@
+/**
+ * tests/unit/quota-combos-custom-and-synced.test.ts
+ *
+ * Verifies that syncQuotaCombos mints qtSd/ combos for custom models and
+ * synced available models, not only hardcoded REGISTRY entries.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-quota-custom-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const poolsDb = await import("../../src/lib/db/quotaPools.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const modelsDb = await import("../../src/lib/db/models.ts");
+const { syncQuotaCombos } = await import("../../src/lib/quota/quotaCombos.ts");
+const { quotaModelName } = await import("../../src/lib/quota/quotaModelNaming.ts");
+const combosDb = await import("../../src/lib/db/combos.ts");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  if (fs.existsSync(TEST_DATA_DIR))
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(async () => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("syncQuotaCombos generates qtSd/ combos for custom models added to a provider", async () => {
+  const provider = "codex";
+  const customModelId = "gpt-6-astra";
+
+  const conn = await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    name: "codex-test",
+    apiKey: "sk-codex-test",
+  });
+  const connId = (conn as Record<string, unknown>).id as string;
+  const pool = poolsDb.createPool({ connectionId: connId, name: "Codex Quota Pool" });
+
+  // Add custom model
+  await modelsDb.addCustomModel(provider, customModelId, "GPT-6 Astra");
+
+  // Sync quota combos
+  await syncQuotaCombos(pool.id);
+
+  const expectedName = quotaModelName("GroupDemo", provider, customModelId);
+  const combo = await combosDb.getComboByName(expectedName);
+  assert.ok(combo, `combo "${expectedName}" must exist for custom model`);
+  assert.equal(combo.strategy, "quota-share");
+  const models = combo.models as Array<{ model: string }>;
+  assert.equal(models[0]?.model, `${provider}/${customModelId}`);
+});
+
+test("syncQuotaCombos generates qtSd/ combos for synced models added to a connection", async () => {
+  const provider = "openrouter";
+  const syncedModelId = "deepseek/deepseek-r1-distill";
+
+  const conn = await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    name: "openrouter-test",
+    apiKey: "sk-openrouter-test",
+  });
+  const connId = (conn as Record<string, unknown>).id as string;
+  const pool = poolsDb.createPool({ connectionId: connId, name: "OpenRouter Pool" });
+
+  // Add synced model for this connection
+  await modelsDb.replaceSyncedAvailableModelsForConnection(provider, connId, [
+    { id: syncedModelId, name: "DeepSeek R1 Distill" },
+  ]);
+
+  // Sync quota combos
+  await syncQuotaCombos(pool.id);
+
+  const expectedName = quotaModelName("GroupDemo", provider, syncedModelId);
+  const combo = await combosDb.getComboByName(expectedName);
+  assert.ok(combo, `combo "${expectedName}" must exist for synced model`);
+  assert.equal(combo.strategy, "quota-share");
+});


### PR DESCRIPTION
## Summary

- **Support custom & synced models in Quota Sharing**: `syncQuotaCombos` previously only checked static provider registries, ignoring custom models and models imported from providers. Quota pools generate `qtSd/` virtual models for both, and automatically re-sync when models are added or removed.

- **WebSocket to HTTP fallback for quota pools**: The Responses WebSocket bridge cannot handle multi-account DRR scheduling or in-flight leases. Requesting a `qtSd/` model over WebSocket now returns HTTP 426 (`responses_websocket_http_fallback`), telling Codex CLI to cleanly retry over HTTP/SSE.

- **Fix pool wizard preview**: Modal preview now uses the group slug instead of the raw pool name so it matches actual endpoint names.

## Issues closed

- Closes #13151

## Validation

- [x] Change type: routing / DB / UI
- [x] Ran focused tests:
  - `tests/unit/quota-combos-custom-and-synced.test.ts`
  - `tests/unit/codex-responses-ws-model-resolution.test.ts`
  - `tests/unit/quota-combos-sync.test.ts`
  - `npm run check:cycles`
  - `npm run typecheck:core`
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/quota-combos-custom-and-synced.test.ts` (new tests for custom and synced model combo creation)
- `tests/unit/codex-responses-ws-model-resolution.test.ts` (added test for unwrapping `qtSd/` model names)

## Coverage Notes

- Covered by `quota-combos-custom-and-synced.test.ts` and `codex-responses-ws-model-resolution.test.ts`.

## Reviewer Notes

- No database migrations needed.
- Uses the existing `responses_websocket_http_fallback` mechanism that Codex CLI already supports.

## Post-rebase validation (2026-09-18)

Rebased onto `release/v3.8.51` at `7cc454d931da506722bcbfa93873be6d97a1d5fc`. Resolved the conflicts in `src/lib/db/models.ts` and the Responses WebSocket route. Preserved the upstream vision-override and synced-model persistence modules, the sync timestamp update, and the existing quota-combo notifications and HTTP 426 fallback.

Fresh run on `e27b54f296b3db3350401e8f5abe1fe17d2f976c` with Node.js v24.16.0:

```sh
node --import tsx/esm --test tests/unit/quota-combos-custom-and-synced.test.ts tests/unit/codex-responses-ws-model-resolution.test.ts tests/unit/quota-combos-sync.test.ts
```

**22 passed, 0 failed, 0 skipped.** Prettier checks for both conflict files and `git diff --check` also passed. The full unit and Vitest suites were not rerun for this rebase.
