### PR TITLE
fix(dashboard): show full text on hover when feature-flag description is clamped

### DIFF
--- a/src/app/(dashboard)/dashboard/settings/components/FeatureFlagCard.tsx
+++ b/src/app/(dashboard)/dashboard/settings/components/FeatureFlagCard.tsx
@@ -213,7 +213,9 @@ export default function FeatureFlagCard({
       </div>
 
       {/* Description */}
-      <p className="mb-3 line-clamp-2 text-xs text-text-muted">{flag.description}</p>
+      <p className="mb-3 line-clamp-2 text-xs text-text-muted" title={flag.description}>
+        {flag.description}
+      </p>
 
       <EnvPrecedenceWarning flag={flag} text={t("ccDiscoveryAliasesEnvWarning")} />
 

--- a/tests/unit/ui/FeatureFlagCard.test.tsx
+++ b/tests/unit/ui/FeatureFlagCard.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+// next-intl: no local mock — falls through to the real-EN-text default mock in
+// tests/_setup/vitestUiPolyfills.ts.
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+const { default: FeatureFlagCard } =
+  await import("@/app/(dashboard)/dashboard/settings/components/FeatureFlagCard");
+
+type Flag = React.ComponentProps<typeof FeatureFlagCard>["flag"];
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeFlag(overrides: Partial<Flag> = {}): Flag {
+  return {
+    key: "SOME_FLAG",
+    label: "Some Flag",
+    description:
+      "A very long description that would normally overflow past two lines of text in the card and get visually cut off.",
+    category: "runtime",
+    type: "boolean",
+    enumValues: null,
+    effectiveValue: "false",
+    source: "default",
+    requiresRestart: false,
+    ...overrides,
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const containers: HTMLElement[] = [];
+
+function renderCard(flag: Flag): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <FeatureFlagCard flag={flag} onToggle={() => {}} onReset={() => {}} saving={false} />
+    );
+  });
+  return container;
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  while (containers.length > 0) {
+    containers.pop()?.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("FeatureFlagCard", () => {
+  it("renders the flag key", () => {
+    const container = renderCard(makeFlag());
+    expect(container.textContent).toContain("SOME_FLAG");
+  });
+
+  it("exposes the full description as a title attribute so a clamped description stays readable on hover", () => {
+    const description =
+      "A very long description that would normally overflow past two lines of text in the card and get visually cut off.";
+    const container = renderCard(makeFlag({ description }));
+    const descriptionEl = container.querySelector("p[title]");
+    expect(descriptionEl).not.toBeNull();
+    expect(descriptionEl!.getAttribute("title")).toBe(description);
+    expect(descriptionEl!.textContent).toBe(description);
+  });
+});


### PR DESCRIPTION
﻿Fixes #12739.

## Problem

`FeatureFlagCard` clamps the flag description to 2 lines with `line-clamp-2`. When a
description is longer than that, the remaining text is silently cut off with no way to
read the rest of it from the dashboard Settings page.

## Fix

Add a `title` attribute carrying the full, un-clamped description to the `<p>` element.
Browsers show it as a native tooltip on hover, so a truncated description stays fully
readable without changing the compact card layout.

## Testing

- `npx vitest run tests/unit/ui/FeatureFlagCard.test.tsx` — added a test asserting the
  card renders the flag key and exposes the full description via `title`.
- `npx eslint` on the changed files — clean.
- `npx tsc --noEmit` — no new errors.
