### PR TITLE
fix(test): resolve the WebDAV handler path with fileURLToPath

### DIFF
--- a/changelog.d/fixes/webdav-test-windows-path.md
+++ b/changelog.d/fixes/webdav-test-windows-path.md
@@ -1,0 +1,1 @@
+- **fix(test):** resolve the WebDAV handler path with `fileURLToPath` so the suite's 37 WebDAV tests run on Windows instead of failing with a doubled `C:\C:\` drive prefix

--- a/tests/unit/webdav-server-3485.test.ts
+++ b/tests/unit/webdav-server-3485.test.ts
@@ -30,14 +30,19 @@ import path from "node:path";
 import http from "node:http";
 import { EventEmitter } from "node:events";
 import { createCipheriv, randomBytes, scryptSync } from "node:crypto";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
+// `URL.pathname` is a URL path, not an OS path: on Windows it yields
+// "/C:/..." — a leading slash before the drive letter. `path.resolve` does not
+// treat that as absolute, so it prepends the CWD and produces "C:\C:\...",
+// which fails to import. `fileURLToPath` decodes to a real OS path on every
+// platform (it also un-escapes %20 in paths containing spaces).
 const HANDLER_PATH = path.resolve(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../../scripts/dev/webdav-handler.mjs"
 );
 


### PR DESCRIPTION
## Problem

All 37 tests in `tests/unit/webdav-server-3485.test.ts` fail on Windows:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  'C:\C:\...\scripts\dev\webdav-handler.mjs'
```

Note the doubled drive prefix. The handler path is built from `URL.pathname`:

```ts
const HANDLER_PATH = path.resolve(
  path.dirname(new URL(import.meta.url).pathname),
  "../../scripts/dev/webdav-handler.mjs"
);
```

`URL.pathname` returns a **URL** path, not an OS path. On POSIX the two happen to coincide, so this works. On Windows it yields `/C:/Users/...` — a leading slash *before* the drive letter. `path.resolve` does not consider that absolute, so it prepends the CWD and produces `C:\C:\...`, which cannot be imported.

CI runs on Linux, so this never shows up there; it only costs Windows contributors, silently, on every run.

## Fix

Use `fileURLToPath`, which decodes a `file:` URL to a real OS path on every platform. (It also un-escapes percent-encoding, so paths containing spaces work — `URL.pathname` would leave `%20` in place.) `node:url` was already imported here for `pathToFileURL`.

## Verification

Same file, same machine (Windows), before and after:

| | pass | fail |
|---|---|---|
| before | 0 | 37 |
| after | **37** | **0** |

Found while auditing why a local full-suite run reports failures that CI does not. This accounts for 37 of them.
