### PR TITLE
fix(deps): declare remark-gfm as a direct dependency

### DIFF
--- a/config/quality/dependency-allowlist.json
+++ b/config/quality/dependency-allowlist.json
@@ -130,6 +130,7 @@
     "react-markdown",
     "react-reconciler",
     "recharts",
+    "remark-gfm",
     "safe-regex",
     "selfsigned",
     "sharp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "react-reconciler": "^0.33.0",
         "react18-json-view": "0.2.10",
         "recharts": "^3.8.1",
+        "remark-gfm": "^4.0.1",
         "safe-regex": "^2.1.1",
         "selfsigned": "^5.5.0",
         "sharp": "^0.35.4",

--- a/package.json
+++ b/package.json
@@ -346,6 +346,7 @@
     "react-reconciler": "^0.33.0",
     "react18-json-view": "0.2.10",
     "recharts": "^3.8.1",
+    "remark-gfm": "^4.0.1",
     "safe-regex": "^2.1.1",
     "selfsigned": "^5.5.0",
     "sharp": "^0.35.4",


### PR DESCRIPTION
MarkdownMessage.tsx and other client components (traffic-inspector chat, RequestLoggerDetail) import remark-gfm directly, but it was only present transitively via fumadocs-mdx (a devDependency). npm's flat node_modules hoisting happens to resolve it — masking the issue — but pnpm's strict node_modules isolation fails with "Module not found: Can't resolve remark-gfm" since the package was never declared as a direct dependency of the app.

This PR declares it explicitly in package.json/package-lock.json and adds it to the supply-chain dependency allowlist.

Validation: no automated test reproduces this under npm (hoisting masks it there); reproduced manually via a clean pnpm install + npm run dev, which fails to compile MarkdownMessage.tsx before this fix and succeeds after. npm run check:deps, npm run lint (pre-existing errors only, unrelated file), and npm run check:any-budget:t11 all pass on this branch.

⚠️ base-red inherited: #12732