### PR TITLE
fix(quota): apply the equal-split fallback in the pool usage snapshot

### DIFF
--- a/src/lib/quota/redisQuotaStore.ts
+++ b/src/lib/quota/redisQuotaStore.ts
@@ -271,7 +271,13 @@ export class RedisQuotaStore implements QuotaStore {
         const consumed = await this.peek(alloc.apiKeyId, dim);
         consumedTotal += consumed;
 
-        const effectiveWeight = totalWeight > 0 ? alloc.weight : 0;
+        // Equal-split fallback, matching enforce.ts: when every allocation in the
+        // pool has weight 0, each counts as an equal share, so the snapshot
+        // describes the budget enforcement actually grants. The old ternary could
+        // not do this -- totalWeight === 0 implies every alloc.weight is 0, so both
+        // arms returned 0 -- and every key rendered as borrowing all it consumed.
+        const effectiveWeight =
+          totalWeight > 0 ? alloc.weight : allocations.length > 0 ? 100 / allocations.length : 0;
         const fairShare = (effectiveWeight / 100) * planDim.limit;
         const deficit = consumed - fairShare;
         const borrowing = consumed > fairShare;

--- a/src/lib/quota/sqliteQuotaStore.ts
+++ b/src/lib/quota/sqliteQuotaStore.ts
@@ -198,7 +198,13 @@ export class SqliteQuotaStore implements QuotaStore {
         const consumed = await this.peek(alloc.apiKeyId, dim);
         consumedTotal += consumed;
 
-        const effectiveWeight = totalWeight > 0 ? alloc.weight : 0;
+        // Equal-split fallback, matching enforce.ts: when every allocation in the
+        // pool has weight 0, each counts as an equal share, so the snapshot
+        // describes the budget enforcement actually grants. The old ternary could
+        // not do this -- totalWeight === 0 implies every alloc.weight is 0, so both
+        // arms returned 0 -- and every key rendered as borrowing all it consumed.
+        const effectiveWeight =
+          totalWeight > 0 ? alloc.weight : allocations.length > 0 ? 100 / allocations.length : 0;
         const fairShare = (effectiveWeight / 100) * planDim.limit;
         const deficit = consumed - fairShare;
         const borrowing = consumed > fairShare;

--- a/tests/unit/quota-pool-usage-equal-split.test.ts
+++ b/tests/unit/quota-pool-usage-equal-split.test.ts
@@ -1,0 +1,159 @@
+/**
+ * tests/unit/quota-pool-usage-equal-split.test.ts
+ *
+ * Regression: enforce.ts applies an equal-split fallback when every allocation
+ * in a pool has weight 0 (see quota-equal-split.test.ts), but neither quota
+ * store did the same in poolUsageWithDimensions. GET /api/quota/pools/[id]/usage
+ * therefore reported fairShare = 0 for every key in such a pool, so each one
+ * rendered as borrowing its entire consumption while enforcement was happily
+ * granting it 100/N of the budget. Same pool, two answers.
+ *
+ * The tell was that the store's ternary could not do anything: weights are
+ * non-negative, so `totalWeight === 0` implies every `alloc.weight` is already
+ * 0, and `totalWeight > 0 ? alloc.weight : 0` returned `alloc.weight` either
+ * way. The branch existed exactly where the fallback belonged.
+ *
+ * This is the same divergence class as quota-pool-usage-summed-budget.test.ts,
+ * which corrected the accountCount side of the enforce↔usage split.
+ *
+ * Levels:
+ *   A (structural): both stores compute effectiveWeight with the equal-split
+ *     fallback, in the same shape enforce.ts uses, and the no-op form is gone.
+ *   B (logic): replicate the store's per-key math to prove the fallback fixes
+ *     fairShare and clears the bogus borrowing flag, and that pools with real
+ *     weights are untouched.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(fileURLToPath(import.meta.url), "..", "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+const STORES = [
+  "src/lib/quota/sqliteQuotaStore.ts",
+  "src/lib/quota/redisQuotaStore.ts",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Level A — structural: both stores carry the enforce.ts fallback
+// ---------------------------------------------------------------------------
+
+for (const store of STORES) {
+  test(`${store} applies the equal-split fallback to effectiveWeight`, () => {
+    const src = read(store);
+    assert.ok(
+      /100 \/ allocations\.length/.test(src),
+      "store must fall back to an equal 100/N share when the pool has no weights"
+    );
+    assert.ok(
+      /allocations\.length > 0\s*\?\s*100 \/ allocations\.length\s*:\s*0/.test(src),
+      "the equal split must guard against an empty allocation list, like enforce.ts"
+    );
+  });
+
+  test(`${store} no longer zeroes effectiveWeight when the pool has no weights`, () => {
+    const src = read(store);
+    assert.ok(
+      !/const effectiveWeight = totalWeight > 0 \? alloc\.weight : 0;/.test(src),
+      "the old ternary was a no-op and must not come back"
+    );
+  });
+}
+
+test("enforce.ts is still the shape the stores are mirroring", () => {
+  const src = read("src/lib/quota/enforce.ts");
+  assert.ok(
+    /allocCount > 0\s*\?\s*100 \/ allocCount\s*:\s*0/.test(src),
+    "enforce.ts must keep the equal-split fallback the stores now mirror"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Level B — logic: the fallback corrects fairShare and the borrowing flag
+//
+// Replicates the per-key math from poolUsageWithDimensions:
+//   fairShare = (effectiveWeight / 100) × planDim.limit
+//   deficit   = consumed - fairShare
+//   borrowing = consumed > fairShare
+// ---------------------------------------------------------------------------
+
+/** The store's per-key snapshot, parameterised by the effectiveWeight rule. */
+function perKey(
+  allocations: Array<{ weight: number }>,
+  index: number,
+  limit: number,
+  consumed: number,
+  withFallback: boolean
+) {
+  const totalWeight = allocations.reduce((sum, a) => sum + a.weight, 0);
+  const alloc = allocations[index]!;
+  const effectiveWeight = withFallback
+    ? totalWeight > 0
+      ? alloc.weight
+      : allocations.length > 0
+        ? 100 / allocations.length
+        : 0
+    : totalWeight > 0
+      ? alloc.weight
+      : 0;
+  const fairShare = (effectiveWeight / 100) * limit;
+  return { fairShare, deficit: consumed - fairShare, borrowing: consumed > fairShare };
+}
+
+test("all-zero pool: the snapshot now grants the same share enforcement does", () => {
+  const allocations = [{ weight: 0 }, { weight: 0 }];
+  const LIMIT = 1000;
+  const CONSUMED = 100;
+
+  const before = perKey(allocations, 0, LIMIT, CONSUMED, false);
+  assert.equal(before.fairShare, 0, "sanity: the bug gave every key a zero share");
+  assert.equal(before.deficit, CONSUMED, "sanity: the whole consumption read as a deficit");
+  assert.equal(before.borrowing, true, "sanity: every key was flagged as borrowing");
+
+  const after = perKey(allocations, 0, LIMIT, CONSUMED, true);
+  assert.equal(after.fairShare, 500, "two unweighted keys split the limit evenly");
+  assert.equal(after.deficit, -400, "a key inside its share runs a negative deficit");
+  assert.equal(after.borrowing, false, "and must not be flagged as borrowing");
+});
+
+test("all-zero pool: the snapshot share matches what enforce.ts computes", () => {
+  const allocations = [{ weight: 0 }, { weight: 0 }, { weight: 0 }, { weight: 0 }];
+  const LIMIT = 1000;
+
+  // enforce.ts: effectiveWeight = 100 / allocCount when poolTotalWeight === 0
+  const enforced = (100 / allocations.length / 100) * LIMIT;
+  const snapshot = perKey(allocations, 2, LIMIT, 0, true).fairShare;
+
+  assert.equal(snapshot, enforced, "usage and enforcement must agree on the fair share");
+  assert.equal(snapshot, 250, "four unweighted keys get a quarter each");
+});
+
+test("weighted pools are untouched by the fallback", () => {
+  const allocations = [{ weight: 70 }, { weight: 30 }];
+  const LIMIT = 1000;
+
+  for (const index of [0, 1]) {
+    const before = perKey(allocations, index, LIMIT, 0, false);
+    const after = perKey(allocations, index, LIMIT, 0, true);
+    assert.equal(after.fairShare, before.fairShare, "a weighted pool keeps its shares");
+  }
+  assert.equal(perKey(allocations, 0, LIMIT, 0, true).fairShare, 700);
+  assert.equal(perKey(allocations, 1, LIMIT, 0, true).fairShare, 300);
+});
+
+test("a pool where one key carries all the weight still starves the rest", () => {
+  // totalWeight > 0, so the fallback must not engage: a 0-weight key next to a
+  // weighted one is a deliberate allocation, not an unconfigured pool.
+  const allocations = [{ weight: 100 }, { weight: 0 }];
+  const LIMIT = 1000;
+
+  assert.equal(perKey(allocations, 0, LIMIT, 0, true).fairShare, 1000);
+  assert.equal(
+    perKey(allocations, 1, LIMIT, 0, true).fairShare,
+    0,
+    "an explicitly unweighted key in a weighted pool keeps its zero share"
+  );
+});


### PR DESCRIPTION
## Summary

A quota pool whose allocations all have weight 0 is reported as fully over-subscribed
on the dashboard, while enforcement is happily letting the same keys through.

`enforce.ts:238-246` treats such a pool as an equal split, with a comment saying why:

```ts
// Equal-split fallback: when ALL allocations in the pool have weight 0 (e.g. newly
// added keys whose weight was never set), treat each as an equal share so the pool
// is usable without requiring a re-save. Original non-zero weights are kept as-is.
const effectiveWeight =
  poolTotalWeight > 0 ? poolAllocation.weight : allocCount > 0 ? 100 / allocCount : 0;
```

`upsertAllocations` (`src/lib/db/quotaPools.ts:646`) normalises the same case on write,
for the same stated reason. But `poolUsageWithDimensions` — in **both** stores — did not:

```ts
const effectiveWeight = totalWeight > 0 ? alloc.weight : 0;
const fairShare = (effectiveWeight / 100) * planDim.limit;
const deficit = consumed - fairShare;
const borrowing = consumed > fairShare;
```

so `GET /api/quota/pools/[id]/usage` returns `fairShare: 0`, `deficit: <everything
consumed>`, `borrowing: true` for every key in the pool.

### The line could not do anything

Weights are non-negative, so `totalWeight === 0` implies every `alloc.weight` is already
`0` — both arms of that ternary return the same value. It is a no-op sitting exactly
where the fallback belongs, which is what convinced me this was an omission rather than
a deliberate difference.

### Effect

Pool with two allocations, both `weight: 0`, one `tokens` dimension with `limit: 1000`,
one key having consumed 100:

| | fairShare | deficit | borrowing |
|---|---|---|---|
| `enforceQuotaShare` | 500 | — | allows |
| `/usage` before | **0** | **100** | **true** |
| `/usage` after | 500 | −400 | false |

`sqliteQuotaStore.ts:201` and `redisQuotaStore.ts:274` carried the identical line; both
now mirror `enforce.ts`.

Pools with real weights are untouched. So is a `weight: 0` key sitting next to a
weighted one — there `totalWeight > 0`, the fallback stays out, and that deliberate zero
share is preserved. There is a test for exactly that case.

## Related Issues

- Related to #10253 — same enforce↔usage divergence class, on the `accountCount` side.

## Validation

- [x] Change type: **DB** (quota stores) — no UI, provider, routing or i18n surface
- [x] Focused tests: `quota-pool-usage-equal-split`, plus `quota-equal-split`,
      `quota-pool-usage-summed-budget`, `quota-pool-usage-shape`, `quota-fair-share`,
      `quota-enforce` for regressions
- [ ] `npm run lint` — **not run**; I do not have the repo's `node_modules` installed on
      this machine, so `eslint.config.mjs` cannot resolve `@eslint/compat`. The changed
      files are `prettier --write` clean against `prettier.config.mjs`, and the new
      expression is structurally identical to the one already at `enforce.ts:246`
      (nested ternary, no `eslint-disable`), so I expect CI to be green — but I would
      rather say I skipped it than tick a box I did not exercise.
- [x] Reconciled with the current active release base (`release/v3.8.51`)
- [x] Production-code changes include a new automated test in this PR

## Tests Added Or Updated

- `tests/unit/quota-pool-usage-equal-split.test.ts` (new)

Structured like `quota-pool-usage-summed-budget.test.ts`:

- **Level A (structural)** — both stores compute `effectiveWeight` with the equal-split
  fallback and the empty-list guard, the old no-op form is gone, and `enforce.ts` still
  has the shape they mirror.
- **Level B (logic)** — replicates the store's per-key math to show the fallback fixes
  `fairShare`/`deficit`/`borrowing`, that the snapshot share now equals what `enforce.ts`
  computes, and that weighted pools (including `[100, 0]`) are unchanged.

Reverting the two store files alone makes exactly the four Level A tests fail (9 pass /
0 fail → 5 pass / 4 fail); Level B passes either way by design, since it carries both
rules.

## Coverage Notes

The change is two lines in `src/lib/quota/`, both covered by the Level A structural
assertions and by the Level B math that mirrors the surrounding function.

## Reviewer Notes

- No migration, no feature flag, no schema change.
- Reachability: since `upsertAllocations` normalises all-zero weights on write, a pool in
  that state today comes from rows written before that normalisation landed — or from any
  future writer that bypasses it. `enforce.ts` keeps its own fallback for the same reason,
  so I have matched the reporting path to the enforcement path rather than assume the
  state is now impossible. If you would rather delete the fallback everywhere and rely
  solely on write-time normalisation, that is a coherent alternative — it just needs to be
  one decision applied to all three places.
- I could not run `npm run lint` locally; see Validation above.
