### PR TITLE
docs(changelog): add the missing bullet marker to the DeepSeek PoW fragment

### DIFF
--- a/changelog.d/fixes/13094-deepseek-pow-slot-leak.md
+++ b/changelog.d/fixes/13094-deepseek-pow-slot-leak.md
@@ -1,1 +1,1 @@
-Fix a concurrency-slot leak in the DeepSeek PoW solver: a worker that failed to spawn (for example a missing worker script) never released its slot, so `MAX_CONCURRENT_WORKERS` failures disabled the solver until restart.
+- Fix a concurrency-slot leak in the DeepSeek PoW solver: a worker that failed to spawn (for example a missing worker script) never released its slot, so `MAX_CONCURRENT_WORKERS` failures disabled the solver until restart.


### PR DESCRIPTION
`Merge integrity` está vermelho no tip:

```
[changelog-integrity] 1 invalid changelog fragment(s):
  ✗ changelog.d/fixes/13094-deepseek-pow-slot-leak.md: fragment must start with a markdown bullet ("- ")
```

Veio do #13097. Um caractere: o `- ` inicial.

É a terceira vez que esse mesmo gate cai pela mesma causa nesta release — antes foi `reset-aware-model-family.md`, consertado dentro do #12711. Vale considerar um hook de pre-commit que valide o formato do fragmento ao adicioná-lo, em vez de descobrir no CI de quem vier depois.
