### PR TITLE
fix(sse): preserve Fable mid-conversation cache prefixes

### DIFF
--- a/open-sse/executors/claudeIdentity.ts
+++ b/open-sse/executors/claudeIdentity.ts
@@ -309,6 +309,7 @@ const HEAVY_AGENT_BETA_MODEL_PREFIXES = ["claude-opus", "claude-sonnet"];
  */
 const CONTEXT_1M_BETA_MODEL_PREFIXES = ["claude-opus"];
 const CONTEXT_1M_NATIVE_MODEL_PREFIXES = ["claude-opus-5"];
+const MID_CONVERSATION_SYSTEM_MODEL_PREFIXES = ["claude-opus", "claude-fable"];
 
 function matchesModelPrefix(model: unknown, prefixes: string[]): boolean {
   if (typeof model !== "string") return false;
@@ -340,7 +341,9 @@ export function shouldUseMidConversationSystem(
   const effectiveModel = model ?? (typeof payload.model === "string" ? payload.model : "");
 
   return (
-    hasSystem && hasTools && matchesModelPrefix(effectiveModel, CONTEXT_1M_BETA_MODEL_PREFIXES)
+    hasSystem &&
+    hasTools &&
+    matchesModelPrefix(effectiveModel, MID_CONVERSATION_SYSTEM_MODEL_PREFIXES)
   );
 }
 

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2364,8 +2364,8 @@ export async function handleChatCore({
         }
       }
 
-      // Legacy models reject role:"system" messages. Opus accepts them behind
-      // its beta, and hoisting them breaks the prompt cache prefix.
+      // Legacy models reject role:"system" messages. Supported models accept
+      // them behind a beta, and hoisting them breaks the prompt cache prefix.
       if (isClaudeCodeSemanticPassthrough) {
         if (
           provider !== "claude" ||

--- a/tests/unit/chatcore-translation-paths.test.ts
+++ b/tests/unit/chatcore-translation-paths.test.ts
@@ -1371,65 +1371,67 @@ test("chatCore normalizes native Claude Code messages for native Claude OAuth pa
   // user msg[2] (was clientMessages[3]): tool_result preserved (preserveToolResultBlocks:true)
   assert.equal(call.body.messages[2].content[0].type, "tool_result");
 });
-test("chatCore preserves Opus 5 mid-conversation system cache breakpoints", async () => {
-  await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
-  invalidateCacheControlSettingsCache();
+for (const model of ["claude-opus-5", "claude-fable-5", "claude-fable-5-1"]) {
+  test(`chatCore preserves ${model} mid-conversation system cache breakpoints`, async () => {
+    await settingsDb.updateSettings({ alwaysPreserveClientCache: "auto" });
+    invalidateCacheControlSettingsCache();
 
-  const { call, result } = await invokeChatCore({
-    provider: "claude",
-    model: "claude-opus-5",
-    endpoint: "/v1/messages",
-    credentials: { apiKey: "claude-key", providerSpecificData: {} },
-    body: {
-      model: "claude-opus-5",
-      max_tokens: 64,
-      system: [
-        {
-          type: "text",
-          text: "stable system prompt",
-          cache_control: { type: "ephemeral", ttl: "5m" },
-        },
-      ],
-      messages: [
-        { role: "user", content: [{ type: "text", text: "first turn" }] },
-        { role: "assistant", content: [{ type: "text", text: "first response" }] },
-        {
-          role: "system",
-          content: [
-            {
-              type: "text",
-              text: "compact continuation",
-              cache_control: { type: "ephemeral" },
-            },
-          ],
-        },
-        { role: "user", content: [{ type: "text", text: "latest turn" }] },
-      ],
-      tools: [{ name: "Bash", input_schema: { type: "object", properties: {} } }],
-    },
-    userAgent: "Claude-Code/2.1.220",
-    requestHeaders: { "x-app": "cli", "x-claude-code-session-id": "session-123" },
-    responseFormat: "claude",
-  });
+    const { call, result } = await invokeChatCore({
+      provider: "claude",
+      model,
+      endpoint: "/v1/messages",
+      credentials: { apiKey: "claude-key", providerSpecificData: {} },
+      body: {
+        model,
+        max_tokens: 64,
+        system: [
+          {
+            type: "text",
+            text: "stable system prompt",
+            cache_control: { type: "ephemeral", ttl: "5m" },
+          },
+        ],
+        messages: [
+          { role: "user", content: [{ type: "text", text: "first turn" }] },
+          { role: "assistant", content: [{ type: "text", text: "first response" }] },
+          {
+            role: "system",
+            content: [
+              {
+                type: "text",
+                text: "compact continuation",
+                cache_control: { type: "ephemeral" },
+              },
+            ],
+          },
+          { role: "user", content: [{ type: "text", text: "latest turn" }] },
+        ],
+        tools: [{ name: "Bash", input_schema: { type: "object", properties: {} } }],
+      },
+      userAgent: "Claude-Code/2.1.220",
+      requestHeaders: { "x-app": "cli", "x-claude-code-session-id": "session-123" },
+      responseFormat: "claude",
+    });
 
-  assert.equal(result.success, true);
-  assert.deepEqual(
-    call.body.messages.map((message: { role: string }) => message.role),
-    ["user", "assistant", "system", "user"]
-  );
-  assert.deepEqual(call.body.messages[2].content[0].cache_control, {
-    type: "ephemeral",
-    ttl: "5m",
+    assert.equal(result.success, true);
+    assert.deepEqual(
+      call.body.messages.map((message: { role: string }) => message.role),
+      ["user", "assistant", "system", "user"]
+    );
+    assert.deepEqual(call.body.messages[2].content[0].cache_control, {
+      type: "ephemeral",
+      ttl: "5m",
+    });
+    assert.equal(
+      call.body.system.some((block: { text?: string }) => block.text === "compact continuation"),
+      false
+    );
+    assert.deepEqual(call.body.messages[3].content[0].cache_control, {
+      type: "ephemeral",
+      ttl: "5m",
+    });
   });
-  assert.equal(
-    call.body.system.some((block: { text?: string }) => block.text === "compact continuation"),
-    false
-  );
-  assert.deepEqual(call.body.messages[3].content[0].cache_control, {
-    type: "ephemeral",
-    ttl: "5m",
-  });
-});
+}
 test("chatCore keeps Claude normalization for non-Claude-Code Claude passthrough", async () => {
   const { call, result } = await invokeChatCore({
     provider: "claude",

--- a/tests/unit/executor-claude-identity.test.ts
+++ b/tests/unit/executor-claude-identity.test.ts
@@ -176,6 +176,7 @@ describe("claudeIdentity — selectBetaFlags", () => {
     };
     const flags = mod.selectBetaFlags(body, "claude-opus-4");
     assert.ok(flags.includes("context-1m-2025-08-07"));
+    assert.ok(flags.includes("mid-conversation-system-2026-04-07"));
   });
 
   it("omits the legacy context-1m beta for Opus 5", () => {
@@ -194,6 +195,19 @@ describe("claudeIdentity — selectBetaFlags", () => {
     };
     const flags = mod.selectBetaFlags(body, "claude-sonnet-4");
     assert.ok(!flags.includes("context-1m"));
+    assert.ok(!flags.includes("mid-conversation-system"));
+  });
+
+  it("includes mid-conversation-system without context-1m for Fable", () => {
+    const body = {
+      system: "test",
+      tools: [{ name: "test_tool" }],
+    };
+    for (const model of ["claude-fable-5", "claude-fable-5-1"]) {
+      const flags = mod.selectBetaFlags(body, model);
+      assert.ok(flags.includes("mid-conversation-system-2026-04-07"));
+      assert.ok(!flags.includes("context-1m"));
+    }
   });
 });
 


### PR DESCRIPTION
Fable 5 and 5.1 support mid-conversation system messages, but OmniRoute treats only Opus as capable. That hoists each Fable system turn into the top-level system prompt and shifts the prompt-cache prefix.

## what changed

- give Fable its own mid-conversation-system capability path
- keep context-1m limited to Opus
- cover the native Claude Code request path for Opus 5, Fable 5, and Fable 5.1
- confirm Sonnet stays outside the mid-conversation-system path

The capability split matters because sharing the context-1m allowlist would send Fable an unrelated beta.

## how to test

```sh
node --import tsx/esm --test tests/unit/executor-claude-identity.test.ts
node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-isolation=none --test-name-pattern="mid-conversation system cache breakpoints" "$PWD/tests/unit/chatcore-translation-paths.test.ts"
npm run typecheck:core
```

All three checks pass.

A controlled three-turn Fable 5.1 request reproduced `system_changed` on turns 2 and 3 before this patch. The test uses synthetic text, a stable system prompt and tools, and growing mid-conversation system notes.

Anthropic documents prompt-cache invalidation when earlier cached content changes: https://platform.claude.com/docs/en/build-with-claude/prompt-caching