### PR TITLE
chore(deps): bump hono from ^4.12.34 to ^4.13.7 (#13148)

### DIFF
--- a/package.json
+++ b/package.json
@@ -478,7 +478,7 @@
     "vite": "^8.0.16",
     "protobufjs": "^7.6.5",
     "@babel/core": "^7.29.6",
-    "hono": "^4.12.34",
+    "hono": "^4.13.7",
     "@hono/node-server": "^2.0.5",
     "fast-uri": "^3.1.7",
     "body-parser": "^2.3.0",


### PR DESCRIPTION
## Summary

Fixes #13148

Bumps `hono` from `^4.12.34` to `^4.13.7`.

## Changelog highlights (4.13.0 → 4.13.7)

| Version | Fix |
|---|---|
| **4.13.6** | **fix(jsx): prevent XSS via JSX children attribute (#4478)** — primary motivation for this bump |
| 4.13.7 | fix(hono-base): use raw value for x-forwarded-proto in getRequestProtocol |
| 4.13.5 | fix(deno): RPC type regression |
| 4.13.4 | fix(router): RegExpRouter static match regression |
| 4.13.3 | fix(client): form data serialization |
| 4.13.2 | fix(jsx): hydration mismatch on self-closing tags |
| 4.13.1 | fix(context): cookie helper set-cookie ordering |
| 4.13.0 | feature: hono/jsx streaming SSR improvements |

## Security note

**4.13.6** fixes an XSS in `hono/jsx` where JSX children attribute values were not properly escaped. OmniRoute uses `hono` for its edge-facing HTTP surface, so this closes a real injection vector.

## Verification

- Single declaration site: `package.json` dependencies (verified via `git grep` across all tracked `package.json` files)
- No lockfile in repo (packageManager-scoped CI installs resolve fresh)
- Single-file dependency bump, no schema/permission impact

Fixes #13148
