### PR TITLE
fix(tests): drop three needless `as any` casts on the volcengine testing surface (base-red #12732)

### DIFF
--- a/tests/unit/volcengine-plan-binding-upsert.test.ts
+++ b/tests/unit/volcengine-plan-binding-upsert.test.ts
@@ -67,7 +67,7 @@ test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) 
     providerSpecificData: { autoFetchModels: true, customTag: "keep-me" },
   });
 
-  const updated1 = await (bindingTesting as any).upsertConnection(
+  const updated1 = await bindingTesting.upsertConnection(
     "coding",
     "ark-new-key-1",
     "new-cookie-1",
@@ -93,7 +93,7 @@ test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) 
     providerSpecificData: {},
   });
 
-  const createdNew = await (bindingTesting as any).upsertConnection(
+  const createdNew = await bindingTesting.upsertConnection(
     "coding",
     "ark-brand-new-key-3",
     "new-cookie-3",
@@ -117,7 +117,7 @@ test("volcenginePlanBinding upsert rules with SQLite temp isolation", async (t) 
   });
 
   // Passing conn1.id (which is coding-plan) into agent upsert must NOT match conn1
-  const agentUpsertResult = await (bindingTesting as any).upsertConnection(
+  const agentUpsertResult = await bindingTesting.upsertConnection(
     "agent",
     "ark-agent-new-key",
     "agent-cookie",


### PR DESCRIPTION
Fixes the only hard failure in base-red #12732.

## The failure

```
❌ ESLint errors: 3 error(s)

tests/unit/volcengine-plan-binding-upsert.test.ts:70,96,120
  error  @typescript-eslint/no-explicit-any  Unexpected any. Specify a different type
```

## Why it appeared now

The violations are not new. #12795 regenerated `config/quality/eslint-suppressions.json` and **pruned** the entry that had these three frozen — that file shows **0 additions, 5 deletions**, and there is no longer any `volcengine-plan-binding-upsert` key in it. `no-explicit-any` has been `error` in `tests/` since #6218, so a rule the PR never intended to touch started failing the whole-repo lint on code it never edited.

That also explains why #12795's own CI was green: its Lint job ran before the pruned file became the branch's baseline for the next whole-repo run.

## The fix

The casts were unnecessary in the first place:

```ts
// src/lib/providers/volcenginePlanBinding.ts:380-383
export const __testing = {
  findTargetConnection,
  upsertConnection,
};
```

`__testing` exports `upsertConnection` directly, and it is a normally typed exported function — `bindingTesting.upsertConnection(...)` resolves without any help. Dropping `as any` clears the errors **and** puts the three call sites under type checking instead of opting them out, which is strictly better than restoring the suppression entry.

## Validation

| check | before | after |
|---|---|---|
| `eslint` on the file (with suppressions + `--pass-on-unpruned-suppressions`) | exit 1, all 3 errors | exit 0 |
| `npm run typecheck:core` | — | 0 errors |
| `node --test tests/unit/volcengine-plan-binding-upsert.test.ts` | — | 3/3 pass |

Typecheck matters here specifically: removing `as any` is only safe if the now-checked call sites actually satisfy the signature, and they do.

## One deliberate omission

This file is **not** Prettier-clean, and this PR does not reformat it. It was already non-conformant on the base (verified against `HEAD~1`), no CI job enforces Prettier — it only runs through lint-staged on commit — and reformatting would turn a 3-line base-red fix into a 25-line diff across untouched assertions. Left as-is on purpose; happy to split it into a formatting-only PR if you'd rather have it clean.