### PR TITLE
fix(tests): align model-sync log assertion to shipped path redaction (base-red #12732)

### DIFF
--- a/tests/unit/model-sync-route.test.ts
+++ b/tests/unit/model-sync-route.test.ts
@@ -302,7 +302,7 @@ test("model sync route reports invalid JSON /models responses without losing ups
   assert.equal(body.upstreamStatus, 200);
   assert.equal(logs.length, 1);
   assert.equal(logs[0].status, 200);
-  assert.equal(logs[0].error, "Invalid JSON response from /models");
+  assert.equal(logs[0].error, "Invalid JSON response from <path>");
 });
 
 test("model sync route preserves previously synced models when the upstream omits the models list", async () => {


### PR DESCRIPTION
## What

Clears the one still-live code-level base-red on `release/v3.8.51`: `tests/unit/model-sync-route.test.ts` fails on the tip.

The persisted call-log error is now run through `sanitizeErrorForLog` → `errorPathRedaction`, which redacts the path to `<path>` for stored logs (defense in depth — call logs get exported). The live API response to the caller is unchanged (`body.error` is still `/models`); only the stored `logs[0].error` is redacted. The test still expected the pre-redaction `/models` on the log assertion.

Align `logs[0].error` to `<path>`; `body.error` stays `/models`. No production change — a test-only alignment to already-shipped redaction.

## Verification

`node --import tsx/esm --test tests/unit/model-sync-route.test.ts` → 18/18 pass. prettier clean.

## ⚠️ base-red inherited: #12732

The base tip is red under #12732, but that verdict is **stale** — the release-green continuous runs keep getting cancelled by concurrent merges, so the issue never refreshes. Re-checked each of its 5 HARD failures against the current tip:

- `#12058 canonical mode` unit → **passes now** (4/4), stale.
- `chat pipeline persists Codex responses cache/reasoning to call logs` integration → **passes now** (28/28), stale (and not caused by P2b's `video_content_removed` column).
- `check:agent-skills-sync` → **passes now** (exit 0), stale.
- `Package artifact: Build provenance check failed` + `Tarball boot-smoke` → build/infra (needs a real pack build; not a code defect this PR touches).

This PR fixes the only code-level red that still reproduces. CI red on this PR is inherited from #12732; the build/infra items will clear on a fresh idle release-green run.