### PR TITLE
fix(resilience): treat a Cloudflare managed challenge as a fingerprint rejection, not a ban (#13157)

### DIFF
--- a/open-sse/services/errorClassifier.ts
+++ b/open-sse/services/errorClassifier.ts
@@ -194,12 +194,44 @@ function isGeoBlockEligibleProvider(provider?: string | null): boolean {
 const CLOUDFLARE_1010_REGEX =
   /(?<![A-Za-z0-9_-])error[\s_-]?code[\\"':=\s]{0,12}1010(?!\w)|(?<![A-Za-z0-9_-])error[-_]\s?1010(?!\w)\/?/i;
 
+// A Cloudflare managed/JS challenge is the SAME class of block as a 1010 — the
+// edge refused the CLIENT's signature and demanded an interactive browser
+// challenge — but it is a different product surface and carries none of the
+// 1010 markers. It arrives as a ~12KB text/html interstitial (with header
+// `cf-mitigated: challenge`), so a body-shape match is the only signal
+// available to a classifier that sees the body alone.
+//
+// Observed verbatim on `POST chatgpt.com/backend-api/codex/responses/input_tokens`
+// for a HEALTHY Codex OAuth account whose token refreshed successfully in the
+// same second and which served normal `/responses` traffic seconds before and
+// after: `window._cf_chl_opt = {... cType: 'managed', cZone: 'chatgpt.com' ...}`.
+// Without this branch the challenge falls through to FORBIDDEN, and chatCore's
+// FORBIDDEN handler writes the terminal `banned`/`isActive:false` state that
+// never auto-recovers — taking the whole provider offline until an operator
+// reconnects, on a block that says nothing about account health.
+//
+// IMPORTANT: these markers are matched as full, distinctive Cloudflare-internal
+// strings, never as loose words like "challenge" — a provider error body may
+// legitimately discuss a "challenge" in prose.
+const CLOUDFLARE_CHALLENGE_MARKERS = [
+  "_cf_chl_opt",
+  "cdn-cgi/challenge-platform",
+  'id="challenge-error-text"',
+  String.raw`id=\"challenge-error-text\"`,
+] as const;
+
+export function isCloudflareChallengeInterstitial(errorText: string): boolean {
+  const text = String(errorText || "").toLowerCase();
+  return CLOUDFLARE_CHALLENGE_MARKERS.some((marker) => text.includes(marker.toLowerCase()));
+}
+
 export function isCloudflareFingerprintRejection(errorText: string): boolean {
   const text = String(errorText || "").toLowerCase();
   return (
     CLOUDFLARE_1010_REGEX.test(text) ||
     text.includes("browser_signature_banned") ||
-    text.includes("fingerprint_rejection")
+    text.includes("fingerprint_rejection") ||
+    isCloudflareChallengeInterstitial(text)
   );
 }
 

--- a/tests/unit/error-classifier.test.ts
+++ b/tests/unit/error-classifier.test.ts
@@ -5,6 +5,7 @@ const {
   classifyProviderError,
   isResourceNotFoundResponse,
   isCloudflareFingerprintRejection,
+  isCloudflareChallengeInterstitial,
   PROVIDER_ERROR_TYPES,
 } = await import("../../open-sse/services/errorClassifier.ts");
 
@@ -400,4 +401,113 @@ test("classifyProviderError: 422 without the BYOP code stays unclassified (no mo
     null
   );
   assert.equal(classifyProviderError(422, "some other body", "antigravity"), null);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cloudflare managed-challenge interstitial (Codex /responses/input_tokens)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Trimmed but verbatim-shaped excerpt of the interstitial served by Cloudflare on
+// POST chatgpt.com/backend-api/codex/responses/input_tokens (response headers carry
+// `cf-mitigated: challenge`, `server: cloudflare`, `content-type: text/html`).
+const CF_MANAGED_CHALLENGE_BODY = [
+  '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title></head><body>',
+  '<div class="main-content"><noscript><div class="h2">',
+  '<span id="challenge-error-text">Enable JavaScript and cookies to continue</span>',
+  "</div></noscript></div>",
+  "<script>(function(){window._cf_chl_opt = {cFPWv: 'g',cRay: 'a38b1a06cd3ea3e3',",
+  "cType: 'managed',cZone: 'chatgpt.com',cUPMDTk:\"/backend-api/codex/responses/input_tokens\"};",
+  "var a = document.createElement('script');",
+  "a.src = '/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1?ray=a38b1a06cd3ea3e3';",
+  "})();</script></body></html>",
+].join("");
+
+test("classifyProviderError: Cloudflare managed challenge on codex => FINGERPRINT_REJECTION, not FORBIDDEN", () => {
+  // Regression guard: this body previously fell through the whole 403 ladder to
+  // FORBIDDEN, which chatCore persists as the terminal banned/isActive:false state.
+  // The account was healthy — its OAuth token refreshed successfully in the same
+  // second and normal /responses traffic succeeded seconds before and after.
+  const result = classifyProviderError(403, CF_MANAGED_CHALLENGE_BODY, "codex");
+  assert.equal(
+    result,
+    PROVIDER_ERROR_TYPES.FINGERPRINT_REJECTION,
+    "a Cloudflare managed challenge must never terminalize the connection"
+  );
+  assert.notEqual(result, PROVIDER_ERROR_TYPES.FORBIDDEN, "must not fall through to FORBIDDEN");
+});
+
+test("classifyProviderError: managed challenge nested in the gateway error.message => FINGERPRINT_REJECTION", () => {
+  // The executor commonly wraps the upstream body inside error.message, which is
+  // how the operator-visible "[403]: <html>" message is produced.
+  const body = JSON.stringify({
+    error: { message: `[codex/gpt-5.6-sol] [403]: ${CF_MANAGED_CHALLENGE_BODY}` },
+  });
+  assert.equal(
+    classifyProviderError(403, body, "codex"),
+    PROVIDER_ERROR_TYPES.FINGERPRINT_REJECTION
+  );
+});
+
+test("isCloudflareChallengeInterstitial: each distinctive marker is recognized", () => {
+  assert.equal(isCloudflareChallengeInterstitial(CF_MANAGED_CHALLENGE_BODY), true, "full body");
+  assert.equal(
+    isCloudflareChallengeInterstitial("window._cf_chl_opt = {cType: 'managed'}"),
+    true,
+    "_cf_chl_opt"
+  );
+  assert.equal(
+    isCloudflareChallengeInterstitial("/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"),
+    true,
+    "challenge-platform path"
+  );
+  assert.equal(
+    isCloudflareChallengeInterstitial('<span id="challenge-error-text">'),
+    true,
+    "challenge-error-text span"
+  );
+  assert.equal(
+    isCloudflareChallengeInterstitial(String.raw`<span id=\"challenge-error-text\">`),
+    true,
+    "escaped-quote nested form"
+  );
+});
+
+test("isCloudflareChallengeInterstitial: prose mentioning a challenge is NOT a match (FP guard)", () => {
+  // The markers are full Cloudflare-internal strings, never the loose word
+  // "challenge" — provider bodies legitimately discuss challenges in prose.
+  assert.equal(
+    isCloudflareChallengeInterstitial("this request failed a security challenge, please retry"),
+    false,
+    "prose challenge"
+  );
+  assert.equal(
+    isCloudflareChallengeInterstitial(
+      '{"error":"challenge_required","detail":"solve a challenge"}'
+    ),
+    false,
+    "challenge_required code"
+  );
+  assert.equal(
+    isCloudflareChallengeInterstitial("challenge-platform"),
+    false,
+    "bare, no cdn-cgi path"
+  );
+  assert.equal(isCloudflareChallengeInterstitial(""), false, "empty body");
+});
+
+test("classifyProviderError: the terminal 403 paths are unchanged by the challenge branch", () => {
+  // Regression guard for the neighbouring carve-outs: a genuine permission 403
+  // still bans, and ChatGPT Web's Sentinel/Turnstile 403 (#8813) stays FORBIDDEN.
+  assert.equal(
+    classifyProviderError(403, { error: { message: "you do not have permission" } }, "codex"),
+    PROVIDER_ERROR_TYPES.FORBIDDEN
+  );
+  assert.equal(
+    classifyProviderError(403, JSON.stringify({ error: "SENTINEL_BLOCKED" }), "chatgpt-web"),
+    PROVIDER_ERROR_TYPES.FORBIDDEN
+  );
+  assert.equal(
+    classifyProviderError(403, "Turnstile required", "chatgpt-web"),
+    PROVIDER_ERROR_TYPES.FORBIDDEN
+  );
 });


### PR DESCRIPTION
Closes #13157

## Problem

A Cloudflare **managed challenge** served in front of an upstream provider is classified `FORBIDDEN` and persisted as the terminal `banned` connection state, taking the whole provider offline until an operator reconnects in the dashboard.

Observed on `POST chatgpt.com/backend-api/codex/responses/input_tokens` for a **healthy** Codex OAuth account:

```
15:14:07  Trying model 2/2: cx/gpt-5.6-sol
15:14:10  Model cx/gpt-5.6-sol succeeded (5986ms, 0 fallbacks)      ← normal chat OK
15:14:38  POST /v1/responses/input_tokens | …
15:14:39  Successfully refreshed Codex token / CODEX | refreshed    ← credential healthy
15:14:39  [provider] Node e94ce3e6-… banned (403) — disabling permanently
15:14:39  codex | 1 accounts found but none active
```

The OAuth token refreshing successfully in the same second, and normal `/responses` traffic succeeding seconds before and after on the same connection, show the account was never banned upstream.

## Root cause

`isCloudflareFingerprintRejection()` only recognises the Cloudflare **1010** family (`error_code:1010`, `browser_signature_banned`, `fingerprint_rejection`). A managed challenge is the same class of block — the edge refused the *client's* signature, not the credential — but it is a different product surface and carries none of those markers, so the guard at the top of the `403` branch misses it:

```ts
if (statusCode === 403 && isCloudflareFingerprintRejection(bodyStr)) {
  return PROVIDER_ERROR_TYPES.FINGERPRINT_REJECTION;   // ← not reached
}
```

Execution then falls through the rest of the ladder — not geo-blocked, not `accountDeactivated`, not a Cloud Code project error, not `SENTINEL_BLOCKED`/`Turnstile required`, `codex` is neither an `apikey`-category provider nor `authType: "none"` — and lands on `return PROVIDER_ERROR_TYPES.FORBIDDEN`, which `chatCore` persists through `writeTerminalStatus()`.

Measured response, captured against the live account:

```
status 403
cf-mitigated: challenge
server: cloudflare
content-type: text/html; charset=UTF-8

_cf_chl_opt                                  present
cdn-cgi/challenge-platform                   present
id="challenge-error-text"                    present
cType: 'managed'   cZone: 'chatgpt.com'

error code: 1010                             absent
error_code                                   absent
browser_signature_banned                     absent
fingerprint_rejection                        absent
```

The ~12KB HTML body is also why the operator-visible error degrades to `[403]: <html>`.

## Fix

Recognise the challenge interstitial and classify it as `FINGERPRINT_REJECTION`, reusing the existing non-terminal precedent from #9929 — `authTerminalStatus.isNonTerminalProviderError()` already treats that type as non-terminal, so the failing request falls through to the next combo target and the account state stays untouched.

Markers are matched as full, distinctive Cloudflare-internal strings — `_cf_chl_opt`, `cdn-cgi/challenge-platform`, and the `challenge-error-text` span id including its escaped-quote nested form — never as the loose word "challenge", which a provider body may legitimately use in prose.

This is an additive branch on an existing carve-out; the genuine-`403` path is untouched.

## Note for reviewers

`ENABLE_TLS_FINGERPRINT=true` is not a workaround for this. On the affected deployment all `2516` rows in `proxy_logs` — both `codex` and `claude`, successes included — carry `tls_fingerprint = 0` even though the flag is set and `wreq-js` is installed, so the fingerprint transport is never actually taken there. That looks like a separate defect (possibly related to #12491) and is out of scope for this PR.

## Tests

`tests/unit/error-classifier.test.ts` — 39/39 pass (6 new):

- the full managed-challenge interstitial classifies as `FINGERPRINT_REJECTION`, not `FORBIDDEN`;
- the same body nested inside the gateway's `error.message` wrapper;
- each marker recognised individually, including the escaped-quote nested form;
- false-positive guards: prose mentioning a "challenge", a `challenge_required` error code, a bare `challenge-platform` without the `cdn-cgi` path, and an empty body all stay unmatched;
- regression guards: a genuine permission `403` and the ChatGPT Web `SENTINEL_BLOCKED` / `Turnstile required` `403` (#8813) both still classify as `FORBIDDEN`.

Also run: `tests/unit/auth-terminal-status.test.ts` 11/11 pass, `npm run typecheck:core` clean, `eslint` clean on both changed files.
