### PR TITLE
docs(changelog): format the merged 13094 fragment as a markdown bullet

### DIFF
--- a/changelog.d/fixes/13094-deepseek-pow-slot-leak.md
+++ b/changelog.d/fixes/13094-deepseek-pow-slot-leak.md
@@ -1,1 +1,1 @@
-Fix a concurrency-slot leak in the DeepSeek PoW solver: a worker that failed to spawn (for example a missing worker script) never released its slot, so `MAX_CONCURRENT_WORKERS` failures disabled the solver until restart.
+- **fix(deepseek):** the PoW solver releases its concurrency slot when a worker fails to spawn (for example a missing worker script), so `MAX_CONCURRENT_WORKERS` failures no longer disable the solver until restart ([#13097](https://github.com/diegosouzapw/OmniRoute/pull/13097))


### PR DESCRIPTION
The changelog fragment added by #13097 shipped as a bare paragraph instead of a markdown bullet.

`scripts/check/check-changelog-integrity.mjs` requires every fragment to start with `- `, so this fails the **Merge integrity (changelog + generated skills)** gate on *every* branch built off `release/v3.8.51` — not only the PR that introduced it.

```
✗ changelog.d/fixes/13094-deepseek-pow-slot-leak.md: fragment must start with a markdown bullet ("- ")
```

Reformatted to match the surrounding fragments (bolded scope prefix + PR link). The gate reports 0 violations afterwards. Content is unchanged apart from the bullet and the link.