### PR TITLE
fix(stream): release the upstream body when the JSON-to-SSE sniff times out

### DIFF
--- a/changelog.d/fixes/13169-jsonbody-sniff-reader-leak.md
+++ b/changelog.d/fixes/13169-jsonbody-sniff-reader-leak.md
@@ -1,0 +1,1 @@
+- **fix(stream):** cancel the upstream response body when the JSON-to-SSE sniff unwinds on a body timeout, so a stalled upstream no longer pins the connection ([#13169](https://github.com/diegosouzapw/OmniRoute/issues/13169))

--- a/open-sse/handlers/chatCore/jsonBodyToSse.ts
+++ b/open-sse/handlers/chatCore/jsonBodyToSse.ts
@@ -88,33 +88,46 @@ async function sniffJsonBodyForSse(
   let sniffed = "";
   let sniffedBytes = 0;
   const maxSniffBytes = 4096;
-  while (sniffedBytes < maxSniffBytes) {
-    const chunk = await deps.withBodyTimeout<ReadableStreamReadResult<Uint8Array>>(reader.read());
-    if (chunk.done || !chunk.value) break;
-    bufferedChunks.push(chunk.value);
-    sniffedBytes += chunk.value.byteLength;
-    sniffed += decoder.decode(chunk.value, { stream: true });
+  // The two success paths below hand this still-open reader to
+  // prependBufferedChunks(), so the reader must NOT be cancelled on the happy
+  // path. Any other unwind (notably a withBodyTimeout rejection on a stalled
+  // upstream) would otherwise abandon the body with no cancellation, pinning
+  // the connection for the lifetime of the socket.
+  let handedOff = false;
+  try {
+    while (sniffedBytes < maxSniffBytes) {
+      const chunk = await deps.withBodyTimeout<ReadableStreamReadResult<Uint8Array>>(reader.read());
+      if (chunk.done || !chunk.value) break;
+      bufferedChunks.push(chunk.value);
+      sniffedBytes += chunk.value.byteLength;
+      sniffed += decoder.decode(chunk.value, { stream: true });
 
-    if (classifyBodyPrefix(sniffed) === "sse") {
-      const rebuiltHeaders = new Headers(providerResponse.headers);
-      rebuiltHeaders.delete("content-length");
-      rebuiltHeaders.set("content-type", "text/event-stream");
-      ctx.log?.debug?.(
-        "STREAM",
-        `Upstream returned SSE bytes with application/json content-type — preserving streaming body (${ctx.provider}/${ctx.model})`
-      );
-      return {
-        sseResponse: new Response(prependBufferedChunks(bufferedChunks, reader), {
-          status: providerResponse.status,
-          statusText: providerResponse.statusText,
-          headers: rebuiltHeaders,
-        }),
-        jsonBody: new Response(null),
-      };
+      if (classifyBodyPrefix(sniffed) === "sse") {
+        const rebuiltHeaders = new Headers(providerResponse.headers);
+        rebuiltHeaders.delete("content-length");
+        rebuiltHeaders.set("content-type", "text/event-stream");
+        ctx.log?.debug?.(
+          "STREAM",
+          `Upstream returned SSE bytes with application/json content-type — preserving streaming body (${ctx.provider}/${ctx.model})`
+        );
+        handedOff = true;
+        return {
+          sseResponse: new Response(prependBufferedChunks(bufferedChunks, reader), {
+            status: providerResponse.status,
+            statusText: providerResponse.statusText,
+            headers: rebuiltHeaders,
+          }),
+          jsonBody: new Response(null),
+        };
+      }
     }
-  }
 
-  return { jsonBody: new Response(prependBufferedChunks(bufferedChunks, reader)) };
+    handedOff = true;
+    return { jsonBody: new Response(prependBufferedChunks(bufferedChunks, reader)) };
+  } finally {
+    // Cancellation is best-effort: the body may already be errored or closed.
+    if (!handedOff) void reader.cancel().catch(() => {});
+  }
 }
 
 export async function maybeConvertJsonBodyToSse(

--- a/tests/unit/jsonbody-sniff-reader-leak-13169.test.ts
+++ b/tests/unit/jsonbody-sniff-reader-leak-13169.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression test for #13169: the JSON-to-SSE sniff must release the upstream
+ * body when it unwinds abnormally.
+ *
+ * `sniffJsonBodyForSse()` reads the upstream body under `withBodyTimeout()`.
+ * On a stalled upstream that rejects, an un-cancelled reader keeps the
+ * connection pinned. The upstream stream declares an explicit `cancel()` hook,
+ * so the assertions observe real cancellation rather than an incidental close.
+ */
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { maybeConvertJsonBodyToSse } from "../../open-sse/handlers/chatCore/jsonBodyToSse.ts";
+
+type Deps = Parameters<typeof maybeConvertJsonBodyToSse>[2];
+
+/** Upstream that serves `first` and then stalls forever, tracking cancellation. */
+function stallingUpstream(first: string) {
+  const state = { cancelled: false };
+  let pulls = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      pulls += 1;
+      if (pulls === 1) {
+        controller.enqueue(new TextEncoder().encode(first));
+        return;
+      }
+      return new Promise<void>(() => {});
+    },
+    cancel() {
+      state.cancelled = true;
+    },
+  });
+  return { body, state };
+}
+
+function timeoutDeps(ms: number): Deps {
+  return {
+    withBodyTimeout: (<T>(p: Promise<T>) =>
+      Promise.race([
+        p,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => {
+            const err = new Error(`Response body read timeout after ${ms}ms`);
+            err.name = "BodyTimeoutError";
+            reject(err);
+          }, ms)
+        ),
+      ])) as Deps["withBodyTimeout"],
+    synthesizeOpenAiSseFromJson: () => null,
+  } as Deps;
+}
+
+describe("jsonBodyToSse upstream body release (#13169)", () => {
+  test("cancels the upstream body when the sniff times out", async () => {
+    const { body, state } = stallingUpstream('{"choices":[');
+    const providerResponse = new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await assert.rejects(
+      () =>
+        maybeConvertJsonBodyToSse(providerResponse, { provider: "p", model: "m" }, timeoutDeps(50)),
+      (err: Error) => err.name === "BodyTimeoutError"
+    );
+
+    // Let any async cancellation settle before observing.
+    await new Promise((r) => setTimeout(r, 50));
+
+    assert.equal(state.cancelled, true, "upstream body should be cancelled after the timeout");
+  });
+
+  test("does NOT cancel the body on the success path", async () => {
+    // A complete SSE-looking body: the sniff hands the reader onward, so
+    // cancelling here would truncate a healthy stream.
+    const state = { cancelled: false };
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: {}\n\n"));
+        controller.close();
+      },
+      cancel() {
+        state.cancelled = true;
+      },
+    });
+    const providerResponse = new Response(body, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    const out = await maybeConvertJsonBodyToSse(
+      providerResponse,
+      { provider: "p", model: "m" },
+      timeoutDeps(5000)
+    );
+
+    assert.ok(out instanceof Response, "sniff should return a Response");
+    assert.equal(state.cancelled, false, "a healthy body must not be cancelled by the sniff");
+  });
+});


