### PR TITLE
fix(evals): compile string regex patterns with dotAll so multi-line answers grade correctly

### DIFF
--- a/changelog.d/fixes/13202-eval-regex-dotall.md
+++ b/changelog.d/fixes/13202-eval-regex-dotall.md
@@ -1,0 +1,1 @@
+- **fix(evals):** regex grading compiles suite-supplied string patterns with `dotAll`, so correct multi-line answers are no longer marked wrong ([#13202](https://github.com/diegosouzapw/OmniRoute/pull/13202)) — thanks @aaustinhuang

--- a/src/lib/evals/evalRunner.ts
+++ b/src/lib/evals/evalRunner.ts
@@ -153,10 +153,16 @@ export function evaluateCase(evalCase: any, actualOutput: string) {
           details.error = "No regex value provided for evaluation.";
           break;
         }
+        // Suite JSON can only carry a pattern as a string, so the `s` (dotAll) flag has to
+        // be supplied here: without it `.` does not cross a newline, and several built-in
+        // cases join tokens a model naturally puts on separate lines (gs-09 `1.*2.*3.*4.*5`,
+        // code-03 `SELECT.*FROM.*WHERE`, instr-02 `1\..*2\..*3\..*4\..*5\.`). dotAll widens
+        // `.` only, so a pattern that matched before still matches — it is not a regression
+        // risk. An author-supplied RegExp keeps exactly the flags they wrote.
         const regex =
           expectedValue instanceof RegExp
             ? new RegExp(expectedValue.source, expectedValue.flags.replace(/[gy]/g, ""))
-            : new RegExp(expectedValue);
+            : new RegExp(expectedValue, "s");
         if (regex.source.length > 512) {
           passed = false;
           details.error = "Regex pattern too large for safe evaluation.";

--- a/tests/unit/eval-runner-regex-dotall.test.ts
+++ b/tests/unit/eval-runner-regex-dotall.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression: regex grading must compile string patterns with the `s` (dotAll) flag.
+ *
+ * Issue #13138 — `evaluateCase()` compiles suite-supplied string patterns with no flags, so
+ * `.` does not match a newline. Suite JSON can only carry a string, so the no-flags branch is
+ * the one every custom and built-in suite takes. LLM answers are routinely multi-line and
+ * several built-in cases join tokens with `.*`, so those cases fail on correct answers.
+ */
+
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+
+import { evaluateCase, resetSuites } from "../../src/lib/evals/evalRunner.ts";
+
+function grader(pattern: string) {
+  return {
+    id: "dotall-case",
+    name: "dotall case",
+    model: "gemini-2.5-flash",
+    input: { messages: [{ role: "user", content: "irrelevant" }] },
+    expected: { strategy: "regex", value: pattern },
+  };
+}
+
+describe("evalRunner — regex dotAll grading (#13138)", () => {
+  after(() => {
+    resetSuites();
+  });
+
+  it("matches a multi-line answer against a `.*`-joined pattern (gs-09 Counting)", () => {
+    const result = evaluateCase(grader("1.*2.*3.*4.*5"), "1\n2\n3\n4\n5");
+    assert.equal(result.passed, true);
+  });
+
+  it("matches a multi-line SQL answer (code-03 SELECT query)", () => {
+    const result = evaluateCase(
+      grader("SELECT.*FROM.*WHERE"),
+      "```sql\nSELECT *\nFROM users\nWHERE age > 25\n```"
+    );
+    assert.equal(result.passed, true);
+  });
+
+  it("matches a multi-line numbered list (instr-02 Numbered list format)", () => {
+    const result = evaluateCase(
+      grader("1\\..*2\\..*3\\..*4\\..*5\\."),
+      "1. Mercury\n2. Venus\n3. Earth\n4. Mars\n5. Jupiter"
+    );
+    assert.equal(result.passed, true);
+  });
+
+  it("still fails an answer that genuinely does not match", () => {
+    const result = evaluateCase(grader("1.*2.*3.*4.*5"), "I will not answer that.");
+    assert.equal(result.passed, false);
+  });
+
+  it("still anchors single-line patterns correctly", () => {
+    const result = evaluateCase(grader("^\\s*[Bb]lue\\s*\\.?\\s*$"), "Blue.");
+    assert.equal(result.passed, true);
+  });
+
+  it("keeps the safeRegex guard and the 512-character source limit", () => {
+    const catastrophic = evaluateCase(grader("(a+)+$"), `${"a".repeat(40)}b`);
+    assert.equal(catastrophic.passed, false);
+    assert.match(String(catastrophic.details?.error), /unsafe/i);
+
+    const oversized = evaluateCase(grader("a".repeat(600)), "aaa");
+    assert.equal(oversized.passed, false);
+    assert.match(String(oversized.details?.error), /too large/i);
+  });
+
+  it("still honours an explicit RegExp instance's own flags", () => {
+    const makeCase = (value: RegExp) => ({
+      id: "regexp-instance",
+      name: "regexp instance",
+      model: "gpt-4o",
+      input: { messages: [{ role: "user", content: "irrelevant" }] },
+      expected: { strategy: "regex", value },
+    });
+
+    // An author-supplied `s` is preserved (the RegExp branch keeps the author's flags).
+    assert.equal(evaluateCase(makeCase(/1.*5/s), "1\n5").passed, true);
+    // An author who does not ask for dotAll keeps that choice.
+    assert.equal(evaluateCase(makeCase(/1.*5/), "1\n5").passed, false);
+  });
+});


### PR DESCRIPTION
Fixes the eval regex-grading defect reported in #13138.

## What was wrong

`evaluateCase()` (`src/lib/evals/evalRunner.ts`) compiled suite-supplied string patterns with
**no flags**, so `dotAll` was off and `.` did not cross a newline:

```js
const regex =
  expectedValue instanceof RegExp
    ? new RegExp(expectedValue.source, expectedValue.flags.replace(/[gy]/g, ""))
    : new RegExp(expectedValue);   // <- every suite-supplied pattern takes this branch
```

Suite JSON can only carry a pattern as a string, so the second branch is the one every custom
and built-in suite takes. LLM answers are routinely multi-line, and several built-in cases join
tokens with `.*` that a model naturally puts on separate lines.

## Reproduction

Three built-in cases, all with correct model output:

| case | pattern | correct model output | before |
|---|---|---|---|
| `gs-09` Counting | `1.*2.*3.*4.*5` | `1\n2\n3\n4\n5` | fail |
| `code-03` SQL — SELECT query | `SELECT.*FROM.*WHERE` | ```` ```sql\nSELECT *\nFROM users\nWHERE age > 25``` ```` | fail |
| `instr-02` Numbered list format | `1\..*2\..*3\..*4\..*5\.` | `1. Mercury\n2. Venus\n3. Earth\n4. Mars\n5. Jupiter` | fail |

## Change

Compile string patterns with `s`. The graded answers are exactly what the cases ask for.

**Why this cannot regress a passing case:** `dotAll` only *widens* `.` (from "any char except
line terminators" to "any char"). Any match that succeeded before still succeeds, because the
same characters still satisfy `.`. So `passed` can only move `false → true`, never `true → false`.

An author-supplied `RegExp` keeps exactly the flags they wrote — only the string branch changes,
so `/1.*5/` without `s` still does not match across a newline while `/1.*5/s` does.

The `safeRegex` guard and the 512-character source limit are untouched; `dotAll` changes matching
semantics, not backtracking behaviour.

## Validation (Hard Rule #18 — TDD)

Regression test added: `tests/unit/eval-runner-regex-dotall.test.ts`.

- **Red** (fix reverted): the three multi-line cases fail — e.g.
  `✖ matches a multi-line answer against a .*-joined pattern (gs-09 Counting)`
- **Green** (fix applied): 7/7 pass
- **No regression**: `batch-b-final.test.ts` + `evalrunner-builtinsuites-split.test.ts` → 38/38 pass

The test also pins the safety behaviour: a catastrophic pattern (`(a+)+$`) is still rejected by
`safeRegex`, an over-long source (>512) is still rejected, a genuinely non-matching answer still
fails, and an anchored single-line pattern still grades correctly.

Commands run:

```bash
node --import tsx/esm --test tests/unit/eval-runner-regex-dotall.test.ts
node --import tsx/esm --test tests/unit/batch-b-final.test.ts tests/unit/evalrunner-builtinsuites-split.test.ts
npx prettier --write src/lib/evals/evalRunner.ts tests/unit/eval-runner-regex-dotall.test.ts
npx eslint src/lib/evals/evalRunner.ts tests/unit/eval-runner-regex-dotall.test.ts
```

## Test files added

- `tests/unit/eval-runner-regex-dotall.test.ts`

## Scope

Two files: the string-pattern compilation branch and its regression test. No API, schema,
dependency, or CI change. The changelog fragment lands in a follow-up commit on this branch.

⚠️ base-red inherited: #12732
