### PR TITLE
fix(kiro): strip orphaned tool_use with no matching tool_result

### DIFF
--- a/open-sse/translator/request/openai-to-kiro.ts
+++ b/open-sse/translator/request/openai-to-kiro.ts
@@ -704,6 +704,51 @@ function convertMessages(messages, tools, model) {
     }
   }
 
+  // Strip orphaned toolUses: an assistantResponseMessage that advertises a
+  // toolUse with no matching toolResult anywhere in history (or the current
+  // message) produces an invalid Kiro/Bedrock transcript -- Bedrock rejects it
+  // with "Expected toolResult blocks at messages.N.content for the following
+  // Ids: ...". This mirrors the orphaned-toolResult cleanup above, but for the
+  // opposite direction (a tool_use that never got answered, e.g. because the
+  // client lost one of two parallel tool results). The same defense
+  // (fixToolPairs, open-sse/services/contextManager.ts) already applies on the
+  // Claude and post-#7822 Antigravity paths; KiroExecutor.execute() never
+  // calls BaseExecutor.execute(), so it never got this guard.
+  const answeredToolUseIds = new Set<string>();
+  for (const item of mergedHistory) {
+    const toolResults = item.userInputMessage?.userInputMessageContext?.toolResults as
+      | Array<{ toolUseId?: string }>
+      | undefined;
+    if (Array.isArray(toolResults)) {
+      for (const result of toolResults) {
+        if (result?.toolUseId) answeredToolUseIds.add(result.toolUseId);
+      }
+    }
+  }
+  const currentToolResultsForOrphanCheck = currentMessage?.userInputMessage
+    ?.userInputMessageContext?.toolResults as Array<{ toolUseId?: string }> | undefined;
+  if (Array.isArray(currentToolResultsForOrphanCheck)) {
+    for (const result of currentToolResultsForOrphanCheck) {
+      if (result?.toolUseId) answeredToolUseIds.add(result.toolUseId);
+    }
+  }
+  for (const item of mergedHistory) {
+    const toolUses = item.assistantResponseMessage?.toolUses as
+      | Array<{ toolUseId?: string }>
+      | undefined;
+    if (!Array.isArray(toolUses)) continue;
+    const filtered = toolUses.filter(
+      (use) => use?.toolUseId && answeredToolUseIds.has(use.toolUseId)
+    );
+    if (filtered.length !== toolUses.length) {
+      if (filtered.length > 0) {
+        item.assistantResponseMessage!.toolUses = filtered;
+      } else {
+        delete item.assistantResponseMessage!.toolUses;
+      }
+    }
+  }
+
   // Ensure alternating roles by inserting synthetic assistant messages
   // between consecutive user turns that couldn't be merged.
   const alternatingHistory: typeof mergedHistory = [];

