### PR TITLE
fix(api): remove hardcoded wildcard CORS in openai-to-gemini-sse.ts (#12573)

### DIFF
--- a/changelog.d/fixes/12573-gemini-cors-wildcard.md
+++ b/changelog.d/fixes/12573-gemini-cors-wildcard.md
@@ -1,0 +1,1 @@
+- fix(api): remove hardcoded wildcard CORS in openai-to-gemini-sse.ts so the centralized fail-closed CORS gate is the sole source of `Access-Control-Allow-Origin` (#12573)

--- a/open-sse/translator/response/openai-to-gemini-sse.ts
+++ b/open-sse/translator/response/openai-to-gemini-sse.ts
@@ -286,7 +286,6 @@ export function transformOpenAISSEToGeminiSSE(upstreamResponse: Response, model:
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
-      "Access-Control-Allow-Origin": "*",
     },
   });
 }
@@ -348,7 +347,7 @@ export async function convertOpenAIResponseToGemini(
       { error: { message: sanitizeErrorMessage(err), code: response.status } },
       {
         status: response.status,
-        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+        headers: { "Content-Type": "application/json" },
       }
     );
   }
@@ -356,7 +355,7 @@ export async function convertOpenAIResponseToGemini(
   // Already Gemini-shape (some upstreams may pre-translate) — pass through.
   if (body.candidates) {
     return Response.json(body, {
-      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
@@ -364,14 +363,14 @@ export async function convertOpenAIResponseToGemini(
   if (body.error) {
     return Response.json(body, {
       status: response.status,
-      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
   const choice = body.choices?.[0];
   if (!choice || !choice.message) {
     return Response.json(body, {
-      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+      headers: { "Content-Type": "application/json" },
     });
   }
 
@@ -426,6 +425,6 @@ export async function convertOpenAIResponseToGemini(
   }
 
   return Response.json(geminiResponse, {
-    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+    headers: { "Content-Type": "application/json" },
   });
 }

--- a/tests/unit/gemini-cors-wildcard-bypass.test.ts
+++ b/tests/unit/gemini-cors-wildcard-bypass.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { transformOpenAISSEToGeminiSSE } from "../../open-sse/translator/response/openai-to-gemini-sse";
+import { applyCorsHeaders } from "../../src/server/cors/origins";
+
+function buildUpstreamSSEResponse(): Response {
+  const encoder = new TextEncoder();
+  const sseBody = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'));
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+  return new Response(sseBody, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("issue #12573 — openai-to-gemini-sse must not pre-set Access-Control-Allow-Origin", () => {
+  it("does not hardcode a wildcard ACAO on the translated SSE response", () => {
+    const geminiResponse = transformOpenAISSEToGeminiSSE(buildUpstreamSSEResponse(), "gemini-test-model");
+    assert.equal(
+      geminiResponse.headers.get("Access-Control-Allow-Origin"),
+      null,
+      "the translator must not set its own ACAO — the centralized CORS gate is the sole source"
+    );
+  });
+
+  it("an anonymous request gets no Access-Control-Allow-Origin after the centralized gate runs (fail-closed)", () => {
+    const geminiResponse = transformOpenAISSEToGeminiSSE(buildUpstreamSSEResponse(), "gemini-test-model");
+
+    const anonymousRequest = new Request(
+      "http://localhost:20128/v1beta/models/gemini-test:streamGenerateContent",
+      { method: "POST" }
+    );
+
+    applyCorsHeaders(geminiResponse, anonymousRequest, /* relaxForTokenAuth */ true);
+
+    assert.equal(
+      geminiResponse.headers.get("Access-Control-Allow-Origin"),
+      null,
+      "expected no Access-Control-Allow-Origin header for an anonymous request (fail-closed policy)"
+    );
+  });
+
+  it("a request carrying x-goog-api-key still gets the origin echoed by the centralized gate", () => {
+    const geminiResponse = transformOpenAISSEToGeminiSSE(buildUpstreamSSEResponse(), "gemini-test-model");
+
+    const authenticatedRequest = new Request(
+      "http://localhost:20128/v1beta/models/gemini-test:streamGenerateContent",
+      {
+        method: "POST",
+        headers: {
+          "x-goog-api-key": "test-key",
+          Origin: "http://localhost:3000",
+        },
+      }
+    );
+
+    applyCorsHeaders(geminiResponse, authenticatedRequest, /* relaxForTokenAuth */ true);
+
+    assert.equal(
+      geminiResponse.headers.get("Access-Control-Allow-Origin"),
+      "http://localhost:3000",
+      "expected the centralized gate to echo the request origin for a token-bearing request"
+    );
+  });
+});


### PR DESCRIPTION
Closes #12573

## Root cause

`open-sse/translator/response/openai-to-gemini-sse.ts` hardcoded `Access-Control-Allow-Origin: "*"` at six response sites (SSE success path + five JSON response paths). The route `src/app/api/v1beta/models/[...path]/route.ts` returns these responses to the client.

The centralized fail-closed CORS gate (`applyCorsHeaders` in `src/server/cors/origins.ts`) does run on this route (`pipeline.ts` calls it with `relaxForTokenAuth=true`), but it only ever calls `response.headers.set(...)` when it resolves a non-null allowed origin — it has no branch that *removes* a header the route handler already wrote. So the hardcoded `*` from the translator survived untouched all the way to the client. On the shipped default `REQUIRE_API_KEY=false`, this let any cross-origin webpage read the completion body via `fetch()`, bypassing the same-origin policy — exactly the anonymous-request case the GHSA-7px7-29v2-m97p fail-closed fix was built to close.

## Fix

Removed all six hardcoded `Access-Control-Allow-Origin: "*"` literals so `applyCorsHeaders` is the sole source of the header on this route, same as every other route on this surface. No change to `src/server/authz/pipeline.ts` was needed — confirmed the v1beta route classification and `applyCorsHeaders(..., relaxForTokenAuth=true)` call are already correct; the bug was purely the translator pre-setting a header the gate never clears.

## Regression test

`tests/unit/gemini-cors-wildcard-bypass.test.ts` (node:test runner)

RED (before fix):
```
✖ does not hardcode a wildcard ACAO on the translated SSE response
  AssertionError: '*' !== null
✖ an anonymous request gets no Access-Control-Allow-Origin after the centralized gate runs (fail-closed)
  AssertionError: '*' !== null
tests 3 / pass 1 / fail 2
```

GREEN (after fix):
```
✔ does not hardcode a wildcard ACAO on the translated SSE response
✔ an anonymous request gets no Access-Control-Allow-Origin after the centralized gate runs (fail-closed)
✔ a request carrying x-goog-api-key still gets the origin echoed by the centralized gate
tests 3 / pass 3 / fail 0
```

The third case is the risk-mitigation check called out in the plan: a request carrying `x-goog-api-key` (the header the `@google/genai` SDK sends) still gets the origin echoed by `applyCorsHeaders`, so authenticated browser/Electron clients are unaffected.

## Gates run

- `node --import tsx/esm --test tests/unit/gemini-cors-wildcard-bypass.test.ts` — 3/3 pass
- `node --import tsx/esm --test tests/unit/v1beta-gemini-tool-calling-6222.test.ts tests/unit/translator-openai-to-gemini-sse.test.ts tests/unit/cors/origins.test.ts tests/unit/cloud-agent-cors-failclosed.test.ts` — 49/49 pass (existing coverage of the touched translator + shared CORS helper, unaffected)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2798 violations, baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations, baseline 1437)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on changed files — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

`docs/security/CORS.md` was checked — it only documents `src/lib/cloudAgent/api.ts` as the sole intentional per-route CORS exception and never referenced `openai-to-gemini-sse.ts`, so no doc update was needed.

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync

