### PR TITLE
fix(codex): route discovered reasoning tiers through catalog and dispatch

### DIFF
--- a/changelog.d/fixes/13224-codex-discovered-reasoning-efforts.md
+++ b/changelog.d/fixes/13224-codex-discovered-reasoning-efforts.md
@@ -1,0 +1,1 @@
+- **fix(codex):** Preserve discovered native reasoning levels and defaults through synchronization, dashboard/catalog variants, and request dispatch; keep Max unchanged and protect exact upstream model IDs from suffix parsing ([#13224](https://github.com/diegosouzapw/OmniRoute/pull/13224)) — thanks @TPOHH

--- a/open-sse/executors/codex.ts
+++ b/open-sse/executors/codex.ts
@@ -52,12 +52,8 @@ export {
   getCodexDualWindowCooldownMs,
 } from "./codex/quota.ts";
 import { isCodexFreePlan, normalizeCodexTools } from "./codex/tools.ts";
-import {
-  CODEX_EFFORT_ORDER as EFFORT_ORDER,
-  GPT_5_6_ULTRA_ALIAS_MODELS,
-  splitCodexReasoningSuffix,
-  type CodexEffortLevel as EffortLevel,
-} from "./codex/reasoningSuffix.ts";
+import { GPT_5_6_ULTRA_ALIAS_MODELS, splitCodexReasoningSuffix } from "./codex/reasoningSuffix.ts";
+import { applyCodexReasoningSelection } from "./codex/reasoningPolicy.ts";
 import { repairMissingCodexToolCallOutputs } from "./codex/toolCallRepair.ts";
 import { resolveAppServerConfig } from "./codex/appServerConfig.ts";
 import { CodexAppServerExecutor } from "./codex-app-server.ts";
@@ -322,37 +318,6 @@ function normalizeServiceTierValue(value: unknown): string | undefined {
   if (!normalized) return undefined;
   if (normalized === "fast") return CODEX_FAST_WIRE_VALUE;
   return normalized;
-}
-
-/**
- * Maximum reasoning effort allowed per Codex model.
- * Models not listed here retain the legacy xhigh cap.
- * Update this table when Codex releases new models with different caps.
- */
-const MAX_EFFORT_BY_MODEL: Record<string, EffortLevel> = {
-  "gpt-5.6-sol": "ultra",
-  "gpt-5.6-terra": "ultra",
-  "gpt-5.6-luna": "max",
-  "gpt-5.3-codex": "xhigh",
-  "gpt-5.1-codex-max": "xhigh",
-  "gpt-5-mini": "high",
-  "gpt-5.1-mini": "high",
-  "gpt-4.1-mini": "high",
-};
-
-/**
- * Clamp reasoning effort to the model's maximum allowed level.
- * Returns the original value if within limits, or the cap if it exceeds it.
- */
-function clampEffort(model: string, requested: string): string {
-  const max: EffortLevel = MAX_EFFORT_BY_MODEL[model] ?? "xhigh";
-  const reqIdx = EFFORT_ORDER.indexOf(requested as EffortLevel);
-  const maxIdx = EFFORT_ORDER.indexOf(max);
-  if (reqIdx > maxIdx) {
-    console.debug(`[Codex] clampEffort: "${requested}" → "${max}" (model: ${model})`);
-    return max;
-  }
-  return requested;
 }
 
 const CODEX_REASONING_ENCRYPTED_CONTENT_INCLUDE = "reasoning.encrypted_content";
@@ -1361,38 +1326,13 @@ export class CodexExecutor extends BaseExecutor {
     delete body.messages;
     delete body.prompt;
 
-    let modelEffort: string | null = null;
-    let cleanModel = typeof body.model === "string" ? body.model : model;
-    const splitModel = splitCodexReasoningSuffix(cleanModel);
-    if (splitModel.effort) {
-      modelEffort = splitModel.effort;
-      body.model = splitModel.baseModel;
-      cleanModel = splitModel.baseModel;
-    }
-
-    const reasoningRecord =
-      body.reasoning && typeof body.reasoning === "object" && !Array.isArray(body.reasoning)
-        ? (body.reasoning as Record<string, unknown>)
-        : null;
-    const explicitReasoning = normalizeEffortValue(reasoningRecord?.effort);
-    const requestReasoningEffort = normalizeEffortValue(body.reasoning_effort);
-    const fallbackReasoningEffort = allowConnectionReasoningDefaults
-      ? requestDefaults.reasoningEffort || "medium"
-      : undefined;
-    // Issue #2331: model suffix aliases (for example gpt-5.5-xhigh) represent an
-    // explicit model selection, so they must override client-injected defaults such
-    // as OpenCode's automatic reasoning.effort=medium for GPT-5-family requests.
-    const rawEffort =
-      modelEffort || explicitReasoning || requestReasoningEffort || fallbackReasoningEffort;
-
-    if (rawEffort) {
-      const clampedEffort = clampEffort(cleanModel, rawEffort);
-      body.reasoning = {
-        ...(reasoningRecord || {}),
-        // Ultra coordinates delegation in Codex clients; the upstream wire effort is Max.
-        effort: clampedEffort === "ultra" ? "max" : clampedEffort,
-      };
-    }
+    applyCodexReasoningSelection(
+      model,
+      body,
+      credentials.providerSpecificData?._omnirouteCodexThinking,
+      allowConnectionReasoningDefaults ? requestDefaults.reasoningEffort : undefined,
+      allowConnectionReasoningDefaults
+    );
     ensureCodexReasoningSummary(body);
     if (isCompactRequest) {
       delete body.include;

--- a/open-sse/executors/codex/reasoningPolicy.ts
+++ b/open-sse/executors/codex/reasoningPolicy.ts
@@ -1,0 +1,87 @@
+import {
+  CODEX_EFFORT_ORDER as EFFORT_ORDER,
+  splitCodexReasoningSuffix,
+  type CodexEffortLevel as EffortLevel,
+} from "./reasoningSuffix.ts";
+
+type RecordValue = Record<string, unknown>;
+function asRecord(value: unknown): RecordValue {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as RecordValue) : {};
+}
+function effort(value: unknown): string | undefined {
+  return typeof value === "string" ? value.trim().toLowerCase() || undefined : undefined;
+}
+
+/**
+ * Maximum reasoning effort allowed per Codex model.
+ * Fallback for legacy catalog entries only. Discovered metadata takes precedence.
+ */
+const MAX_EFFORT_BY_MODEL: Record<string, EffortLevel> = {
+  "gpt-5.6-sol": "ultra",
+  "gpt-5.6-terra": "ultra",
+  "gpt-5.6-luna": "max",
+  "gpt-5.3-codex": "xhigh",
+  "gpt-5.1-codex-max": "xhigh",
+  "gpt-5-mini": "high",
+  "gpt-5.1-mini": "high",
+  "gpt-4.1-mini": "high",
+};
+
+/**
+ * Clamp reasoning effort to the model's maximum allowed level.
+ * Returns the original value if within limits, or the cap if it exceeds it.
+ */
+function clampEffort(model: string, requested: string): string {
+  const max = MAX_EFFORT_BY_MODEL[model];
+  if (!max) return requested;
+  const reqIdx = EFFORT_ORDER.indexOf(requested as EffortLevel);
+  const maxIdx = EFFORT_ORDER.indexOf(max);
+  if (reqIdx > maxIdx) {
+    console.debug(`[Codex] clampEffort: "${requested}" → "${max}" (model: ${model})`);
+    return max;
+  }
+  return requested;
+}
+
+/** Apply a catalog-resolved selection without parsing a real upstream ID twice. */
+export function applyCodexReasoningSelection(
+  model: string,
+  body: RecordValue,
+  metadataInput: unknown,
+  connectionDefault: string | undefined,
+  allowDefaults: boolean
+): void {
+  const metadata = asRecord(metadataInput);
+  const requestedModel = typeof body.model === "string" ? body.model : model;
+  const hasCatalog =
+    metadata.model === requestedModel && Array.isArray(metadata.supportedThinkingEfforts);
+  const split = hasCatalog
+    ? { baseModel: requestedModel, effort: effort(metadata.resolvedThinkingEffort) }
+    : splitCodexReasoningSuffix(requestedModel);
+  if (split.effort) body.model = split.baseModel;
+  const reasoning = asRecord(body.reasoning);
+  // Chat→Responses translation normalizes canonical max to xhigh. Restore the
+  // original choice for catalog-backed Codex models in passthrough mode; explicit
+  // thinking-budget policies still own the translated value in other modes.
+  const requested =
+    hasCatalog && allowDefaults && Object.hasOwn(metadata, "requestedThinkingEffort")
+      ? effort(metadata.requestedThinkingEffort)
+      : effort(reasoning.effort) || effort(body.reasoning_effort);
+  const selected =
+    split.effort ||
+    requested ||
+    (allowDefaults
+      ? connectionDefault || effort(metadata.defaultThinkingEffort) || "medium"
+      : undefined);
+  if (!selected) return;
+  // New catalog values pass through verbatim, including upstream validation errors.
+  // Only the old built-in Ultra aliases retain their historical Max wire mapping.
+  const resolved = hasCatalog ? selected : clampEffort(split.baseModel, selected);
+  body.reasoning = {
+    ...reasoning,
+    effort:
+      !hasCatalog && MAX_EFFORT_BY_MODEL[split.baseModel] && resolved === "ultra"
+        ? "max"
+        : resolved,
+  };
+}

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -2992,6 +2992,7 @@ export async function handleChatCore({
       provider,
       ccSessionId,
       modelInfo,
+      requestBody: body,
     });
 
   let onPipelineStreamError: streamFailure.PipelineStreamErrorHandler | null = null;

--- a/open-sse/handlers/chatCore/executionCredentials.ts
+++ b/open-sse/handlers/chatCore/executionCredentials.ts
@@ -83,6 +83,7 @@ export function resolveExecutionCredentials(opts: {
   provider: string | null | undefined;
   ccSessionId: string | null;
   modelInfo?: Record<string, unknown> | null;
+  requestBody?: Record<string, unknown>;
 }): ResolvedExecutionCredentials {
   const {
     credentials,
@@ -92,6 +93,7 @@ export function resolveExecutionCredentials(opts: {
     provider,
     ccSessionId,
     modelInfo,
+    requestBody,
   } = opts;
 
   const nextCredentials = nativeCodexPassthrough
@@ -166,6 +168,22 @@ export function resolveExecutionCredentials(opts: {
   }
 
   applyKimiExecutionMetadata(providerSpecificData, provider, targetFormat, modelInfo);
+  // Request-local resolved catalog metadata; never persist this on the connection.
+  if (provider === "codex" && Array.isArray(modelInfo?.supportedThinkingEfforts)) {
+    providerSpecificData._omnirouteCodexThinking = {
+      model: modelInfo.model,
+      supportedThinkingEfforts: modelInfo.supportedThinkingEfforts,
+      defaultThinkingEffort: modelInfo.defaultThinkingEffort,
+      resolvedThinkingEffort: modelInfo.resolvedThinkingEffort,
+      ...(requestBody
+        ? {
+            requestedThinkingEffort:
+              (requestBody.reasoning as Record<string, unknown> | undefined)?.effort ??
+              requestBody.reasoning_effort,
+          }
+        : {}),
+    };
+  }
   const withApiType = {
     ...nextCredentials,
     providerSpecificData,

--- a/open-sse/utils/syncedEffortVariants.ts
+++ b/open-sse/utils/syncedEffortVariants.ts
@@ -19,17 +19,17 @@
  * only when the base model's own `supportedThinkingEfforts` actually declares that tier —
  * never a blind string match.
  *
- * Skipped entirely for `codex`, `kimi`-owned, and GLM (`glm`, `glm-cn`, `glmt`) models:
- * they already own conflicting `-{effort}` aliases (`splitCodexReasoningSuffix`,
- * `getKimiCodeStaticThinkingPolicy`, or `GlmExecutor::parseGlmEffortTier`), so generating
- * another layer here would create invalid nested ids. Also skipped for any model whose id
- * already ends in a token that matches a canonical effort value, to avoid colliding with a
- * model that legitimately ends in an effort-like token (e.g. a model named "...-high").
+ * Skipped entirely for `kimi`-owned, and GLM (`glm`, `glm-cn`, `glmt`) models:
+ * they already own conflicting `-{effort}` aliases (`getKimiCodeStaticThinkingPolicy`, or `GlmExecutor::parseGlmEffortTier`), so generating
+ * another layer here would create invalid nested ids. Other providers skip model ids that
+ * already end in an effort token. Codex resolves exact discovered ids before aliases, so
+ * legitimate upstream names such as "...-high" can also declare their own effort variants.
  */
+import { getCodexWireEfforts } from "@/shared/reasoning/codexEfforts.ts";
 import { CANONICAL_EFFORT_VALUES } from "@/shared/reasoning/effortStandardization.ts";
 
 /** Provider ids with dedicated `-{effort}` aliases — never synthesize another suffix layer. */
-export const SYNCED_EFFORT_SKIP_PROVIDERS = new Set(["codex", "glm", "glm-cn", "glmt"]);
+export const SYNCED_EFFORT_SKIP_PROVIDERS = new Set(["glm", "glm-cn", "glmt"]);
 /** Provider-id prefixes covering that mechanism's multiple connection variants (kimi-coding, kimi-coding-apikey). */
 const SYNCED_EFFORT_SKIP_PROVIDER_PREFIXES = ["kimi"];
 
@@ -55,9 +55,14 @@ function endsWithKnownEffortToken(id: string): boolean {
 }
 
 function extractEffortTiers(model: CatalogModelEntry): string[] {
-  const tiers = model.capabilities?.effort_tiers;
+  const tiers =
+    model.capabilities?.effort_tiers ??
+    (model.owned_by === "codex" ? model.supportedThinkingEfforts : undefined);
   if (!Array.isArray(tiers)) return [];
-  return tiers.filter((tier): tier is string => typeof tier === "string" && tier.length > 0);
+  const values = tiers.filter(
+    (tier): tier is string => typeof tier === "string" && tier.length > 0
+  );
+  return model.owned_by === "codex" ? getCodexWireEfforts(values) : values;
 }
 
 /**
@@ -65,7 +70,7 @@ function extractEffortTiers(model: CatalogModelEntry): string[] {
  *
  * Rule: a synced model that declares `capabilities.effort_tiers`, is not owned by a
  * provider that already owns its own suffix mechanism, is not a virtual combo entry, and
- * whose id does not already end in a token that collides with a canonical effort value.
+ * whose id does not already end in a canonical effort token (except exact Codex ids).
  */
 export function shouldExposeSyncedEffortVariants(
   model: CatalogModelEntry
@@ -77,7 +82,7 @@ export function shouldExposeSyncedEffortVariants(
   if (typeof model.owned_by === "string" && isSkippedEffortProvider(model.owned_by)) {
     return false;
   }
-  if (endsWithKnownEffortToken(id)) return false;
+  if (model.owned_by !== "codex" && endsWithKnownEffortToken(id)) return false;
   return extractEffortTiers(model).length > 0;
 }
 
@@ -102,7 +107,18 @@ export function appendSyncedEffortVariants<T extends CatalogModelEntry>(models: 
       const variantId = `${model.id}-${tier}`;
       if (existingIds.has(variantId)) continue;
       existingIds.add(variantId);
-      variants.push({ ...model, id: variantId, root: `${baseRoot}-${tier}` });
+      variants.push({
+        ...model,
+        id: variantId,
+        root: `${baseRoot}-${tier}`,
+        ...(model.owned_by === "codex"
+          ? {
+              name: `${typeof model.name === "string" ? model.name : model.id} (${tier})`,
+              supportedThinkingEfforts: undefined,
+              capabilities: { ...model.capabilities, effort_tiers: undefined },
+            }
+          : {}),
+      });
     }
   }
 

--- a/src/app/api/providers/[id]/models/discovery/codex.ts
+++ b/src/app/api/providers/[id]/models/discovery/codex.ts
@@ -3,6 +3,7 @@ import {
   getCodexClientVersion,
   getCodexDefaultHeaders,
 } from "@omniroute/open-sse/config/codexClient.ts";
+import { readCodexReasoningMetadata } from "@/shared/reasoning/codexEfforts";
 import { isCodexDiscoveryModelExcluded } from "@/shared/services/codexDiscoveryPolicy";
 
 export {
@@ -27,6 +28,8 @@ export type CodexDiscoveryModel = {
   inputTokenLimit?: number;
   outputTokenLimit?: number;
   description?: string;
+  supportedThinkingEfforts?: string[];
+  defaultThinkingEffort?: string;
   supportsThinking?: boolean;
   supportsVision?: boolean;
 };
@@ -164,6 +167,7 @@ function buildCodexDiscoveryModel(record: JsonRecord): CodexDiscoveryModel | nul
     owned_by: "codex",
     apiFormat: "responses",
     supportedEndpoints: ["responses"],
+    ...readCodexReasoningMetadata(record),
   };
   // The live Codex OAuth catalog reports BOTH `context_window` (the first
   // pricing tier, ~272K) and `max_context_window` (the real usable window,

--- a/src/app/api/v1/models/syncedCapabilities.ts
+++ b/src/app/api/v1/models/syncedCapabilities.ts
@@ -12,25 +12,15 @@
  * model-scoped: executors record under connection ids while this module sees
  * provider ids, so an exact provider:model key would always miss.
  *
- * Exclusion gate: `ownedBy` is REQUIRED and checked against
- * `isSkippedEffortProvider` (codex/glm/kimi — providers that already own a
- * conflicting `-{effort}` suffix mechanism, see syncedEffortVariants.ts, #7694).
- * Without this, the blind opencode-plugin mapping (`capabilities.effort_tiers`
- * -> ModelV2 `variants`) would double-handle those providers' native suffix
- * ids. `shouldExposeSyncedEffortVariants` gates only the *synthetic*
- * `<id>-<tier>` catalog entries (open-sse/utils/syncedEffortVariants.ts) — it
- * never runs over the base entry's `capabilities`, so it cannot substitute
- * for this check. Required (not optional) so no call site can silently skip it.
- *
- * #12299 carve-out: Kimi K3's synced base entries (`k3`, `k3-256k` — the kmca
- * catalog's `low`/`high`/`max` vocabulary) are exempted from the exclusion so
- * catalog-only clients (OpenCode, plain SDK pickers) can see and select their
- * tiers. Model-scoped, never provider-wide: Codex, GLM, and non-K3 kimi models
- * keep the full exclusion exactly as before this carve-out.
+ * Kimi and GLM keep their existing suffix mechanisms. Kimi K3 base models
+ * may expose their native tiers without generating synthetic suffix entries.
+ * Codex discovery advertises wire efforts from upstream metadata; generated
+ * variants drop effort_tiers to prevent clients from appending a second suffix.
  */
 // Use the same canonical alias as catalogModelPolicy.ts (l.1) — a relative path from
 // src/app/api/v1/models/ to open-sse/ would need 5 `../` and silently breaks under
 // refactors. (Confirmed convention: grep "from \"@omniroute/open-sse" src/app/api/v1/models/)
+import { getCodexWireEfforts } from "@/shared/reasoning/codexEfforts";
 import { getLearnedReasoningEffortForModel } from "@omniroute/open-sse/services/learnedReasoningEffortCaps.ts";
 import { isSkippedEffortProvider } from "@omniroute/open-sse/utils/syncedEffortVariants.ts";
 import {
@@ -54,8 +44,8 @@ const KIMI_K3_MODEL_ID_PATTERN = /(?:^|\/)(?:kimi-)?k3(?:$|-)/i;
 /**
  * #12299: only Kimi K3's synced BASE entries are exempt from the
  * `isSkippedEffortProvider` exclusion. Model-scoped, never provider-wide —
- * the exemption requires a kimi-owned provider AND a K3 model id, so Codex,
- * GLM, and non-K3 kimi models keep the exclusion contract from #7694.
+ * the exemption requires a kimi-owned provider AND a K3 model id, so GLM
+ * and non-K3 kimi models keep the exclusion contract from #7694.
  */
 function isExemptKimiK3BaseModel(sm: SyncedCapabilityFlags, ownedBy: string): boolean {
   return (
@@ -64,11 +54,12 @@ function isExemptKimiK3BaseModel(sm: SyncedCapabilityFlags, ownedBy: string): bo
 }
 
 function effectiveEffortTiers(sm: SyncedCapabilityFlags, ownedBy: string): string[] | undefined {
-  // Exclusion gate (#7694): codex/glm/kimi own a conflicting `-{effort}` suffix
-  // mechanism — the blind opencode-plugin mapping must never see effort_tiers
-  // for them, or it double-handles the suffix. #12299 narrows only the kimi K3
-  // base-model entries out of that gate; everything else stays excluded.
+  // Preserve the dedicated Kimi/GLM suffix policies.
   if (isSkippedEffortProvider(ownedBy) && !isExemptKimiK3BaseModel(sm, ownedBy)) return undefined;
+  if (ownedBy === "codex") {
+    const efforts = getCodexWireEfforts(sm.supportedThinkingEfforts || []);
+    return efforts.length > 0 ? efforts : undefined;
+  }
   const learned = sm.id ? getLearnedReasoningEffortForModel(sm.id) : null;
   const synced =
     Array.isArray(sm.supportedThinkingEfforts) && sm.supportedThinkingEfforts.length > 0

--- a/src/lib/providerModels/modelDiscovery.ts
+++ b/src/lib/providerModels/modelDiscovery.ts
@@ -159,7 +159,11 @@ function parseEffortList(rawList: unknown): string[] | undefined {
  */
 export function detectDefaultThinkingEffort(record: JsonRecord): string | undefined {
   if (typeof record.defaultThinkingEffort === "string" && record.defaultThinkingEffort.length > 0) {
-    return normalizeSupportedEffort(record.defaultThinkingEffort);
+    // A native default declared in the same tier list is not a canonical synonym.
+    return Array.isArray(record.supportedThinkingEfforts) &&
+      record.supportedThinkingEfforts.includes(record.defaultThinkingEffort)
+      ? record.defaultThinkingEffort
+      : normalizeSupportedEffort(record.defaultThinkingEffort);
   }
   const parsed = reasoningDefaultEffortSchema.safeParse(record.reasoning);
   if (parsed.success && parsed.data) {

--- a/src/lib/providers/mergeProviderModelListing.ts
+++ b/src/lib/providers/mergeProviderModelListing.ts
@@ -4,6 +4,7 @@
  * live synced catalog when non-empty.
  */
 
+import { appendSyncedEffortVariants } from "@omniroute/open-sse/utils/syncedEffortVariants";
 import { ensureCursorAutoCatalogEntry } from "@/lib/providerModels/cursorAutoCatalog";
 import { mergeModelsWithCustomPrecedence } from "@/lib/providers/modelMetadataPrecedence";
 import {
@@ -67,8 +68,10 @@ export function mergeProviderModelListing(
     return dedupeById(mergeModelsWithCustomPrecedence(withAuto, normalizedCustom));
   }
 
+  const syncedById = new Map(synced.map((model) => [model.id, model]));
   const builtInModels = input.registryModels.map((model) => ({
     ...model,
+    ...(input.providerId === "codex" ? syncedById.get(model.id) : {}),
     source: "system",
   }));
   const registryIds = new Set(builtInModels.map((model) => model.id));
@@ -87,7 +90,10 @@ export function mergeProviderModelListing(
     source: normalizeCustomSource(model.source),
   }));
 
-  return dedupeById(
+  const merged = dedupeById(
     mergeModelsWithCustomPrecedence([...builtInModels, ...syncedExtras], normalizedCustom)
   );
+  return input.providerId === "codex"
+    ? appendSyncedEffortVariants(merged.map((model) => ({ ...model, owned_by: "codex" })))
+    : merged;
 }

--- a/src/shared/reasoning/codexEfforts.ts
+++ b/src/shared/reasoning/codexEfforts.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+const effortSchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z][a-z0-9_]*$/);
+const effortEntrySchema = z.union([effortSchema, z.object({ effort: effortSchema })]);
+
+/** Codex catalog levels are native values, not canonical-effort synonyms. */
+export function readCodexReasoningMetadata(record: Record<string, unknown>): {
+  supportedThinkingEfforts?: string[];
+  defaultThinkingEffort?: string;
+} {
+  if (!Array.isArray(record.supported_reasoning_levels)) return {};
+  const efforts = new Set<string>();
+  for (const entry of record.supported_reasoning_levels) {
+    const parsed = effortEntrySchema.safeParse(entry);
+    if (parsed.success) {
+      efforts.add(typeof parsed.data === "string" ? parsed.data : parsed.data.effort);
+    }
+  }
+  if (!efforts.size) return {};
+  const defaultEffort = effortSchema.safeParse(record.default_reasoning_level);
+  return {
+    supportedThinkingEfforts: [...efforts],
+    ...(defaultEffort.success && efforts.has(defaultEffort.data)
+      ? { defaultThinkingEffort: defaultEffort.data }
+      : {}),
+  };
+}
+
+/**
+ * Ultra in the Codex catalog is a client-side delegation preset. The Responses
+ * wire enum rejects it; do not advertise a new API alias that only fails or silently
+ * becomes Max. Keep the original catalog metadata and legacy aliases intact.
+ */
+export function getCodexWireEfforts(efforts: readonly string[]): string[] {
+  return efforts.filter((effort) => effort !== "ultra");
+}

--- a/src/sse/handlers/chat.ts
+++ b/src/sse/handlers/chat.ts
@@ -1013,7 +1013,15 @@ async function handleChatImplementation(
       if (isComboLiveTest) return true;
       // #12886: combo-name allow-list must not skip inner targets (#9057 still
       // checks auto/* / disableNonPublic via comboTargetPassesKeyModelPolicy).
-      if (!(await comboTargetPassesKeyModelPolicy({ apiKey, apiKeyInfo, requestedModelStr: resolvedModelStr, targetModelStr: modelString, isModelAllowedForKey }))) {
+      if (
+        !(await comboTargetPassesKeyModelPolicy({
+          apiKey,
+          apiKeyInfo,
+          requestedModelStr: resolvedModelStr,
+          targetModelStr: modelString,
+          isModelAllowedForKey,
+        }))
+      ) {
         return false;
       }
 
@@ -1817,7 +1825,6 @@ async function handleSingleModelChat(
         resolveBareModelToConnectionDefault(modelStr, model, credentials.defaultModel) ?? model;
       let requestBody =
         effectiveModel !== model ? { ...body, model: `${provider}/${effectiveModel}` } : body;
-
       // If the combo explicitly overrode the provider to a passthrough provider, we
       // must preserve the original unstripped modelStr so that proxy providers
       // (e.g., cline, kilocode) get the exact string they expect.
@@ -1939,6 +1946,7 @@ async function handleSingleModelChat(
             extendedContext,
             modelApiFormat: apiFormat,
             modelTargetFormat: targetFormat,
+            runtimeModelInfo: resolved.modelInfo,
             providerProfile,
             cachedSettings: runtimeOptions.cachedSettings,
             skipUpstreamRetry: runtimeOptions.skipUpstreamRetry ?? false,

--- a/src/sse/handlers/chatHelpers.ts
+++ b/src/sse/handlers/chatHelpers.ts
@@ -334,7 +334,7 @@ export async function resolveModelOrError(
     log.info("ROUTING", `Provider: ${provider}, Model: ${model}${ctxTag}`);
   }
 
-  return { provider, model, sourceFormat, targetFormat, extendedContext, apiFormat };
+  return { provider, model, sourceFormat, targetFormat, extendedContext, apiFormat, modelInfo };
 }
 
 export async function checkPipelineGates(
@@ -428,6 +428,7 @@ export async function executeChatWithBreaker({
   extendedContext,
   modelApiFormat,
   modelTargetFormat,
+  runtimeModelInfo,
   providerProfile,
   cachedSettings,
   skipUpstreamRetry = false,
@@ -468,13 +469,10 @@ export async function executeChatWithBreaker({
         runWithProxyContext(proxyInfo?.proxy || null, () =>
           (handleChatCore as any)({
             body: { ...body, model: `${provider}/${model}` },
-            // #2905-followup: forward the already-resolved custom-model targetFormat
-            // override through as modelInfo.targetFormat. Without this, chatCore.ts's
-            // own resolveChatCoreRequestSetup() reads customModelTargetFormat off THIS
-            // modelInfo object (not the one resolveModelOrError computed it from) and
-            // finds nothing, silently re-deriving targetFormat from the static registry
-            // / provider default and discarding the DB override a second time.
+            // Preserve the resolved catalog metadata and per-model wire format
+            // through the dispatch boundary, including native reasoning tiers.
             modelInfo: {
+              ...runtimeModelInfo,
               provider,
               model,
               extendedContext,

--- a/src/sse/services/model.ts
+++ b/src/sse/services/model.ts
@@ -118,7 +118,7 @@ type RuntimeModelMeta = {
 // Providers that already own a native `-{effort}` suffix mechanism — never
 // double-resolve the generic synced suffix on top of theirs (#7694, mirrors the
 // catalog-side skip list in `open-sse/utils/syncedEffortVariants.ts`).
-const SYNCED_EFFORT_SKIP_PROVIDER_PREFIXES = ["codex", "kimi"];
+const SYNCED_EFFORT_SKIP_PROVIDER_PREFIXES = ["kimi"];
 
 function isSyncedEffortSkippedProvider(providerId: string): boolean {
   return SYNCED_EFFORT_SKIP_PROVIDER_PREFIXES.some((prefix) => providerId.startsWith(prefix));
@@ -186,6 +186,9 @@ function resolveSyncedModelIdAndEffort(
   modelId: string,
   syncedModels: unknown
 ): { modelId: string; effort: string | null } {
+  if (providerId === "codex" && findRegistryModel(providerId, modelId)) {
+    return { modelId, effort: null };
+  }
   if (isSyncedEffortSkippedProvider(providerId) || !Array.isArray(syncedModels)) {
     return { modelId, effort: null };
   }

--- a/tests/unit/codex-discovered-reasoning.test.ts
+++ b/tests/unit/codex-discovered-reasoning.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-discovered-reasoning-"));
+process.env.DATA_DIR = dataDir;
+const { resetDbInstance } = await import("../../src/lib/db/core.ts");
+const { createProviderConnection } = await import("../../src/lib/db/providers.ts");
+const { getSyncedAvailableModelsForConnection } = await import("../../src/lib/db/models.ts");
+const { normalizeCodexModelsResponse } =
+  await import("../../src/app/api/providers/[id]/models/discovery/codex.ts");
+const { persistDiscoveredModels } = await import("../../src/lib/providerModels/modelDiscovery.ts");
+const { mergeProviderModelListing } =
+  await import("../../src/lib/providers/mergeProviderModelListing.ts");
+const { getModelInfo } = await import("../../src/sse/services/model.ts");
+const { resolveExecutionCredentials } =
+  await import("../../open-sse/handlers/chatCore/executionCredentials.ts");
+const { CodexExecutor } = await import("../../open-sse/executors/codex.ts");
+const { getUnifiedModelsResponse } = await import("../../src/app/api/v1/models/catalog.ts");
+
+const modelId = "future-codex-preview";
+const efforts = ["minimal", "low", "high", "max", "ultra"];
+let connectionId: string;
+test.before(async () => {
+  const c = await createProviderConnection({
+    provider: "codex",
+    authType: "oauth",
+    name: "test",
+    accessToken: "test",
+    isActive: true,
+  });
+  connectionId = c.id;
+});
+test.after(() => {
+  resetDbInstance();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+async function sync() {
+  const models = normalizeCodexModelsResponse({
+    models: [
+      {
+        slug: modelId,
+        supported_reasoning_levels: [
+          ...efforts.map((effort) => ({ effort })),
+          { effort: "max" },
+          null,
+          { effort: 5 },
+        ],
+        default_reasoning_level: "max",
+      },
+      {
+        slug: "future-codex-max",
+        supported_reasoning_levels: ["low", "high"],
+        default_reasoning_level: "low",
+      },
+      {
+        slug: "future-codex-high",
+        supported_reasoning_levels: ["low", "high"],
+        default_reasoning_level: "low",
+      },
+    ],
+  });
+  await persistDiscoveredModels("codex", connectionId, models);
+  return getSyncedAvailableModelsForConnection("codex", connectionId);
+}
+
+test("Codex discovery and repeated sync retain exact native tiers and default", async () => {
+  await sync();
+  const saved = await sync();
+  assert.equal(saved.length, 3);
+  assert.deepEqual(saved[0].supportedThinkingEfforts, efforts);
+  assert.equal(saved[0].defaultThinkingEffort, "max");
+});
+
+test("dashboard and public catalog expose future model wire tiers without client-only Ultra", async () => {
+  const saved = await sync();
+  const listing = mergeProviderModelListing({
+    providerId: "codex",
+    registryModels: [{ id: "gpt-5.6-sol-ultra" }],
+    syncedModels: saved,
+    customModels: [],
+  });
+  for (const tier of efforts.filter((e) => e !== "ultra"))
+    assert.ok(
+      listing.some((m) => m.id === `${modelId}-${tier}`),
+      tier
+    );
+  assert.ok(!listing.some((m) => m.id === `${modelId}-ultra`));
+  assert.ok(listing.some((m) => m.id === "gpt-5.6-sol-ultra"));
+  assert.equal(new Set(listing.map((m) => m.id)).size, listing.length);
+  const response = await getUnifiedModelsResponse(new Request("http://localhost/api/v1/models"));
+  const catalog = await response.json();
+  assert.ok(catalog.data.some((m: { id: string }) => m.id === `cx/${modelId}-max`));
+  assert.ok(!catalog.data.some((m: { id: string }) => m.id === `cx/${modelId}-ultra`));
+});
+
+async function capture(model: string, body: Record<string, unknown> = {}) {
+  const info = await getModelInfo(`cx/${model}`);
+  const credentials = resolveExecutionCredentials({
+    credentials: { accessToken: "test", connectionId },
+    nativeCodexPassthrough: false,
+    endpointPath: "/responses",
+    targetFormat: "openai-responses",
+    provider: "codex",
+    ccSessionId: null,
+    modelInfo: info,
+  });
+  const executor = new CodexExecutor();
+  const captured: Array<{ model: string; reasoning: { effort: string } }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    captured.push(JSON.parse(String(init?.body)));
+    return new Response(JSON.stringify({ id: "resp_test", object: "response" }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  try {
+    await executor.execute({
+      model: info.model,
+      body: { model: info.model, input: [], ...body },
+      stream: true,
+      credentials,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(captured.length, 1);
+  return captured[0];
+}
+
+test("resolved future max alias wins over client default and reaches actual upstream body", async () => {
+  await sync();
+  const body = await capture(`${modelId}-max`, { reasoning: { effort: "low" } });
+  assert.equal(body.model, modelId);
+  assert.equal(body.reasoning.effort, "max");
+});
+
+test("future base default and explicit max are forwarded without xhigh clamping", async () => {
+  await sync();
+  assert.equal((await capture(modelId)).reasoning.effort, "max");
+  assert.equal((await capture(modelId, { reasoning_effort: "max" })).reasoning.effort, "max");
+  // A caller's unsupported wire value is left for upstream validation, never silently lowered.
+  assert.equal((await capture(modelId, { reasoning_effort: "ultra" })).reasoning.effort, "ultra");
+});
+
+test("exact discovered ids ending in max or high remain literal upstream model ids", async () => {
+  await sync();
+  for (const id of ["future-codex-max", "future-codex-high"]) {
+    const body = await capture(id);
+    assert.equal(body.model, id);
+    assert.equal(body.reasoning.effort, "low");
+  }
+  assert.equal(
+    (await capture("gpt-5.1-codex-max", { reasoning_effort: "high" })).model,
+    "gpt-5.1-codex-max"
+  );
+});
+
+test("chat route preserves the declared native max through Responses translation", async () => {
+  await sync();
+  const { POST } = await import("../../src/app/api/v1/chat/completions/route.ts");
+  const originalFetch = globalThis.fetch;
+  const captured: Array<{ model: string; reasoning: { effort: string } }> = [];
+  globalThis.fetch = async (url, init) => {
+    assert.equal(String(url), "https://chatgpt.com/backend-api/codex/responses");
+    captured.push(JSON.parse(String(init?.body)));
+    const response = {
+      id: "resp_test",
+      object: "response",
+      status: "completed",
+      model: modelId,
+      output: [
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "5" }] },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1, total_tokens: 6 },
+    };
+    return new Response(
+      `data: ${JSON.stringify({ type: "response.output_text.delta", delta: "5", output_index: 0, content_index: 0 })}\n\ndata: ${JSON.stringify({ type: "response.completed", response })}\n\n`,
+      { headers: { "Content-Type": "text/event-stream" } }
+    );
+  };
+  try {
+    for (const payload of [{ reasoning_effort: "max" }, {}]) {
+      const result = await POST(
+        new Request("http://localhost/api/v1/chat/completions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model: `cx/${modelId}`,
+            messages: [{ role: "user", content: "2+3?" }],
+            stream: true,
+            ...payload,
+          }),
+        })
+      );
+      await result.text();
+      assert.equal(result.status, 200);
+      assert.equal(captured.at(-1)?.reasoning.effort, "max");
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("resync replaces changed tiers and default without stale variants", async () => {
+  await sync();
+  await persistDiscoveredModels(
+    "codex",
+    connectionId,
+    normalizeCodexModelsResponse({
+      models: [
+        {
+          slug: modelId,
+          supported_reasoning_levels: ["low", "high"],
+          default_reasoning_level: "high",
+        },
+      ],
+    })
+  );
+  const saved = await getSyncedAvailableModelsForConnection("codex", connectionId);
+  const listing = mergeProviderModelListing({
+    providerId: "codex",
+    registryModels: [],
+    syncedModels: saved,
+    customModels: [],
+  });
+  assert.equal(listing.length, 3);
+  assert.ok(!listing.some((m) => m.id === `${modelId}-max`));
+  const info = await getModelInfo(`cx/${modelId}`);
+  assert.deepEqual(info.supportedThinkingEfforts, ["low", "high"]);
+  assert.equal(info.defaultThinkingEffort, "high");
+});
+
+test("malformed defaults are not advertised and literal max metadata remains native", () => {
+  const models = normalizeCodexModelsResponse({
+    models: [
+      {
+        slug: "unlisted-default",
+        supported_reasoning_levels: ["high"],
+        default_reasoning_level: "max",
+      },
+      {
+        slug: "string-tiers",
+        supported_reasoning_levels: [" high ", "max", "max"],
+        default_reasoning_level: "max",
+      },
+    ],
+  });
+  assert.equal(models[0].defaultThinkingEffort, undefined);
+  assert.deepEqual(models[1].supportedThinkingEfforts, ["high", "max"]);
+  assert.equal(models[1].defaultThinkingEffort, "max");
+});

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -318,7 +318,7 @@ test("CodexExecutor.transformRequest non-passthrough allowlist strips all residu
   assert.equal(result._internal_marker, undefined, "internal markers should be stripped");
 });
 
-test("CodexExecutor.transformRequest normalizes max reasoning_effort to xhigh", () => {
+test("CodexExecutor.transformRequest forwards max for upstream validation without an unknown-model cap", () => {
   const executor = new CodexExecutor();
   const result = executor.transformRequest(
     "gpt-5.5",
@@ -333,7 +333,7 @@ test("CodexExecutor.transformRequest normalizes max reasoning_effort to xhigh", 
     }
   );
 
-  assert.equal(result.reasoning.effort, "xhigh");
+  assert.equal(result.reasoning.effort, "max");
   assert.equal(result.reasoning_effort, undefined);
 });
 

--- a/tests/unit/sync-reasoning-supported-efforts-7694.test.ts
+++ b/tests/unit/sync-reasoning-supported-efforts-7694.test.ts
@@ -199,14 +199,14 @@ test("#7694 catalog: GET /api/v1/models advertises a <model>-<tier> alias id per
 // shouldExposeSyncedEffortVariants / appendSyncedEffortVariants — pure unit tests.
 // ---------------------------------------------------------------------------
 
-test("shouldExposeSyncedEffortVariants: skips codex/kimi-owned models (own suffix mechanism) — Kimi/codex regression guard", () => {
+test("shouldExposeSyncedEffortVariants: exposes declared Codex tiers and skips Kimi native suffixes", () => {
   assert.equal(
     shouldExposeSyncedEffortVariants({
       id: "codex/gpt-5.5",
       owned_by: "codex",
       capabilities: { effort_tiers: ["low", "high"] },
     }),
-    false
+    true
   );
   assert.equal(
     shouldExposeSyncedEffortVariants({
@@ -224,7 +224,7 @@ test("shouldExposeSyncedEffortVariants: skips codex/kimi-owned models (own suffi
     }),
     false
   );
-  assert.ok(SYNCED_EFFORT_SKIP_PROVIDERS.has("codex"));
+  assert.ok(!SYNCED_EFFORT_SKIP_PROVIDERS.has("codex"));
 });
 
 test("shouldExposeSyncedEffortVariants: skips a model id that already ends in a token matching a canonical effort value (collision guard)", () => {

--- a/tests/unit/synced-capabilities-learned-effort-override.test.ts
+++ b/tests/unit/synced-capabilities-learned-effort-override.test.ts
@@ -65,7 +65,7 @@ test("merge path keeps vision AND applies the learned override", () => {
 // #12299 exempts only Kimi K3's BASE model entries (asserted in
 // tests/unit/kimi-k3-effort-tiers-12299.test.ts) — non-K3 kimi models such as
 // "excluded-model" below stay excluded alongside codex/glm.
-for (const ownedBy of ["codex", "glm", "glm-cn", "glmt", "kimi", "kimi-coding-apikey"]) {
+for (const ownedBy of ["glm", "glm-cn", "glmt", "kimi", "kimi-coding-apikey"]) {
   test(`build: excluded provider "${ownedBy}" never gets effort_tiers (synced)`, () => {
     const caps = buildSyncedCapabilities(
       { id: "excluded-model", supportedThinkingEfforts: SYNC_TIERS },
@@ -89,7 +89,7 @@ test("excluded provider still gets vision through buildSyncedCapabilities", () =
   assert.deepEqual(caps, { vision: true });
 });
 
-test("merge path also excludes codex/glm/kimi from effort_tiers", () => {
+test("merge path also excludes glm/kimi from effort_tiers", () => {
   recordLearnedReasoningEffort("conn-glm", "glm-model", ["low", "max"]);
   const merged = mergeSyncedCapabilities(
     { tool_calling: true },


### PR DESCRIPTION
## Summary

Codex discovery currently drops object-shaped `supported_reasoning_levels` entries and the upstream default. Newly discovered models consequently lack effort variants in the dashboard and `/v1/models`, while native `max` can silently become `xhigh` during dispatch.

This preserves native effort metadata through discovery, persistence, model resolution, and the executor. Discovered models receive deduplicated catalog/dashboard variants without adding their names to the static registry. Exact upstream IDs, including names ending in `-high` or `-max`, take precedence over synthetic aliases. The Chat route carries the resolved metadata and original explicit choice through translation so `max` reaches Codex unchanged.

Ultra is preserved in raw discovery metadata but excluded from newly generated API aliases and advertised wire tiers: the live Codex Responses endpoint rejects `ultra` and accepts `max`. Existing built-in Ultra aliases retain their historical Max mapping. Connection defaults and explicit thinking policies retain precedence over discovered defaults.

## Related Issues

- Related partial work: #12933 (safe discovery/static Astra), #12759 (static Astra support), and #12686 (reasoning-rule vocabulary). This addresses the generic discovery-to-dispatch path and object-shaped metadata rather than adding another model-name rule.
- ⚠️ base-red inherited: #12732

## Validation

- [x] Change type: provider / routing
- [x] Reconciled with active `release/v3.8.51` at `81bf3cc36e614574c65f5746a571342b8f1fbbcf`; its Kimi K3 capability carve-out is preserved.
- [x] Focused Node suite on the PR base: **127 tests passed**, including the new regression file, Codex executor, discovery split, synced efforts/capabilities, and `kimi-k3-effort-tiers-12299.test.ts`.
- [x] `npm run typecheck:core`, `check:provider-consistency`, `check:provider-assets`, and `check:file-size` passed.
- [x] Changed-file Prettier/ESLint and all pre-commit gates passed.
- [ ] Full `npm run lint -- --quiet`: three existing `no-explicit-any` errors in unchanged `tests/unit/volcengine-plan-binding-upsert.test.ts` (70, 96, 120), plus stale suppressions. No baseline changes in this PR.
- [x] Production-code changes include automated regressions.

The same fix was backported to v3.8.50 for a local production build (`npm ci`, `npm run build:release`) and tested with the actual OAuth catalog. Two repeated syncs retained 27 discovered models without duplicates; the dashboard and `/v1/models` exposed Astra Low through Max. Live probes returned HTTP 200 and `OK` for Responses `cx/gpt-6-astra-max` (upstream echoed `reasoning.effort=max` despite a conflicting `low` body value), Chat base Astra with explicit Max, and the existing Sol Low alias. The stable checkout also passed 37 additional compatibility tests.

The stable `check:open-sse-typecheck` reported seven diagnostics in unchanged `catalog.ts` and `videoBridgeHelpers.ts`; core typechecking passed. Full unit shards, Vitest, coverage, and the production build on the release base remain CI validation. GitHub Actions currently reports `action_required` for this fork; maintainer approval is required before those workflows can run.

## Tests Added Or Updated

- `tests/unit/codex-discovered-reasoning.test.ts` — new isolated DB/catalog/dashboard/resolver/executor regressions, repeated sync, exact suffix-like upstream IDs, and mocked HTTP Chat route proving explicit/default native Max survives translation.
- `tests/unit/executor-codex.test.ts` — unknown model effort passthrough.
- `tests/unit/sync-reasoning-supported-efforts-7694.test.ts` — Codex discovery eligibility while preserving Kimi/GLM exclusions.
- `tests/unit/synced-capabilities-learned-effort-override.test.ts` — updated provider exclusion contract.

## Coverage Notes

The new tests cover the metadata lifecycle and outgoing request payload, including malformed discovery entries, refreshed defaults, alias precedence, legacy behavior, and the HTTP route. No coverage baseline was changed; repository-wide coverage remains a CI check.

## Reviewer Notes

No migrations, credentials, local configuration, databases, or generated build artifacts are included. Gitleaks scanned all contribution commits with default rules and no repository allowlists; no leaks were found. The request-scoped Codex metadata is not persisted to connection credentials. Known legacy models keep their compatibility caps; unknown model names no longer inherit an arbitrary XHigh cap.