--- a/tests/unit/kiro-orphan-tooluse-13170.test.ts
+++ b/tests/unit/kiro-orphan-tooluse-13170.test.ts
@@ -1,0 +1,157 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildKiroPayload } = await import("../../open-sse/translator/request/openai-to-kiro.ts");
+
+const CREDENTIALS = {
+  accessToken: "test-token",
+  profileArn: "arn:aws:codewhisperer:us-east-1:000000000000:profile/TEST",
+  region: "us-east-1",
+};
+
+function build(messages) {
+  return buildKiroPayload(
+    "claude-sonnet-4.5",
+    { model: "claude-sonnet-4.5", messages },
+    false,
+    CREDENTIALS
+  );
+}
+
+/**
+ * Collect every toolUseId advertised by assistant turns and every toolUseId
+ * answered by a toolResult, across history plus currentMessage.
+ *
+ * Bedrock rejects a transcript where an assistant turn advertises a toolUse
+ * that is never answered ("Expected toolResult blocks"), so every advertised
+ * id must have a matching answered id.
+ */
+function collectToolIds(payload) {
+  const history = payload?.conversationState?.history ?? [];
+  const advertised = [];
+  const answered = [];
+
+  for (const entry of history) {
+    const toolUses = entry?.assistantResponseMessage?.toolUses;
+    if (Array.isArray(toolUses)) {
+      for (const use of toolUses) advertised.push(use.toolUseId ?? use.id);
+    }
+    const toolResults = entry?.userInputMessage?.userInputMessageContext?.toolResults;
+    if (Array.isArray(toolResults)) {
+      for (const result of toolResults) answered.push(result.toolUseId);
+    }
+  }
+
+  const currentResults =
+    payload?.conversationState?.currentMessage?.userInputMessage?.userInputMessageContext
+      ?.toolResults;
+  if (Array.isArray(currentResults)) {
+    for (const result of currentResults) answered.push(result.toolUseId);
+  }
+
+  return { advertised, answered };
+}
+
+// --- RED: a tool_use with no matching tool_result anywhere must be dropped --
+
+test("kiro #13170: an orphaned parallel tool_call (no tool_result ever) is stripped, its sibling survives", () => {
+  const payload = build([
+    { role: "user", content: "run two commands" },
+    {
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        { id: "call_A", type: "function", function: { name: "terminal", arguments: "{}" } },
+        { id: "call_B", type: "function", function: { name: "terminal", arguments: "{}" } },
+      ],
+    },
+    // call_B's result is missing -- e.g. lost client-side, never recorded.
+    { role: "tool", tool_call_id: "call_A", content: "1" },
+    { role: "user", content: "now say hi" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised, ["call_A"], "call_B must not be advertised without a result");
+  assert.deepEqual(answered, ["call_A"]);
+});
+
+test("kiro #13170: an assistant turn where every tool_call is orphaned drops toolUses entirely", () => {
+  const payload = build([
+    { role: "user", content: "go" },
+    {
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "call_A", type: "function", function: { name: "terminal", arguments: "{}" } }],
+    },
+    // No tool result anywhere for call_A.
+    { role: "user", content: "thanks" },
+  ]);
+
+  const { advertised } = collectToolIds(payload);
+  assert.deepEqual(advertised, []);
+
+  const history = payload?.conversationState?.history ?? [];
+  const assistantTurn = history.find((entry) => entry?.assistantResponseMessage);
+  assert.ok(assistantTurn, "the assistant turn itself must survive (only toolUses is stripped)");
+  assert.ok(
+    !("toolUses" in assistantTurn.assistantResponseMessage),
+    "toolUses must be removed entirely, not left as an empty array"
+  );
+});
+
+// --- Regression: a still-in-flight trailing tool_call is not stripped ------
+
+test("kiro #13170: a trailing (in-flight) tool_call with no result yet is preserved", () => {
+  const payload = build([
+    { role: "user", content: "go" },
+    {
+      role: "assistant",
+      content: "",
+      tool_calls: [{ id: "call_A", type: "function", function: { name: "terminal", arguments: "{}" } }],
+    },
+  ]);
+
+  // The trailing assistant message becomes currentMessage, not a history
+  // entry with toolUses -- so there is nothing to strip in this shape. This
+  // test pins that a single trailing assistant turn is not corrupted by the
+  // new filter.
+  const current = payload?.conversationState?.currentMessage;
+  assert.ok(current, "currentMessage must be present");
+});
+
+// --- Characterization: fully-answered parallel calls must keep working ----
+
+test("kiro #13170: fully-answered parallel tool_calls are unaffected", () => {
+  const payload = build([
+    { role: "user", content: "run two commands" },
+    {
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        { id: "call_A", type: "function", function: { name: "terminal", arguments: "{}" } },
+        { id: "call_B", type: "function", function: { name: "terminal", arguments: "{}" } },
+      ],
+    },
+    { role: "tool", tool_call_id: "call_A", content: "1" },
+    { role: "tool", tool_call_id: "call_B", content: "2" },
+    { role: "user", content: "thanks" },
+  ]);
+
+  const { advertised, answered } = collectToolIds(payload);
+  assert.deepEqual(advertised.sort(), ["call_A", "call_B"]);
+  assert.deepEqual(answered.sort(), ["call_A", "call_B"]);
+});
+
+test("kiro #13170: assistant text is preserved on an ordinary non-tool transcript", () => {
+  const payload = build([
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "PLAIN_REPLY" },
+    { role: "user", content: "again" },
+  ]);
+
+  const history = payload?.conversationState?.history ?? [];
+  const assistantContents = history
+    .filter((entry) => entry?.assistantResponseMessage)
+    .map((entry) => entry.assistantResponseMessage.content);
+  assert.ok(assistantContents.some((c) => String(c).includes("PLAIN_REPLY")));
+});


