### PR TITLE
[URGENT] fix(tests): clear the ESLint base-red on release/v3.8.51 (volcengine any casts)

### DIFF
--- a/tests/unit/volcengine-plan-binding-upsert.test.ts
+++ b/tests/unit/volcengine-plan-binding-upsert.test.ts
@@ -67,7 +67,7 @@ test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) 
     providerSpecificData: { autoFetchModels: true, customTag: "keep-me" },
   });
 
-  const updated1 = await (bindingTesting as any).upsertConnection(
+  const updated1 = await bindingTesting.upsertConnection(
     "coding",
     "ark-new-key-1",
     "new-cookie-1",
@@ -93,7 +93,7 @@ test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) 
     providerSpecificData: {},
   });
 
-  const createdNew = await (bindingTesting as any).upsertConnection(
+  const createdNew = await bindingTesting.upsertConnection(
     "coding",
     "ark-brand-new-key-3",
     "new-cookie-3",
@@ -117,7 +117,7 @@ test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) 
   });
 
   // Passing conn1.id (which is coding-plan) into agent upsert must NOT match conn1
-  const agentUpsertResult = await (bindingTesting as any).upsertConnection(
+  const agentUpsertResult = await bindingTesting.upsertConnection(
     "agent",
     "ark-agent-new-key",
     "agent-cookie",


### PR DESCRIPTION
## Summary

Clears the **ESLint base-red on `release/v3.8.51`** that fans out to every open PR as `No new ESLint warnings` → red.

`tests/unit/volcengine-plan-binding-upsert.test.ts` carried three `(bindingTesting as any).upsertConnection(...)` casts. The `__testing.upsertConnection` helper is fully typed (exported from `src/lib/providers/volcenginePlanBinding.ts`), so the casts were dead weight — and with `@typescript-eslint/no-explicit-any` set to **error** under `tests/`, they turned the release tip itself red the moment they merged (originating PR #12950 is already merged, so there is no branch left to fix: this is a base-reds repair PR).

## Change

```diff
- const updated1 = await (bindingTesting as any).upsertConnection(...)
+ const updated1 = await bindingTesting.upsertConnection(...)
```
…same for the two other call sites (lines 70/96/120). No production code, no test semantics changed.

## Validation (on this branch, from the release tip `8ecdd88c1`)

- `npx eslint tests/unit/volcengine-plan-binding-upsert.test.ts --suppressions-location config/quality/eslint-suppressions.json` → **0 errors**
- `node --import tsx/esm --test tests/unit/volcengine-plan-binding-upsert.test.ts` → **3/3 pass**

## Impact

- Fixes 1 of the 2 hard failures reported on base-red **#12732**.
- Un-reds the `No new ESLint warnings` check on every open PR (including #12608, #12759, #13177).

## Notes

- The other base-red items are already owned elsewhere: Stryker tap registration → **#12945**, docs count (172) → merged via **#13209**.
- No release-freeze is active as of opening this PR.