### PR DESCRIPTION
Fixes #13169.

## Problem

`sniffJsonBodyForSse()` reads the upstream body under `withBodyTimeout()`. When that timeout rejects, the function unwinds without cancelling the reader, so the upstream body is never released and undici cannot reclaim the connection. `maybeConvertJsonBodyToSse()` is awaited from `chatCore.ts:5535` with no `try`/`catch`, so the rejection propagates and the abandoned body stays pinned.

## Fix

Wrap the sniff loop in `try`/`finally` and cancel the reader on any unwind that did not hand it off. A `handedOff` flag marks the two success paths, which must keep passing the still-open reader to `prependBufferedChunks()` — cancelling there would truncate a healthy stream. Cancellation is best-effort (`.catch(() => {})`), since the body may already be errored.

The functional change is 13 lines; the rest of the diff is re-indentation from the new `try` block. Review with `git diff -w`.

## Evidence

Driving the real module with an upstream that serves one chunk then stalls, under a 50 ms body timeout:

```
before:  threw BodyTimeoutError   upstream cancelled: false   LEAK
after:   threw BodyTimeoutError   upstream cancelled: true    OK
```

`tests/unit/jsonbody-sniff-reader-leak-13169.test.ts` covers both directions:

- **times out** -> body is cancelled (fails on the unpatched revision: `pass 1 / fail 1`)
- **success path** -> body is NOT cancelled (passes on both revisions, guarding against over-cancelling a healthy stream)

Verified red-before-green by stashing the source change and rerunning: test 1 fails, test 2 still passes. With the fix applied: `pass 2 / fail 0`. Full-project `tsc --noEmit` is clean.

## Scope

Same shape as #13152 and #13165: a resource acquired before an unwind path exists that can release it.