### PR DESCRIPTION
## Summary

Fixes #13170: `KiroExecutor.execute()` never calls `super.execute()`, so it never gets the shared `fixToolPairs` guard that strips orphaned `tool_use` entries — the same gap #7822 fixed for Antigravity/Vertex Claude dispatch. An assistant `tool_call` with no matching `role:"tool"` result anywhere in the conversation (e.g. one of two parallel tool calls silently lost its result client-side) sailed straight into `assistantResponseMessage.toolUses`, and Bedrock rejected the transcript:

```
[400]: Bedrock error message: Expected toolResult blocks at messages.N.content for the following Ids: tooluse_XXX
```

This is a **different** bug from #8903/#8931: those fixed grouping of consecutive `role:"tool"` messages that *do* all eventually get answered. Here, one `tool_use` is never answered at all, anywhere in history.

## Root cause

`open-sse/translator/request/openai-to-kiro.ts`'s `convertMessages` already has the symmetric defense for the *opposite* direction — an orphaned `tool_result` with no preceding `assistantResponseMessage.toolUses` gets stripped and converted to text (the `hasPrecedingAssistant` blocks). There was no equivalent cleanup for an orphaned `tool_use` with no following `tool_result`.

## Fix

Right after the existing orphaned-`toolResult` cleanup (both the `mergedHistory` loop and the `currentMessage` check), collect every `toolUseId` answered by a `toolResult` across `mergedHistory` + `currentMessage`, then filter each `assistantResponseMessage.toolUses` array down to only the answered ids — deleting the `toolUses` key entirely if nothing survives. This mirrors `fixToolPairs` (`open-sse/services/contextManager.ts`) used on the Claude/Antigravity paths, scoped to Kiro's own `conversationState` shape (`assistantResponseMessage.toolUses` / `userInputMessage.userInputMessageContext.toolResults`) rather than OpenAI's `tool_calls`/`role:"tool"` shape, since the Kiro translator already has its own pure-history representation by the point this runs.

No changes to `KiroExecutor` itself, no changes to any other provider's translator.

## Reproduction

Minimal repro (also reproduced on a real 57-message production transcript captured via request logging, where one of two parallel `tool_calls` never got a recorded result):

```json
{
  "model": "kiro/claude-sonnet-4.5",
  "messages": [
    {"role":"user","content":"run two commands"},
    {"role":"assistant","content":"","tool_calls":[
      {"id":"tooluse_AAAAAAAAAAAAAAAAAAAAAA","type":"function","function":{"name":"terminal","arguments":"{\"command\":\"echo 1\"}"}},
      {"id":"tooluse_BBBBBBBBBBBBBBBBBBBBBB","type":"function","function":{"name":"terminal","arguments":"{\"command\":\"echo 2\"}"}}
    ]},
    {"role":"tool","tool_call_id":"tooluse_AAAAAAAAAAAAAAAAAAAAAA","content":"1"},
    {"role":"user","content":"now say hi"}
  ]
}
```

Before this fix: `400 Expected toolResult blocks ... tooluse_BBBBBBBBBBBBBBBBBBBBBB` (reproduced on production, 5/6 tries — the other try hit an unrelated per-connection `profileArn` error from a different pooled account).

## Tests Added

`tests/unit/kiro-orphan-tooluse-13170.test.ts` (5 tests):
- an orphaned parallel tool_call is stripped, its answered sibling survives
- an assistant turn where *every* tool_call is orphaned drops `toolUses` entirely (not left as `[]`)
- a trailing (in-flight, not-yet-answered) tool_call on the final assistant turn is unaffected (it becomes `currentMessage`, not a history entry with `toolUses`, so nothing to strip)
- characterization: fully-answered parallel tool_calls are unaffected (no regression)
- characterization: assistant text is preserved on an ordinary non-tool transcript (no regression)

## Notes for review

- This is my first PR to this repo — happy to adjust naming/placement/test style to match project conventions, or split into a smaller diff if preferred.
- I have not run the full local test/lint/typecheck suite against this branch (no local dev environment set up for this repo) — please treat the "Tests Added" section above as unverified-by-CI until this PR's own checks run, and let me know if I should set that up before this is reviewable.
- Draft while CI runs / for an initial look at the approach before I mark it ready.

Closes #13170