### PR TITLE
test: use deterministic clocks and local fixtures

### DIFF
--- a/changelog.d/fixes/12539-deterministic-test-fixtures.md
+++ b/changelog.d/fixes/12539-deterministic-test-fixtures.md
@@ -1,0 +1,1 @@
+- Use controlled clocks and local service fixtures in batch, breaker, and scheduled-job tests to reduce real-time waits and host-environment dependencies.

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -4081,11 +4081,6 @@
       "count": 1
     }
   },
-  "tests/unit/lib/jobRegistry/registry.test.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "tests/unit/lib/managementCliToken.test.ts": {
     "@typescript-eslint/no-unused-vars": {
       "count": 1

--- a/tests/helpers/redisProbeServer.ts
+++ b/tests/helpers/redisProbeServer.ts
@@ -1,0 +1,70 @@
+import net from "node:net";
+
+// ioredis pipelines handshake commands. TCP chunks are not command boundaries:
+// reply once per complete RESP command, retaining partial commands for later data.
+export async function startRedisProbeServer(
+  reply: (command: string, socket: net.Socket) => string
+) {
+  const sockets = new Set<net.Socket>();
+  let connections = 0;
+  const server = net.createServer((socket) => {
+    connections++;
+    sockets.add(socket);
+    let pending = Buffer.alloc(0);
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      sockets.delete(socket);
+    });
+    socket.on("data", (chunk) => {
+      pending = Buffer.concat([pending, chunk]);
+      while (pending.length > 0) {
+        const headerEnd = pending.indexOf("\r\n");
+        if (headerEnd === -1) return;
+        const count = Number(pending.subarray(1, headerEnd).toString());
+        if (pending[0] !== 42 || !Number.isSafeInteger(count) || count < 1) {
+          socket.destroy(new Error("Expected a RESP command array"));
+          return;
+        }
+        const args: string[] = [];
+        let offset = headerEnd + 2;
+        for (let index = 0; index < count; index++) {
+          const end = pending.indexOf("\r\n", offset);
+          if (end === -1) return;
+          const size = Number(pending.subarray(offset + 1, end).toString());
+          if (pending[offset] !== 36 || !Number.isSafeInteger(size) || size < 0) {
+            socket.destroy(new Error("Expected a RESP bulk string"));
+            return;
+          }
+          if (pending.length < end + 2 + size + 2) return;
+          args.push(pending.subarray(end + 2, end + 2 + size).toString());
+          offset = end + 2 + size + 2;
+        }
+        pending = pending.subarray(offset);
+        const response = reply(args[0].toLowerCase(), socket);
+        if (socket.destroyed) return;
+        socket.write(response);
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return {
+    port: (server.address() as net.AddressInfo).port,
+    connections: () => connections,
+    socketClosed: () => connections > 0 && sockets.size === 0,
+    close: () => {
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    },
+  };
+}
+
+export function redisHandshakeReply(command: string): string {
+  if (command === "info") {
+    const body = "redis_version:7.0.0\r\n";
+    return `$${Buffer.byteLength(body)}\r\n${body}\r\n`;
+  }
+  return command === "ping" ? "+PONG\r\n" : "+OK\r\n";
+}

--- a/tests/unit/audit-timeline.test.ts
+++ b/tests/unit/audit-timeline.test.ts
@@ -24,15 +24,21 @@ function makeEntry(id: number, timestampIso: string, action = "provider.added"):
   };
 }
 
-// Reference: 2026-05-27T15:00:00.000Z (UTC)
-const REF = new Date("2026-05-27T15:00:00.000Z").getTime();
-// Today: 2026-05-27
-const TODAY_ISO = "2026-05-27T10:00:00.000Z";
-const TODAY_ISO_2 = "2026-05-27T08:00:00.000Z";
-// Yesterday: 2026-05-26
-const YESTERDAY_ISO = "2026-05-26T12:00:00.000Z";
-// 3 days ago: 2026-05-24
-const WEEK_AGO_ISO = "2026-05-24T09:00:00.000Z";
+// Build the fixture in local calendar time because groupByDay intentionally uses
+// the server's local day. Fixed UTC literals near a date boundary can map to
+// different local dates, such as the Asia/Seoul reference crossing local midnight.
+const REFERENCE_DATE = new Date(2026, 4, 27, 15, 0, 0, 0);
+const REF = REFERENCE_DATE.getTime();
+const localIso = (dayOffset: number, hour: number) => {
+  const date = new Date(REFERENCE_DATE);
+  date.setDate(date.getDate() + dayOffset);
+  date.setHours(hour, 0, 0, 0);
+  return date.toISOString();
+};
+const TODAY_ISO = localIso(0, 10);
+const TODAY_ISO_2 = localIso(0, 8);
+const YESTERDAY_ISO = localIso(-1, 12);
+const WEEK_AGO_ISO = localIso(-3, 9);
 
 // ── groupByDay ─────────────────────────────────────────────────────────────
 

--- a/tests/unit/batch_api.test.ts
+++ b/tests/unit/batch_api.test.ts
@@ -53,7 +53,19 @@ test.afterEach(async () => {
   }
 });
 
-test("Batch API and Processing", async () => {
+test("Batch API and Processing", async (t) => {
+  const dispatched: Request[] = [];
+  t.mock.method(globalThis, "fetch", async (input, init) => {
+    dispatched.push(new Request(input, init));
+    return new Response(
+      JSON.stringify({
+        model: "gpt-4o-mini",
+        choices: [{ message: { role: "assistant", content: "batch response" } }],
+        usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  });
   // 0. Setup environment, mock provider and API key
   process.env.API_KEY_SECRET = "test-secret-123";
 
@@ -104,69 +116,38 @@ test("Batch API and Processing", async () => {
   assert.ok(batch.id.startsWith("batch_"), "Batch ID should start with batch_");
   assert.strictEqual(batch.status, "validating");
 
-  // 3. Start the processor manually for one tick (or wait if we used initBatchProcessor)
-  // For testing, we might want to expose the processing functions or just wait.
-  // We'll use a shorter interval in the processor if we want to test polling.
-  // Here we'll just call processPendingBatches if it was exported, but it's not.
-
-  // Instead of polling, let's just wait a bit if we started the processor
+  // Keep the polling entry point covered while advancing only its interval clock.
+  t.mock.timers.enable({ apis: ["setInterval"] });
   initBatchProcessor();
-
-  console.log("Waiting for batch processing...");
-
-  // Poll for status change
-  let maxAttempts = 30;
-  let currentBatch = getBatch(batch.id);
-  while (
-    maxAttempts > 0 &&
-    currentBatch?.status !== "completed" &&
-    currentBatch?.status !== "failed" &&
-    currentBatch?.status !== "cancelled"
-  ) {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    currentBatch = getBatch(batch.id);
-    const progress = currentBatch?.requestCountsTotal
-      ? `${currentBatch.requestCountsCompleted}/${currentBatch.requestCountsTotal}`
-      : "not started";
-    console.log(
-      `[TEST] Current status: ${currentBatch?.status}, completed: ${progress}, failed: ${currentBatch?.requestCountsFailed || 0}`
-    );
-    maxAttempts--;
-  }
-
-  // Stop the processor so the test can exit
+  t.mock.timers.tick(9_999);
+  assert.strictEqual(getBatch(batch.id)?.status, "validating", "polling must wait ten seconds");
+  assert.strictEqual(dispatched.length, 0);
+  t.mock.timers.tick(1);
+  await waitForAllBatches();
   stopBatchProcessor();
-
-  if (maxAttempts === 0) {
-    console.error(
-      "[TEST] Polling timed out. Final batch state:",
-      JSON.stringify(currentBatch, null, 2)
-    );
-  }
-
-  assert.ok(
-    currentBatch?.status === "completed" || currentBatch?.status === "failed",
-    "Batch should reach a terminal state"
-  );
-
-  // In test environment, the mock key might fail, which is fine for this test as long as it finishes
-  if (currentBatch?.status === "failed" || currentBatch?.requestCountsFailed > 0) {
-    console.warn(
-      "[TEST] Batch finished with failures (likely due to mock credentials). This is acceptable for this test."
-    );
-    assert.strictEqual(currentBatch?.requestCountsTotal, 2, "Total requests should be 2");
-    assert.strictEqual(
-      (currentBatch?.requestCountsCompleted || 0) + (currentBatch?.requestCountsFailed || 0),
-      2,
-      "Total processed should be 2"
-    );
-    return;
-  }
+  const currentBatch = getBatch(batch.id);
 
   assert.strictEqual(currentBatch?.status, "completed", "Batch should be completed");
   assert.strictEqual(currentBatch?.requestCountsTotal, 2);
   assert.strictEqual(currentBatch?.requestCountsCompleted, 2);
+  assert.strictEqual(currentBatch?.requestCountsFailed, 0);
   assert.ok(currentBatch?.outputFileId, "Should have output file ID");
+
+  assert.strictEqual(dispatched.length, 2, "each batch item must be dispatched once");
+  for (const [index, request] of dispatched.entries()) {
+    const url = new URL(request.url);
+    assert.strictEqual(url.hostname, "127.0.0.1");
+    assert.ok(url.pathname.endsWith("/v1/chat/completions"));
+    assert.strictEqual(request.method, "POST");
+    assert.strictEqual(request.headers.get("Content-Type"), "application/json");
+    assert.strictEqual(request.headers.get("Authorization"), `Bearer ${apiKey.key}`);
+    assert.strictEqual(request.redirect, "error");
+    assert.deepStrictEqual(await request.json(), {
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: ["Hello world", "Goodbye world"][index] }],
+      stream: false,
+    });
+  }
 
   const inputFileAfter = getFile(file.id);
   assert.ok(inputFileAfter, "Input file should exist");
@@ -209,7 +190,6 @@ test("Batch handles and counts failures correctly", async () => {
       headers: { "Content-Type": "application/json" },
     });
 
-  initBatchProcessor();
   try {
     // 1. Create a file with a request that will fail (invalid provider/model)
     const batchItems = [
@@ -240,18 +220,10 @@ test("Batch handles and counts failures correctly", async () => {
       apiKeyId: null,
     });
 
-    // 3. Poll for completion
-    let maxAttempts = 20;
-    let currentBatch = getBatch(batch.id);
-    while (
-      maxAttempts > 0 &&
-      currentBatch?.status !== "completed" &&
-      currentBatch?.status !== "failed"
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      currentBatch = getBatch(batch.id);
-      maxAttempts--;
-    }
+    // 3. Process pending work to completion
+    await processPendingBatches();
+    await waitForAllBatches();
+    const currentBatch = getBatch(batch.id);
 
     // 4. Verify failure counts
     assert.strictEqual(currentBatch?.requestCountsTotal, 1, "Total should be 1");
@@ -290,7 +262,6 @@ test("Batch dispatches non-chat endpoints through the matching route handler", a
       }
     );
 
-  initBatchProcessor();
   try {
     await createProviderConnection({
       provider: "openai",
@@ -327,17 +298,9 @@ test("Batch dispatches non-chat endpoints through the matching route handler", a
       apiKeyId: null,
     });
 
-    let maxAttempts = 20;
-    let currentBatch = getBatch(batch.id);
-    while (
-      maxAttempts > 0 &&
-      currentBatch?.status !== "completed" &&
-      currentBatch?.status !== "failed"
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      currentBatch = getBatch(batch.id);
-      maxAttempts--;
-    }
+    await processPendingBatches();
+    await waitForAllBatches();
+    const currentBatch = getBatch(batch.id);
 
     assert.strictEqual(currentBatch?.status, "completed", "embedding batch should complete");
     assert.strictEqual(currentBatch?.requestCountsCompleted, 1);
@@ -355,7 +318,6 @@ test("Batch dispatches non-chat endpoints through the matching route handler", a
 });
 
 test("Batch rejects input lines whose url does not match the batch endpoint", async () => {
-  initBatchProcessor();
   try {
     const batchItems = [
       JSON.stringify({
@@ -413,7 +375,6 @@ test("Batch forces stream: false for all requests", async () => {
     );
   };
 
-  initBatchProcessor();
   try {
     const batchItems = [
       JSON.stringify({
@@ -443,17 +404,9 @@ test("Batch forces stream: false for all requests", async () => {
       apiKeyId: null,
     });
 
-    let maxAttempts = 20;
-    let currentBatch = getBatch(batch.id);
-    while (
-      maxAttempts > 0 &&
-      currentBatch?.status !== "completed" &&
-      currentBatch?.status !== "failed"
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      currentBatch = getBatch(batch.id);
-      maxAttempts--;
-    }
+    await processPendingBatches();
+    await waitForAllBatches();
+    const currentBatch = getBatch(batch.id);
 
     assert.strictEqual(currentBatch?.status, "completed", "Batch should be completed");
     const outputFileId = currentBatch?.outputFileId || currentBatch?.errorFileId;
@@ -1183,8 +1136,15 @@ test("File metadata helpers do not load content blobs", async () => {
   assert.deepEqual(getFileContent(record.id), content);
 });
 
-test("Batch dispatches to embeddings handler for /v1/embeddings URL", async () => {
-  initBatchProcessor();
+test("Batch dispatches to embeddings handler for /v1/embeddings URL", async (t) => {
+  let dispatchedUrl = "";
+  t.mock.method(globalThis, "fetch", async (input) => {
+    dispatchedUrl = String(input);
+    return new Response(JSON.stringify({ error: { message: "Embedding model unavailable" } }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
   try {
     const batchItems = [
       JSON.stringify({
@@ -1210,23 +1170,18 @@ test("Batch dispatches to embeddings handler for /v1/embeddings URL", async () =
       apiKeyId: null,
     });
 
-    let maxAttempts = 20;
-    let currentBatch = getBatch(batch.id);
-    while (
-      maxAttempts > 0 &&
-      currentBatch?.status !== "completed" &&
-      currentBatch?.status !== "failed"
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      currentBatch = getBatch(batch.id);
-      maxAttempts--;
-    }
+    await processPendingBatches();
+    await waitForAllBatches();
+    const currentBatch = getBatch(batch.id);
 
     assert.ok(
       currentBatch?.status === "completed" || currentBatch?.status === "failed",
       "Batch should reach a terminal state"
     );
     assert.strictEqual(currentBatch?.requestCountsTotal, 1);
+
+    assert.equal(new URL(dispatchedUrl).pathname.endsWith("/v1/embeddings"), true);
+    assert.equal(currentBatch?.requestCountsFailed, 1);
 
     // Verify the batch item was dispatched to the embeddings handler, not the chat handler.
     // The chat handler would return errors about missing "messages", "Missing model", etc.

--- a/tests/unit/binaryManager.test.ts
+++ b/tests/unit/binaryManager.test.ts
@@ -247,7 +247,9 @@ describe("binaryManager", () => {
 
         assert.equal(spawn.command, path.join(binDir, "cliproxyapi.exe"));
         assert.equal(fs.existsSync(spawn.command), true);
-        assert.equal(await mod.getCurrentBinaryPath(tmpDir), spawn.command);
+        const currentBinaryPath = await mod.getCurrentBinaryPath(tmpDir);
+        assert.ok(currentBinaryPath);
+        assert.equal(fs.realpathSync(currentBinaryPath), fs.realpathSync(spawn.command));
       } finally {
         if (originalPlatformDescriptor) {
           Object.defineProperty(process, "platform", originalPlatformDescriptor);

--- a/tests/unit/compression-settings-cache.test.ts
+++ b/tests/unit/compression-settings-cache.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+import test, { mock } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -110,17 +110,37 @@ test("getCompressionSettings returned config has expected shape", async () => {
 test("getCompressionSettings TTL expires after 5 seconds", async () => {
   setup();
   try {
+    const { getDbInstance } = await import("../../src/lib/db/core.ts");
     const { getCompressionSettings } = await import("../../src/lib/db/compression.ts");
 
-    const first = await getCompressionSettings();
-    const cached = await getCompressionSettings();
-    assert.equal(first, cached, "should be cached within TTL");
+    // Run migrations before mocking Date so migration timestamps stay real. The
+    // cache itself only reads Date.now(), so advancing the Date clock is enough
+    // to exercise both sides of the five-second boundary without sleeping.
+    getDbInstance();
+    // Start beyond any cache left by the preceding tests in this process; the
+    // module intentionally has no test-only cache reset hook.
+    mock.timers.enable({ apis: ["Date"], now: Date.now() + 6_000 });
 
-    await new Promise((r) => setTimeout(r, 5100));
+    try {
+      const first = await getCompressionSettings();
+      const cached = await getCompressionSettings();
+      assert.equal(first, cached, "should be cached within TTL");
 
-    const afterExpiry = await getCompressionSettings();
-    assert.deepEqual(first, afterExpiry, "config content should be equivalent after TTL expiry");
-    assert.notEqual(first, afterExpiry, "should be a new object reference after TTL expiry");
+      mock.timers.tick(4_999);
+      assert.equal(
+        await getCompressionSettings(),
+        first,
+        "cache should remain valid just before the TTL boundary"
+      );
+
+      mock.timers.tick(2);
+
+      const afterExpiry = await getCompressionSettings();
+      assert.deepEqual(first, afterExpiry, "config content should be equivalent after TTL expiry");
+      assert.notEqual(first, afterExpiry, "should be a new object reference after TTL expiry");
+    } finally {
+      mock.timers.reset();
+    }
   } finally {
     cleanup();
   }

--- a/tests/unit/lib/jobRegistry/registry.test.ts
+++ b/tests/unit/lib/jobRegistry/registry.test.ts
@@ -1,4 +1,4 @@
-/** JobRegistry runtime tests . Uses real timers + isolated temp DB. */
+/** JobRegistry runtime tests . Uses mocked timers + isolated temp DB. */
 
 // Access private internals (avoids `as any`).
 type TestRegistry = JobRegistry & {
@@ -9,7 +9,7 @@ function regInternals(reg: JobRegistry): TestRegistry {
   return reg as TestRegistry;
 }
 
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -24,6 +24,21 @@ process.env.DISABLE_SQLITE_AUTO_BACKUP = "true";
 const core = await import("@/lib/db/core.ts");
 const index = await import("@/lib/jobRegistry/index.ts");
 const { getJobRegistry, __resetJobRegistry } = index;
+
+const TIMER_APIS = ["Date", "setTimeout", "setInterval"] as const;
+
+function enableMockTimers(t: TestContext, now = Date.now()): void {
+  // Initialize SQLite before replacing the timer globals: the DB bootstrap has
+  // its own synchronous setup and should not depend on a fake clock.
+  core.getDbInstance();
+  t.mock.timers.enable({ apis: [...TIMER_APIS], now });
+}
+
+function flush(): Promise<void> {
+  // setImmediate is intentionally left real so async safeRun continuations can
+  // drain without advancing the scheduler under test.
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 let nowIso: string;
 function def(
@@ -70,7 +85,8 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
-test("register + start (interval) fires handler immediately", async () => {
+test("register + start (interval) fires handler immediately", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -80,12 +96,13 @@ test("register + start (interval) fires handler immediately", async () => {
     })
   );
   reg.start("j");
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   assert.equal(calls, 1, "interval fires once on start");
   reg.stop("j");
 });
 
-test("re-entrancy: second tick skipped while handler is running", async () => {
+test("re-entrancy: second tick skipped while handler is running", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   let release: (v: void) => void = () => {};
@@ -102,17 +119,18 @@ test("re-entrancy: second tick skipped while handler is running", async () => {
     )
   );
   reg.start("j"); // fires immediately, blocks on gate
-  await new Promise((r) => setTimeout(r, 10));
+  await flush();
   assert.equal(calls, 1);
   // ~100ms passes; setInterval would tick again but must be skipped (running guard).
-  await new Promise((r) => setTimeout(r, 120));
+  t.mock.timers.tick(120);
   assert.equal(calls, 1, "must not re-enter while handler runs");
   release();
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   reg.stop("j");
 });
 
-test("cron nextTick: handler fires via recursive setTimeout", async () => {
+test("cron nextTick: handler fires via recursive setTimeout", async (t) => {
+  enableMockTimers(t, Date.parse("2026-01-01T00:00:00.000Z"));
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -131,12 +149,17 @@ test("cron nextTick: handler fires via recursive setTimeout", async () => {
     )
   );
   reg.start("j");
-  await new Promise((r) => setTimeout(r, 1400));
+  t.mock.timers.tick(999);
+  await flush();
+  assert.equal(calls, 0, "cron handler must wait for the next exact second");
+  t.mock.timers.tick(1);
+  await flush();
   reg.stop("j");
-  assert.ok(calls >= 1, `cron handler should fire at least once, got ${calls}`);
+  assert.equal(calls, 1, "cron handler should fire exactly at the next second boundary");
 });
 
-test("runNow: manual trigger starts a disabled job's run", async () => {
+test("runNow: manual trigger starts a disabled job's run", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -147,7 +170,7 @@ test("runNow: manual trigger starts a disabled job's run", async () => {
   );
   const res = await reg.runNow("j");
   assert.deepEqual(res, { started: true });
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   assert.equal(calls, 1);
 });
 
@@ -164,7 +187,8 @@ test("runNow: unknown job returns reason=not_found", async () => {
   assert.deepEqual(res, { started: false, reason: "not_found" });
 });
 
-test("runNow: queue depth=1, coalesces concurrent triggers then re-runs", async () => {
+test("runNow: queue depth=1, coalesces concurrent triggers then re-runs", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   let release: (v: void) => void = () => {};
@@ -183,7 +207,7 @@ test("runNow: queue depth=1, coalesces concurrent triggers then re-runs", async 
   // The queued promise must not pile up: only one extra fire after release.
   release();
   const queuedRes = await queued;
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   assert.equal(calls, 2, "initial + one queued re-run = 2 fires, no pile-up");
   assert.deepEqual(queuedRes, { started: true });
 });
@@ -201,7 +225,8 @@ test("runNow: env gate blocks when env explicitly disabled", async () => {
   assert.equal(calls, 0);
 });
 
-test("setEnabled(false) stops timer; handler no longer fires", async () => {
+test("setEnabled(false) stops timer; handler no longer fires", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -215,14 +240,17 @@ test("setEnabled(false) stops timer; handler no longer fires", async () => {
     )
   );
   reg.start("j");
-  await new Promise((r) => setTimeout(r, 25));
+  t.mock.timers.tick(25);
+  await flush();
   reg.setEnabled("j", false);
-  await new Promise((r) => setTimeout(r, 120));
+  t.mock.timers.tick(120);
+  await flush();
   reg.stop("j");
   assert.equal(calls, 1, "only the immediate fire before disable");
 });
 
-test("setEnabled(true) restarts a stopped job", async () => {
+test("setEnabled(true) restarts a stopped job", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -236,12 +264,15 @@ test("setEnabled(true) restarts a stopped job", async () => {
     )
   );
   reg.setEnabled("j", true);
-  await new Promise((r) => setTimeout(r, 130));
+  await flush();
+  t.mock.timers.tick(130);
+  await flush();
   reg.stop("j");
   assert.ok(calls >= 2, `expected repeated fires, got ${calls}`);
 });
 
-test("envFlag gate generic: unset env fires (defaultWhenUnset=true)", async () => {
+test("envFlag gate generic: unset env fires (defaultWhenUnset=true)", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -261,30 +292,41 @@ test("envFlag gate generic: unset env fires (defaultWhenUnset=true)", async () =
     )
   );
   reg.start("j");
-  await new Promise((r) => setTimeout(r, 1400));
+  t.mock.timers.tick(2_000);
+  await flush();
   reg.stop("j");
   assert.ok(calls >= 1, "unset env with default=true should fire");
 });
 
-test("envFlag gate warmup: unset env does NOT fire (envDefault=false)", async () => {
+test("envFlag gate warmup: unset env does NOT fire (envDefault=false)", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
-    def("j", async () => ({ success: true }), {
-      type: "cron",
-      cron: "* * * * * *",
-      intervalMs: null,
-      envFlag: "OMNIROUTE_WARMUP_ENABLED",
-      config: { timezone: "UTC", envDefault: false },
-    })
+    def(
+      "j",
+      async () => {
+        calls++;
+        return { success: true };
+      },
+      {
+        type: "cron",
+        cron: "* * * * * *",
+        intervalMs: null,
+        envFlag: "OMNIROUTE_WARMUP_ENABLED",
+        config: { timezone: "UTC", envDefault: false },
+      }
+    )
   );
   reg.start("j");
-  await new Promise((r) => setTimeout(r, 1400));
+  t.mock.timers.tick(2_000);
+  await flush();
   reg.stop("j");
   assert.equal(calls, 0, "unset env with envDefault=false must not fire");
 });
 
-test("startAll: registers + starts all enabled jobs; throws if no handlers", async () => {
+test("startAll: registers + starts all enabled jobs; throws if no handlers", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   await assert.rejects(() => reg.startAll(), /No handlers registered/);
 
@@ -303,13 +345,14 @@ test("startAll: registers + starts all enabled jobs; throws if no handlers", asy
     })
   );
   await reg.startAll();
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   assert.ok(a >= 1, "job a started");
   assert.ok(b >= 1, "job b started");
   reg.stopAll();
 });
 
-test("startAll isolation: a missing handler skips that job, starts the rest", async () => {
+test("startAll isolation: a missing handler skips that job, starts the rest", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let a = 0;
   reg.register(
@@ -333,12 +376,13 @@ test("startAll isolation: a missing handler skips that job, starts the rest", as
     updatedAt: nowIso,
   });
   await reg.startAll();
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   assert.ok(a >= 1, "registered job a still starts despite orphan in DB");
   reg.stopAll();
 });
 
-test("startAll isolation: one job whose start() throws does not abort the rest", async () => {
+test("startAll isolation: one job whose start() throws does not abort the rest", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let a = 0;
   let c = 0;
@@ -370,13 +414,14 @@ test("startAll isolation: one job whose start() throws does not abort the rest",
     reg.start = realStart;
   }
 
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   assert.ok(a >= 1, "job registered before the throwing one still started");
   assert.ok(c >= 1, "job registered after the throwing one still started");
   reg.stopAll();
 });
 
-test("error isolation: handler throw records failure and survives", async () => {
+test("error isolation: handler throw records failure and survives", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -387,7 +432,7 @@ test("error isolation: handler throw records failure and survives", async () => 
     })
   );
   await reg.runNow("j");
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   const runs = reg.getRuns("j");
   assert.equal(runs.length, 1);
   assert.equal(runs[0].status, "failure");
@@ -395,16 +440,18 @@ test("error isolation: handler throw records failure and survives", async () => 
   assert.ok(!runs[0].errorMessage?.includes("at /"), "error must be sanitized");
 });
 
-test("getRuns returns recent records newest-first", async () => {
+test("getRuns returns recent records newest-first", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   reg.register(def("j", async () => ({ success: true, recordsAffected: 0 })));
   await reg.runNow("j");
+  t.mock.timers.tick(1);
   await reg.runNow("j");
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   const runs = reg.getRuns("j");
   assert.equal(runs.length, 2);
   assert.ok(
-    new Date(runs[0].startedAt).getTime() >= new Date(runs[1].startedAt).getTime(),
+    new Date(runs[0].startedAt).getTime() > new Date(runs[1].startedAt).getTime(),
     "newest first"
   );
 });
@@ -418,7 +465,8 @@ test("listJobs returns registered jobs with handlers", () => {
   assert.equal(typeof j!.handler, "function");
 });
 
-test("cron: invalid expression stops re-scheduling after MAX_CRON_PARSE_FAILURES", async () => {
+test("cron: invalid expression stops re-scheduling after MAX_CRON_PARSE_FAILURES", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -443,7 +491,8 @@ test("cron: invalid expression stops re-scheduling after MAX_CRON_PARSE_FAILURES
   reg.stop("badcron");
 });
 
-test("runNow: queued trigger waits for current run then re-fires", async () => {
+test("runNow: queued trigger waits for current run then re-fires", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   let release: (v: void) => void = () => {};
@@ -460,12 +509,13 @@ test("runNow: queued trigger waits for current run then re-fires", async () => {
   const queued = reg.runNow("slow");
   release();
   const queuedRes = await queued;
-  await new Promise((r) => setTimeout(r, 30));
+  await flush();
   assert.equal(calls, 2, "initial + one queued re-run = 2 fires");
   assert.deepEqual(queuedRes, { started: true });
 });
 
-test("dispose clears timers and cron failure counts", async () => {
+test("dispose clears timers and cron failure counts", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   reg.register(
@@ -479,17 +529,19 @@ test("dispose clears timers and cron failure counts", async () => {
     )
   );
   reg.start("j");
-  await new Promise((r) => setTimeout(r, 10));
   assert.ok(regInternals(reg).timers.has("j"));
+  await flush();
   reg.dispose();
   assert.equal(regInternals(reg).timers.size, 0);
   assert.equal(regInternals(reg).cronFailCount.size, 0);
   const callsBefore = calls;
-  await new Promise((r) => setTimeout(r, 100));
+  t.mock.timers.tick(100);
+  await flush();
   assert.equal(calls, callsBefore, "disposed timers must not fire");
 });
 
-test("cronGetter: re-reads cron on each fire", async () => {
+test("cronGetter: re-reads cron on each fire", async (t) => {
+  enableMockTimers(t, Date.parse("2026-01-01T00:00:00.000Z"));
   const reg = getJobRegistry();
   let calls = 0;
   let cronExpr = "*/2 * * * * *";
@@ -510,19 +562,26 @@ test("cronGetter: re-reads cron on each fire", async () => {
     cronGetter: () => cronExpr,
   });
   reg.start("dynamic");
-  await new Promise((r) => setTimeout(r, 2500));
-  const callsAfterInitial = calls;
-  assert.ok(callsAfterInitial >= 1, `should fire with initial cron, got ${callsAfterInitial}`);
-  cronExpr = "0 0 1 1 * 2099";
-  await new Promise((r) => setTimeout(r, 3000));
+  t.mock.timers.tick(1_999);
+  await flush();
+  assert.equal(calls, 0);
+  t.mock.timers.tick(1);
+  await flush();
+  assert.equal(calls, 1, "initial cron fires at two seconds");
+  cronExpr = "0 0 * * * *";
+  t.mock.timers.tick(2_000);
+  await flush();
+  assert.equal(calls, 2, "the already scheduled tick fires once before the new cron takes effect");
+  assert.equal(regInternals(reg).cronFailCount.get("dynamic") ?? 0, 0);
+  t.mock.timers.tick(60_000);
+  await flush();
+  assert.equal(calls, 2, "the hourly cron must not retain the two-second cadence");
   reg.stop("dynamic");
-  const extraFires = calls - callsAfterInitial;
-  assert.ok(extraFires <= 1, `cronGetter change should stop fires, got ${extraFires} extra`);
 });
 
-test("cronFailCount: resets after successful parse", async () => {
+test("cronFailCount: resets after successful parse", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
-  let calls = 0;
   reg.register({
     id: "recover",
     type: "cron",
@@ -533,10 +592,7 @@ test("cronFailCount: resets after successful parse", async () => {
     config: { timezone: "UTC" },
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    handler: async () => {
-      calls++;
-      return { success: true };
-    },
+    handler: async () => ({ success: true }),
   });
   reg.start("recover");
   const failCountAfterFail = regInternals(reg).cronFailCount.get("recover") ?? 0;
@@ -551,10 +607,7 @@ test("cronFailCount: resets after successful parse", async () => {
     config: { timezone: "UTC" },
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
-    handler: async () => {
-      calls++;
-      return { success: true };
-    },
+    handler: async () => ({ success: true }),
     cronGetter: () => "* * * * * *",
   });
   reg.stop("recover");
@@ -564,7 +617,8 @@ test("cronFailCount: resets after successful parse", async () => {
   reg.stop("recover");
 });
 
-test("cronGetter: throws falls back to static cron", async () => {
+test("cronGetter: throws falls back to static cron", async (t) => {
+  enableMockTimers(t);
   const reg = getJobRegistry();
   let calls = 0;
   let shouldThrow = true;
@@ -588,7 +642,8 @@ test("cronGetter: throws falls back to static cron", async () => {
     },
   });
   reg.start("throwing");
-  await new Promise((r) => setTimeout(r, 1100));
+  t.mock.timers.tick(2_000);
+  await flush();
   assert.ok(calls >= 1, "job should fire with static cron fallback when cronGetter throws");
   reg.stop("throwing");
 });

--- a/tests/unit/lib/warmupScheduler/circuitBreakerFactory.test.ts
+++ b/tests/unit/lib/warmupScheduler/circuitBreakerFactory.test.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import net from "node:net";
+import { startRedisProbeServer, redisHandshakeReply } from "../../../helpers/redisProbeServer.ts";
 
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-warmup-factory-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
@@ -35,7 +35,7 @@ test.after(() => {
   fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });
 
-test("REDIS_URL unset → SqliteCircuitBreakerStore", async () => {
+test("REDIS_URL unset → SqliteCircuitBreakerStore", { timeout: 10000 }, async () => {
   const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
     await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
   __resetCircuitBreakerFactory();
@@ -50,71 +50,64 @@ test("REDIS_URL unset → SqliteCircuitBreakerStore", async () => {
  * caches -- an unreachable port only exercises the connect-time fallback, not
  * the far more likely case of Redis going away after we already cached it.
  */
-function startFlakyRedis(): Promise<{ port: number; close: () => void }> {
-  return new Promise((resolve) => {
-    const server = net.createServer((socket) => {
-      socket.on("data", (buf) => {
-        const cmd = buf.toString().toLowerCase();
-        if (cmd.includes("hgetall") || cmd.includes("hset") || cmd.includes("hget")) {
-          socket.destroy(); // the outage: connection drops mid-command
-          return;
-        }
-        if (cmd.includes("info")) {
-          const body = "redis_version:7.0.0\r\n";
-          socket.write(`$${body.length}\r\n${body}\r\n`);
-          return;
-        }
-        socket.write("+PONG\r\n");
-      });
-      socket.on("error", () => {});
-    });
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address() as { port: number };
-      resolve({ port, close: () => server.close() });
-    });
+function startFlakyRedis() {
+  return startRedisProbeServer((command, socket) => {
+    if (["hgetall", "hset", "hget"].includes(command)) {
+      socket.destroy();
+      return "";
+    }
+    return redisHandshakeReply(command);
   });
 }
 
-test("a Redis failure after caching drops the cached store instead of serving it forever", async () => {
-  const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
-    await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
-  const redis = await startFlakyRedis();
-  try {
-    __resetCircuitBreakerFactory();
-    process.env.REDIS_URL = `redis://127.0.0.1:${redis.port}`;
+test(
+  "a Redis failure after caching drops the cached store instead of serving it forever",
+  { timeout: 10000 },
+  async () => {
+    const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
+      await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
+    const redis = await startFlakyRedis();
+    try {
+      __resetCircuitBreakerFactory();
+      process.env.REDIS_URL = `redis://127.0.0.1:${redis.port}`;
 
-    const first = await getCircuitBreakerStore();
-    assert.ok(
-      first.constructor.name.includes("Redis"),
-      `handshake should yield a Redis-backed store, got ${first.constructor.name}`
-    );
+      const first = await getCircuitBreakerStore();
+      assert.ok(
+        first.constructor.name.includes("Redis"),
+        `handshake should yield a Redis-backed store, got ${first.constructor.name}`
+      );
 
-    // The outage. The call that hits it still fails -- that run is lost.
-    await assert.rejects(() => first.get("conn-1"));
+      // The outage. The call that hits it still fails -- that run is lost.
+      await assert.rejects(() => first.get("conn-1"));
 
-    // The point of the fix: the next call must NOT hand back the dead client.
-    process.env.REDIS_URL = "redis://127.0.0.1:1"; // Redis is gone now
-    const second = await getCircuitBreakerStore();
-    assert.ok(
-      second.constructor.name.includes("Sqlite"),
-      `expected re-probe to fall back to Sqlite, got ${second.constructor.name}`
-    );
-  } finally {
-    delete process.env.REDIS_URL;
-    redis.close();
-    __resetCircuitBreakerFactory();
+      // The point of the fix: the next call must NOT hand back the dead client.
+      process.env.REDIS_URL = "redis://127.0.0.1:1"; // Redis is gone now
+      const second = await getCircuitBreakerStore();
+      assert.ok(
+        second.constructor.name.includes("Sqlite"),
+        `expected re-probe to fall back to Sqlite, got ${second.constructor.name}`
+      );
+    } finally {
+      delete process.env.REDIS_URL;
+      redis.close();
+      __resetCircuitBreakerFactory();
+    }
   }
-});
+);
 
-test("REDIS_URL set + unreachable → falls back to SqliteCircuitBreakerStore", async () => {
-  const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
-    await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
-  __resetCircuitBreakerFactory();
-  process.env.REDIS_URL = "redis://127.0.0.1:1"; // non-listening port → connect timeout
-  const store = await getCircuitBreakerStore();
-  assert.ok(
-    store.constructor.name.includes("Sqlite"),
-    `expected Sqlite fallback, got ${store.constructor.name}`
-  );
-  delete process.env.REDIS_URL;
-});
+test(
+  "REDIS_URL set + unreachable → falls back to SqliteCircuitBreakerStore",
+  { timeout: 10000 },
+  async () => {
+    const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
+      await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
+    __resetCircuitBreakerFactory();
+    process.env.REDIS_URL = "redis://127.0.0.1:1"; // non-listening port → connect timeout
+    const store = await getCircuitBreakerStore();
+    assert.ok(
+      store.constructor.name.includes("Sqlite"),
+      `expected Sqlite fallback, got ${store.constructor.name}`
+    );
+    delete process.env.REDIS_URL;
+  }
+);

--- a/tests/unit/lib/warmupScheduler/circuitBreakerFactoryConcurrency.test.ts
+++ b/tests/unit/lib/warmupScheduler/circuitBreakerFactoryConcurrency.test.ts
@@ -2,10 +2,7 @@
  * getCircuitBreakerStore() must serialise concurrent probes, so two callers
  * that arrive before the cache is warm do not each build a Redis client.
  *
- * One ioredis case per file, and this is the whole reason: a client left behind
- * by an earlier case in the same process wedges every later connect, so a second
- * one here hangs rather than fails. Measured both ways round -- reordering does
- * not help, only a fresh process does, and `node:test` gives each file one.
+ * The shared RESP fixture handles pipelined and fragmented handshake commands.
  */
 
 import test from "node:test";
@@ -13,7 +10,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import net from "node:net";
+import { startRedisProbeServer, redisHandshakeReply } from "../../../helpers/redisProbeServer.ts";
 
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-warmup-concurrency-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
@@ -31,54 +28,36 @@ test.after(() => {
  * A Redis that behaves. Counts accepted connections so a test can tell one
  * probe from two.
  */
-function startCountingRedis(): Promise<{
-  port: number;
-  connections: () => number;
-  close: () => void;
-}> {
-  return new Promise((resolve) => {
-    let n = 0;
-    const server = net.createServer((socket) => {
-      n += 1;
-      socket.on("error", () => {});
-      socket.on("data", (buf) => {
-        if (buf.toString().toLowerCase().includes("info")) {
-          const body = "redis_version:7.0.0\r\n";
-          socket.write(`$${body.length}\r\n${body}\r\n`);
-          return;
-        }
-        socket.write("+PONG\r\n");
-      });
-    });
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address() as { port: number };
-      resolve({ port, connections: () => n, close: () => server.close() });
-    });
-  });
+function startCountingRedis() {
+  return startRedisProbeServer(redisHandshakeReply);
 }
 
-test("concurrent callers share one probe instead of each opening a Redis client", async () => {
-  const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
-    await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
-  const redis = await startCountingRedis();
-  try {
-    __resetCircuitBreakerFactory();
-    process.env.REDIS_URL = `redis://127.0.0.1:${redis.port}`;
+test(
+  "concurrent callers share one probe instead of each opening a Redis client",
+  { timeout: 10000 },
+  async () => {
+    const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
+      await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
+    const redis = await startCountingRedis();
+    try {
+      __resetCircuitBreakerFactory();
+      process.env.REDIS_URL = `redis://127.0.0.1:${redis.port}`;
 
-    // Started together, on purpose: neither has awaited, so both see an empty
-    // cache. This is the shape a warmup cycle takes when a tick overruns and
-    // the next one starts while it is still going.
-    const [a, b] = await Promise.all([getCircuitBreakerStore(), getCircuitBreakerStore()]);
+      // Started together, on purpose: neither has awaited, so both see an empty
+      // cache. This is the shape a warmup cycle takes when a tick overruns and
+      // the next one starts while it is still going.
+      const [a, b] = await Promise.all([getCircuitBreakerStore(), getCircuitBreakerStore()]);
 
-    assert.strictEqual(a, b, "both callers should get the same store instance");
-    assert.equal(
-      redis.connections(),
-      1,
-      `a second probe opened a Redis client nobody can close (${redis.connections()} connections)`
-    );
-  } finally {
-    delete process.env.REDIS_URL;
-    redis.close();
-    __resetCircuitBreakerFactory();
+      assert.strictEqual(a, b, "both callers should get the same store instance");
+      assert.equal(
+        redis.connections(),
+        1,
+        `a second probe opened a Redis client nobody can close (${redis.connections()} connections)`
+      );
+    } finally {
+      delete process.env.REDIS_URL;
+      redis.close();
+      __resetCircuitBreakerFactory();
+    }
   }
-});
+);

--- a/tests/unit/lib/warmupScheduler/circuitBreakerFactoryRelease.test.ts
+++ b/tests/unit/lib/warmupScheduler/circuitBreakerFactoryRelease.test.ts
@@ -2,10 +2,7 @@
  * getCircuitBreakerStore() must release the ioredis client it built when the
  * probe fails partway through, not only when the probe succeeds.
  *
- * One ioredis case per file, and this is the whole reason: a client left behind
- * by an earlier case in the same process wedges every later connect, so a second
- * one here hangs rather than fails. Measured both ways round -- reordering does
- * not help, only a fresh process does, and `node:test` gives each file one.
+ * The shared RESP fixture handles pipelined and fragmented handshake commands.
  */
 
 import test from "node:test";
@@ -13,7 +10,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import net from "node:net";
+import { startRedisProbeServer, redisHandshakeReply } from "../../../helpers/redisProbeServer.ts";
 
 const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-warmup-release-"));
 process.env.DATA_DIR = TEST_DATA_DIR;
@@ -36,32 +33,10 @@ test.after(() => {
  * INFO is answered for real. Refusing it too leaves ioredis waiting on a
  * ready-check that `connectTimeout` does not bound.
  */
-function startProbeRefusingRedis(): Promise<{
-  port: number;
-  socketClosed: () => boolean;
-  close: () => void;
-}> {
-  return new Promise((resolve) => {
-    let closed = false;
-    const server = net.createServer((socket) => {
-      socket.on("close", () => {
-        closed = true;
-      });
-      socket.on("error", () => {});
-      socket.on("data", (buf) => {
-        if (buf.toString().toLowerCase().includes("info")) {
-          const body = "redis_version:7.0.0\r\n";
-          socket.write(`$${body.length}\r\n${body}\r\n`);
-          return;
-        }
-        socket.write("-ERR probe refused\r\n");
-      });
-    });
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address() as { port: number };
-      resolve({ port, socketClosed: () => closed, close: () => server.close() });
-    });
-  });
+function startProbeRefusingRedis() {
+  return startRedisProbeServer((command) =>
+    command === "ping" ? "-ERR probe refused\r\n" : redisHandshakeReply(command)
+  );
 }
 
 async function waitUntil(cond: () => boolean, timeoutMs: number): Promise<void> {
@@ -71,27 +46,31 @@ async function waitUntil(cond: () => boolean, timeoutMs: number): Promise<void> 
   }
 }
 
-test("a probe that fails after connecting still releases the Redis client", async () => {
-  const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
-    await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
-  const redis = await startProbeRefusingRedis();
-  try {
-    __resetCircuitBreakerFactory();
-    process.env.REDIS_URL = `redis://127.0.0.1:${redis.port}`;
+test(
+  "a probe that fails after connecting still releases the Redis client",
+  { timeout: 10000 },
+  async () => {
+    const { getCircuitBreakerStore, __resetCircuitBreakerFactory } =
+      await import("../../../../src/lib/warmupScheduler/circuitBreakerFactory.ts");
+    const redis = await startProbeRefusingRedis();
+    try {
+      __resetCircuitBreakerFactory();
+      process.env.REDIS_URL = `redis://127.0.0.1:${redis.port}`;
 
-    const store = await getCircuitBreakerStore();
-    assert.ok(
-      store.constructor.name.includes("Sqlite"),
-      `a refused probe should fall back, got ${store.constructor.name}`
-    );
+      const store = await getCircuitBreakerStore();
+      assert.ok(
+        store.constructor.name.includes("Sqlite"),
+        `a refused probe should fall back, got ${store.constructor.name}`
+      );
 
-    // The client existed by the time the probe threw, so somebody has to close
-    // it. Left open, its socket keeps the event loop alive.
-    await waitUntil(() => redis.socketClosed(), 2000);
-    assert.ok(redis.socketClosed(), "the failed probe leaked its Redis socket");
-  } finally {
-    delete process.env.REDIS_URL;
-    redis.close();
-    __resetCircuitBreakerFactory();
+      // The client existed by the time the probe threw, so somebody has to close
+      // it. Left open, its socket keeps the event loop alive.
+      await waitUntil(() => redis.socketClosed(), 2000);
+      assert.ok(redis.socketClosed(), "the failed probe leaked its Redis socket");
+    } finally {
+      delete process.env.REDIS_URL;
+      redis.close();
+      __resetCircuitBreakerFactory();
+    }
   }
-});
+);

--- a/tests/unit/provider-breaker-halfopen-recovery.test.ts
+++ b/tests/unit/provider-breaker-halfopen-recovery.test.ts
@@ -8,7 +8,7 @@
  * This test verifies that recordProviderSuccess in accountFallback.ts
  * transitions the breaker from HALF_OPEN to CLOSED and resets failure count.
  */
-import { test } from "node:test";
+import { mock, test } from "node:test";
 import assert from "node:assert/strict";
 import {
   getCircuitBreaker,
@@ -27,29 +27,40 @@ import {
 const uniqueProvider = (suffix: string) =>
   `halfopen-test-${suffix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 
-test("recordProviderSuccess transitions breaker from HALF_OPEN to CLOSED and resets failureCount", async () => {
+function withFakeDate<T>(fn: () => T): T {
+  mock.timers.enable({ apis: ["Date"], now: Date.now() });
+  try {
+    return fn();
+  } finally {
+    mock.timers.reset();
+  }
+}
+
+test("recordProviderSuccess transitions breaker from HALF_OPEN to CLOSED and resets failureCount", () => {
   const provider = uniqueProvider("recovery");
 
-  // Step 1: Open the breaker (failureThreshold: 1 -> one failure opens it)
-  recordProviderFailure(provider, undefined, undefined, {
-    failureThreshold: 1,
-    resetTimeoutMs: 150,
+  withFakeDate(() => {
+    // Step 1: Open the breaker (failureThreshold: 1 -> one failure opens it)
+    recordProviderFailure(provider, undefined, undefined, {
+      failureThreshold: 1,
+      resetTimeoutMs: 150,
+    });
+
+    const breaker = getCircuitBreaker(provider);
+    assert.equal(breaker.state, "OPEN", "breaker should be OPEN after failure");
+    assert.equal(breaker.failureCount, 1, "failureCount should be 1");
+
+    // Step 2: Advance past resetTimeout so _refreshOpenState transitions to HALF_OPEN
+    mock.timers.tick(151);
+    breaker.canExecute(); // triggers _refreshOpenState -> HALF_OPEN
+    assert.equal(breaker.state, "HALF_OPEN", "breaker should be HALF_OPEN after resetTimeout");
+
+    // Step 3: recordProviderSuccess should close the breaker
+    recordProviderSuccess(provider, undefined);
+
+    assert.equal(breaker.state, "CLOSED", "breaker should be CLOSED after success");
+    assert.equal(breaker.failureCount, 0, "breaker failureCount should be reset to 0");
   });
-
-  const breaker = getCircuitBreaker(provider);
-  assert.equal(breaker.state, "OPEN", "breaker should be OPEN after failure");
-  assert.equal(breaker.failureCount, 1, "failureCount should be 1");
-
-  // Step 2: Wait past resetTimeout so _refreshOpenState transitions to HALF_OPEN
-  await new Promise((r) => setTimeout(r, 200));
-  breaker.canExecute(); // triggers _refreshOpenState -> HALF_OPEN
-  assert.equal(breaker.state, "HALF_OPEN", "breaker should be HALF_OPEN after resetTimeout");
-
-  // Step 3: recordProviderSuccess should close the breaker
-  recordProviderSuccess(provider, undefined);
-
-  assert.equal(breaker.state, "CLOSED", "breaker should be CLOSED after success");
-  assert.equal(breaker.failureCount, 0, "failureCount should be reset to 0");
 });
 
 test("recordProviderSuccess does not prematurely close an OPEN breaker before resetTimeout", () => {
@@ -133,73 +144,78 @@ test("recordProviderSuccess with null/undefined provider is a safe no-op", () =>
   recordProviderSuccess("", undefined);
 });
 
-test("recordProviderSuccess is idempotent: multiple calls on HALF_OPEN are safe", async () => {
+test("recordProviderSuccess is idempotent: multiple calls on HALF_OPEN are safe", () => {
   const provider = uniqueProvider("idempotent");
 
-  // Open the breaker
-  recordProviderFailure(provider, undefined, undefined, {
-    failureThreshold: 1,
-    resetTimeoutMs: 100,
+  withFakeDate(() => {
+    // Open the breaker
+    recordProviderFailure(provider, undefined, undefined, {
+      failureThreshold: 1,
+      resetTimeoutMs: 100,
+    });
+
+    const breaker = getCircuitBreaker(provider);
+    assert.equal(breaker.state, "OPEN");
+
+    // Advance past resetTimeout for the HALF_OPEN probe.
+    mock.timers.tick(101);
+    breaker.canExecute();
+    assert.equal(breaker.state, "HALF_OPEN");
+
+    // First success closes the breaker
+    recordProviderSuccess(provider, undefined);
+    assert.equal(breaker.state, "CLOSED");
+    assert.equal(breaker.failureCount, 0);
+
+    // Second success is a no-op (state is CLOSED, not HALF_OPEN)
+    recordProviderSuccess(provider, undefined);
+    assert.equal(breaker.state, "CLOSED");
+    assert.equal(breaker.failureCount, 0);
   });
-
-  const breaker = getCircuitBreaker(provider);
-  assert.equal(breaker.state, "OPEN");
-
-  // Wait for HALF_OPEN
-  await new Promise((r) => setTimeout(r, 150));
-  breaker.canExecute();
-  assert.equal(breaker.state, "HALF_OPEN");
-
-  // First success closes the breaker
-  recordProviderSuccess(provider, undefined);
-  assert.equal(breaker.state, "CLOSED");
-  assert.equal(breaker.failureCount, 0);
-
-  // Second success is a no-op (state is CLOSED, not HALF_OPEN)
-  recordProviderSuccess(provider, undefined);
-  assert.equal(breaker.state, "CLOSED");
-  assert.equal(breaker.failureCount, 0);
 });
 
-test("full lifecycle: CLOSED -> OPEN -> HALF_OPEN -> CLOSED via success", async () => {
+test("full lifecycle: CLOSED -> OPEN -> HALF_OPEN -> CLOSED via success", () => {
   const provider = uniqueProvider("lifecycle");
 
-  // Start CLOSED
-  const breaker = getCircuitBreaker(provider, {
-    failureThreshold: 1,
-    resetTimeoutMs: 100,
+  withFakeDate(() => {
+    // Start CLOSED
+    const breaker = getCircuitBreaker(provider, {
+      failureThreshold: 1,
+      resetTimeoutMs: 100,
+    });
+    assert.equal(breaker.state, "CLOSED");
+
+    // Failure opens the breaker
+    recordProviderFailure(provider, undefined, undefined, {
+      failureThreshold: 1,
+      resetTimeoutMs: 100,
+    });
+    assert.equal(breaker.state, "OPEN");
+    assert.equal(breaker.failureCount, 1);
+
+    // Still OPEN before timeout
+    mock.timers.tick(99);
+    recordProviderSuccess(provider, undefined);
+    assert.equal(breaker.state, "OPEN", "must not close before resetTimeout");
+
+    // The exact timeout boundary permits the HALF_OPEN transition.
+    mock.timers.tick(1);
+    breaker.canExecute();
+    assert.equal(breaker.state, "HALF_OPEN");
+
+    // Success recovers to CLOSED
+    recordProviderSuccess(provider, undefined);
+    assert.equal(breaker.state, "CLOSED");
+    assert.equal(breaker.failureCount, 0);
+
+    // Subsequent failure re-opens (proves breaker is functional after recovery)
+    recordProviderFailure(provider, undefined, undefined, {
+      failureThreshold: 1,
+      resetTimeoutMs: 100,
+    });
+    assert.equal(breaker.state, "OPEN");
+    assert.equal(breaker.failureCount, 1);
   });
-  assert.equal(breaker.state, "CLOSED");
-
-  // Failure opens the breaker
-  recordProviderFailure(provider, undefined, undefined, {
-    failureThreshold: 1,
-    resetTimeoutMs: 100,
-  });
-  assert.equal(breaker.state, "OPEN");
-  assert.equal(breaker.failureCount, 1);
-
-  // Still OPEN before timeout
-  recordProviderSuccess(provider, undefined);
-  assert.equal(breaker.state, "OPEN", "must not close before resetTimeout");
-
-  // Wait for HALF_OPEN transition
-  await new Promise((r) => setTimeout(r, 150));
-  breaker.canExecute();
-  assert.equal(breaker.state, "HALF_OPEN");
-
-  // Success recovers to CLOSED
-  recordProviderSuccess(provider, undefined);
-  assert.equal(breaker.state, "CLOSED");
-  assert.equal(breaker.failureCount, 0);
-
-  // Subsequent failure re-opens (proves breaker is functional after recovery)
-  recordProviderFailure(provider, undefined, undefined, {
-    failureThreshold: 1,
-    resetTimeoutMs: 100,
-  });
-  assert.equal(breaker.state, "OPEN");
-  assert.equal(breaker.failureCount, 1);
 });
 
 test("recordProviderSuccess resets cooldown failureCount (exponential backoff)", () => {
@@ -232,36 +248,38 @@ test("recordProviderSuccess resets cooldown failureCount (exponential backoff)",
   assert.equal(breaker.state, "CLOSED", "breaker stays CLOSED (cooldown-only scenario)");
 });
 
-test("recordProviderSuccess with connectionId transitions breaker and resets cooldown", async () => {
+test("recordProviderSuccess with connectionId transitions breaker and resets cooldown", () => {
   const provider = uniqueProvider("connid-breaker");
   const connectionId = "conn-abc";
 
-  // Open the breaker
-  recordProviderFailure(provider, undefined, connectionId, {
-    failureThreshold: 1,
-    resetTimeoutMs: 100,
+  withFakeDate(() => {
+    // Open the breaker
+    recordProviderFailure(provider, undefined, connectionId, {
+      failureThreshold: 1,
+      resetTimeoutMs: 100,
+    });
+
+    const breaker = getCircuitBreaker(provider);
+    assert.equal(breaker.state, "OPEN");
+
+    // Build up cooldown with connectionId
+    for (let i = 0; i < 3; i++) {
+      recordProviderCooldown(provider, connectionId);
+    }
+    assert.equal(isProviderInCooldown(provider, connectionId), true);
+
+    // Advance past resetTimeout for the HALF_OPEN probe.
+    mock.timers.tick(101);
+    breaker.canExecute();
+    assert.equal(breaker.state, "HALF_OPEN");
+
+    // Success with connectionId should close breaker AND reset cooldown
+    recordProviderSuccess(provider, connectionId);
+
+    assert.equal(breaker.state, "CLOSED", "breaker CLOSED after success with connectionId");
+    assert.equal(breaker.failureCount, 0, "failureCount reset");
+    assert.equal(isProviderInCooldown(provider, connectionId), false, "cooldown cleared");
   });
-
-  const breaker = getCircuitBreaker(provider);
-  assert.equal(breaker.state, "OPEN");
-
-  // Build up cooldown with connectionId
-  for (let i = 0; i < 3; i++) {
-    recordProviderCooldown(provider, connectionId);
-  }
-  assert.equal(isProviderInCooldown(provider, connectionId), true);
-
-  // Wait for HALF_OPEN
-  await new Promise((r) => setTimeout(r, 150));
-  breaker.canExecute();
-  assert.equal(breaker.state, "HALF_OPEN");
-
-  // Success with connectionId should close breaker AND reset cooldown
-  recordProviderSuccess(provider, connectionId);
-
-  assert.equal(breaker.state, "CLOSED", "breaker CLOSED after success with connectionId");
-  assert.equal(breaker.failureCount, 0, "failureCount reset");
-  assert.equal(isProviderInCooldown(provider, connectionId), false, "cooldown cleared");
 });
 
 test("resetAllCircuitBreakers cleans up test state", () => {

--- a/tests/unit/redis-probe-server.test.ts
+++ b/tests/unit/redis-probe-server.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import { once } from "node:events";
+import { startRedisProbeServer, redisHandshakeReply } from "../helpers/redisProbeServer.ts";
+
+test(
+  "Redis fixture replies to fragmented and pipelined commands individually",
+  { timeout: 5000 },
+  async (t) => {
+    const commands: string[] = [];
+    const server = await startRedisProbeServer((command) => {
+      commands.push(command);
+      return redisHandshakeReply(command);
+    });
+    t.after(() => server.close());
+    const client = net.createConnection(server.port, "127.0.0.1");
+    t.after(() => client.destroy());
+    await once(client, "connect");
+    const replies = new Promise<string>((resolve, reject) => {
+      let received = "";
+      client.on("error", reject);
+      client.on("data", (chunk) => {
+        received += chunk.toString();
+        if (received.split("\r\n").length === 4) resolve(received);
+      });
+    });
+
+    // PING is incomplete. The remaining bytes and two more commands share a write.
+    client.write("*1\r\n$4\r\nPI");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    client.write("NG\r\n*2\r\n$6\r\nCLIENT\r\n$7\r\nSETINFO\r\n*1\r\n$4\r\nPING\r\n");
+
+    assert.equal(await replies, "+PONG\r\n+OK\r\n+PONG\r\n");
+    assert.deepEqual(commands, ["ping", "client", "ping"]);
+    assert.equal(server.connections(), 1);
+  }
+);
+
+test(
+  "Redis fixture reports closed only after every accepted client disconnects",
+  { timeout: 5000 },
+  async (t) => {
+    const server = await startRedisProbeServer(() => redisHandshakeReply("client"));
+    t.after(() => server.close());
+    assert.equal(server.socketClosed(), false);
+
+    const first = net.createConnection(server.port, "127.0.0.1");
+    const second = net.createConnection(server.port, "127.0.0.1");
+    t.after(() => {
+      first.destroy();
+      second.destroy();
+    });
+    await Promise.all([once(first, "connect"), once(second, "connect")]);
+    while (server.connections() < 2) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    assert.equal(server.connections(), 2);
+
+    const firstClosed = once(first, "close");
+    first.end();
+    await firstClosed;
+    assert.equal(server.socketClosed(), false);
+
+    const secondClosed = once(second, "close");
+    second.end();
+    await secondClosed;
+    assert.equal(server.socketClosed(), true);
+  }
+);

--- a/tests/unit/runner-janitor.test.ts
+++ b/tests/unit/runner-janitor.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -24,15 +25,19 @@ import path from "node:path";
 const ROOT = path.resolve(import.meta.dirname, "..", "..");
 const SCRIPT = path.join(ROOT, "scripts", "ops", "runner-janitor.sh");
 const HOUR = 3_600_000;
-// The sweep needs lsof to PROVE a path is idle (one snapshot of open paths). Hosted CI
-// images ship both; a bare devbox may not. Each branch below asserts what must
-// hold in that environment — without the tools the contract is "delete nothing,
-// say why", which is exactly the behaviour worth pinning.
-const HAVE_BUSY_TOOLS =
-  spawnSync("bash", ["-c", "command -v lsof"], { stdio: "ignore" }).status === 0;
-
 function fixture() {
   const base = mkdtempSync(path.join(os.tmpdir(), "janitor-fixture-"));
+  const tools = path.join(base, "tools");
+  mkdirSync(tools);
+  const lsof = path.join(tools, "lsof");
+  const df = path.join(tools, "df");
+  const pgrep = path.join(tools, "pgrep");
+  writeFileSync(lsof, "#!/bin/sh\nexit 0\n");
+  writeFileSync(df, "#!/bin/sh\nprintf 'Use%%\\n42%%\\n'\n");
+  writeFileSync(pgrep, "#!/bin/sh\nprintf '0\\n'\n");
+  chmodSync(lsof, 0o755);
+  chmodSync(df, 0o755);
+  chmodSync(pgrep, 0o755);
   const old = new Date(Date.now() - 5 * HOUR);
   const mk = (name: string, dir: boolean, when: Date | null) => {
     const p = path.join(base, name);
@@ -64,6 +69,8 @@ function run(args: string[], base: string, extraEnv: Record<string, string> = {}
       JANITOR_RUNNER_DIRS: path.join(base, "no-runners-here-*"),
       JANITOR_PSI_FILE: path.join(base, "no-psi"),
       JANITOR_DF_PATH: base,
+      JANITOR_LSOF: path.join(base, "tools", "lsof"),
+      PATH: `${path.join(base, "tools")}:${process.env.PATH || ""}`,
       ZOMBIE_BUILD_COMM: "janitor-test-no-such-process",
       MAX_ACTIVE_RUNNERS: "9999",
       DISK_ALERT_PCT: "101",
@@ -102,8 +109,7 @@ describe("runner-janitor.sh", () => {
     }
   });
 
-  it("--dry-run names what it WOULD remove and removes nothing", (t) => {
-    if (!HAVE_BUSY_TOOLS) return t.skip("lsof absent on this box — sweep branch covered in CI");
+  it("--dry-run names what it WOULD remove and removes nothing", () => {
     const f = fixture();
     try {
       const r = run(["--dry-run"], f.base);
@@ -134,8 +140,7 @@ describe("runner-janitor.sh", () => {
     }
   });
 
-  it("for real: sweeps the three stale artefacts, keeps the fresh one and the stranger", (t) => {
-    if (!HAVE_BUSY_TOOLS) return t.skip("lsof absent on this box — sweep branch covered in CI");
+  it("for real: sweeps the three stale artefacts, keeps the fresh one and the stranger", () => {
     const f = fixture();
     try {
       const r = run([], f.base);
@@ -163,6 +168,28 @@ describe("runner-janitor.sh", () => {
       const body = readFileSync(SCRIPT, "utf8");
       assert.match(body, /TMPFS_MAX_AGE_HOURS:-3\}/, "tmpfs default must stay short — it is RAM");
       assert.match(body, /WORK_TEMP_MAX_AGE_HOURS:-24\}/);
+    } finally {
+      rmSync(f.base, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+
+  it("keeps stale files and directories reported busy while sweeping idle artifacts", () => {
+    const f = fixture();
+    try {
+      writeFileSync(
+        path.join(f.base, "tools", "lsof"),
+        '#!/bin/sh\nprintf \'n%s\\n\' "$JANITOR_BUSY_FILE" "$JANITOR_BUSY_CHILD"\n'
+      );
+      const r = run([], f.base, {
+        JANITOR_BUSY_FILE: f.staleTar,
+        JANITOR_BUSY_CHILD: path.join(f.staleBuild, "x"),
+      });
+      assert.equal(r.status, 0, r.stderr + r.stdout);
+      assert.ok(existsSync(f.staleTar), "an open stale file must survive");
+      assert.ok(existsSync(f.staleBuild), "a directory containing an open file must survive");
+      assert.ok(!existsSync(f.staleUpgrade), "an idle stale directory must still be swept");
+      assert.ok(existsSync(f.fresh) && existsSync(f.unrelated));
+      assert.equal(r.stdout.split("busy, kept:").length - 1, 2);
     } finally {
       rmSync(f.base, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/tests/unit/serial/combo-strategy-fallbacks-half-open-timing.test.ts
+++ b/tests/unit/serial/combo-strategy-fallbacks-half-open-timing.test.ts
@@ -3,19 +3,15 @@
  *
  * Extracted from tests/unit/combo-strategy-fallbacks.test.ts (#6803).
  *
- * This scenario races a real 80ms setTimeout against a 40ms circuit-breaker
+ * This scenario advances a Date-only fake clock past the circuit-breaker
  * resetTimeout before asserting breaker.getStatus().state === 'HALF_OPEN'.
- * Under a starved event loop (CI-runner CPU contention from concurrent
- * sibling shard jobs) this timing margin can be missed even though the
- * lazy-recovery contract (OPEN → HALF_OPEN once the reset timeout elapses) is
- * implemented correctly.
+ * The lazy-recovery contract is clock-based, so a fake Date keeps this test
+ * deterministic without spending real time or depending on event-loop load.
  *
- * Running this in tests/unit/serial/ (--test-concurrency=1, see package.json's
- * test:unit:serial) removes the intra-suite parallelism that was the dominant
- * source of contention, matching the repo's established remedy pattern for
- * this class of test.
+ * It retains its existing serial collector placement; this change only removes
+ * the wall-clock dependency from the recovery assertion.
  */
-import test from "node:test";
+import test, { mock } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -73,6 +69,15 @@ async function cleanupTestDataDir() {
   if (lastError) throw lastError;
 }
 
+async function withFakeDate<T>(fn: () => Promise<T>): Promise<T> {
+  mock.timers.enable({ apis: ["Date"], now: Date.now() });
+  try {
+    return await fn();
+  } finally {
+    mock.timers.reset();
+  }
+}
+
 test.beforeEach(async () => {
   resetAllComboMetrics();
   resetAllCircuitBreakers();
@@ -100,67 +105,68 @@ test.after(async () => {
 });
 
 test("combo skips a provider while its breaker is OPEN and attempts it again after the reset timeout (HALF_OPEN)", async () => {
-  // Widened from the original 40ms/80ms margin (#6803): under contended
-  // CI-runner load even --test-concurrency=1 doesn't guarantee the "while
-  // OPEN" dispatch completes before a 40ms window elapses. A larger absolute
-  // margin (same ~2x wait:resetTimeout ratio) tolerates real scheduling
-  // jitter while still proving the lazy-recovery contract.
-  const breaker = getCircuitBreaker("openai", { failureThreshold: 1, resetTimeout: 300 });
-  try {
-    await breaker.execute(async () => {
-      throw new Error("simulated provider failure");
+  await withFakeDate(async () => {
+    const breaker = getCircuitBreaker("openai", { failureThreshold: 1, resetTimeout: 300 });
+    try {
+      await breaker.execute(async () => {
+        throw new Error("simulated provider failure");
+      });
+    } catch {
+      // expected — trips the breaker OPEN
+    }
+    assert.equal(breaker.getStatus().state, "OPEN");
+
+    const comboDef = {
+      name: "half-open-recovery",
+      strategy: "priority",
+      models: ["openai/gpt-4o-mini", "claude/sonnet"],
+      config: { maxRetries: 0, retryDelayMs: 0, fallbackDelayMs: 0 },
+    };
+
+    // While OPEN: the openai target must be skipped, claude serves.
+    const callsWhileOpen: string[] = [];
+    const blocked = await handleComboChat({
+      body: {},
+      combo: comboDef,
+      handleSingleModel: async (_body: unknown, modelStr: string) => {
+        callsWhileOpen.push(modelStr);
+        return okResponse();
+      },
+      isModelAvailable: async () => true,
+      log: createLog(),
+      settings: null,
+      allCombos: null,
     });
-  } catch {
-    // expected — trips the breaker OPEN
-  }
-  assert.equal(breaker.getStatus().state, "OPEN");
+    assert.equal(blocked.ok, true);
+    assert.deepEqual(callsWhileOpen, ["claude/sonnet"], "OPEN breaker target must be skipped");
 
-  const comboDef = {
-    name: "half-open-recovery",
-    strategy: "priority",
-    models: ["openai/gpt-4o-mini", "claude/sonnet"],
-    config: { maxRetries: 0, retryDelayMs: 0, fallbackDelayMs: 0 },
-  };
+    // The breaker uses >= for expiry: one millisecond before the boundary it
+    // remains OPEN, then the exact reset timeout permits HALF_OPEN recovery.
+    mock.timers.tick(299);
+    assert.equal(breaker.getStatus().state, "OPEN");
+    mock.timers.tick(1);
+    assert.equal(breaker.getStatus().state, "HALF_OPEN");
 
-  // While OPEN: the openai target must be skipped, claude serves.
-  const callsWhileOpen: string[] = [];
-  const blocked = await handleComboChat({
-    body: {},
-    combo: comboDef,
-    handleSingleModel: async (_body: unknown, modelStr: string) => {
-      callsWhileOpen.push(modelStr);
-      return okResponse();
-    },
-    isModelAvailable: async () => true,
-    log: createLog(),
-    settings: null,
-    allCombos: null,
+    // After the reset timeout the breaker reads HALF_OPEN — the combo must probe
+    // the provider again instead of excluding it forever (lazy recovery contract).
+    const callsAfterExpiry: string[] = [];
+    const probed = await handleComboChat({
+      body: {},
+      combo: comboDef,
+      handleSingleModel: async (_body: unknown, modelStr: string) => {
+        callsAfterExpiry.push(modelStr);
+        return okResponse();
+      },
+      isModelAvailable: async () => true,
+      log: createLog(),
+      settings: null,
+      allCombos: null,
+    });
+    assert.equal(probed.ok, true);
+    assert.deepEqual(
+      callsAfterExpiry,
+      ["openai/gpt-4o-mini"],
+      "HALF_OPEN provider must be probed again"
+    );
   });
-  assert.equal(blocked.ok, true);
-  assert.deepEqual(callsWhileOpen, ["claude/sonnet"], "OPEN breaker target must be skipped");
-
-  // After the reset timeout the breaker reads HALF_OPEN — the combo must probe
-  // the provider again instead of excluding it forever (lazy recovery contract).
-  await new Promise((resolve) => setTimeout(resolve, 600));
-  assert.equal(breaker.getStatus().state, "HALF_OPEN");
-
-  const callsAfterExpiry: string[] = [];
-  const probed = await handleComboChat({
-    body: {},
-    combo: comboDef,
-    handleSingleModel: async (_body: unknown, modelStr: string) => {
-      callsAfterExpiry.push(modelStr);
-      return okResponse();
-    },
-    isModelAvailable: async () => true,
-    log: createLog(),
-    settings: null,
-    allCombos: null,
-  });
-  assert.equal(probed.ok, true);
-  assert.deepEqual(
-    callsAfterExpiry,
-    ["openai/gpt-4o-mini"],
-    "HALF_OPEN provider must be probed again"
-  );
 });


### PR DESCRIPTION
## Summary

Several unit fixtures wait for wall-clock timers or depend on installed host tools and a live local HTTP service. Use Node test clocks, mocked batch responses, and controlled local tool/Redis fixtures to make those checks deterministic.

Keep the batch polling entry point and assert its ten-second boundary, outgoing request contract, successful results, and failure counts. Cover busy janitor paths and fragmented/pipelined Redis requests, including cleanup with two connected clients. Existing test paths, package scripts, CI collection, and coverage thresholds are preserved.

## Related Issues

Related to #12539. This is the focused replacement for the cumulative test changes in #12588, #12606, and #12760; it does not claim to implement the broader test-efficiency proposal.

⚠️ base-red inherited: #12732

## Validation

- [x] Change type: other — test fixture maintenance; no production code changes.
- [x] Focused tests: 113 passed, zero failures, cancellations, skips, or todo tests, using the canonical polyfill/data-isolation preloads and separate serial phase.
- [x] Prettier, suppression-aware ESLint on changed files, test-masking gate, docs-sync, tracked-artifacts, and T11 any-budget checks passed.
- [x] Collection comparison: all 4,991 existing Node test files preserved; one new Redis fixture test file is collected automatically. Dashboard and serial manifests are identical.
- [x] Rebuilt as one commit directly on `release/v3.8.51` at `949235736042b13cf64215632e6d44db7985af76`.
- [ ] Full `npm run lint`: both base and head report the same three existing `no-explicit-any` errors in `tests/unit/volcengine-plan-binding-upsert.test.ts`, plus existing unused suppressions. The obsolete suppression for the changed JobRegistry fixture was removed.
- [ ] Full Node main/dashboard/serial, Vitest, and coverage comparison are in progress against the pinned base and this commit. Results will be added before this PR is considered ready to merge.

## Tests Added Or Updated

- `tests/unit/audit-timeline.test.ts`
- `tests/unit/batch_api.test.ts`
- `tests/unit/binaryManager.test.ts`
- `tests/unit/compression-settings-cache.test.ts`
- `tests/unit/lib/jobRegistry/registry.test.ts`
- `tests/unit/lib/warmupScheduler/circuitBreakerFactory.test.ts`
- `tests/unit/lib/warmupScheduler/circuitBreakerFactoryConcurrency.test.ts`
- `tests/unit/lib/warmupScheduler/circuitBreakerFactoryRelease.test.ts`
- `tests/unit/provider-breaker-halfopen-recovery.test.ts`
- `tests/unit/runner-janitor.test.ts`
- `tests/unit/serial/combo-strategy-fallbacks-half-open-timing.test.ts`
- `tests/unit/redis-probe-server.test.ts` (new)

Shared fixture: `tests/helpers/redisProbeServer.ts`. No production code changed.

## Coverage Notes

No tests were deleted or moved, and no test runner or CI exclusions were introduced. Existing fixtures retain or increase assertion counts; two host-dependent skip branches were removed. Full coverage comparison is pending and the 60/60/60/60 thresholds are unchanged.

## Reviewer Notes

The test-masking gate's report-only warning for `command === "ping"` comes from the local Redis protocol fixture, not a copied production condition. Broad base/head runs are failure inventories: each phase's actual exit code is retained even when later phases continue so coverage can be collected.
