### PR TITLE
fix(open-sse): write Adobe Firefly session tokens and cookie jars with 0700/0600 perms (#12572)

### DIFF
--- a/changelog.d/fixes/12572-adobe-firefly-session-file-perms.md
+++ b/changelog.d/fixes/12572-adobe-firefly-session-file-perms.md
@@ -1,0 +1,1 @@
+- fix(open-sse): write Adobe Firefly session tokens and cookie jars with 0700/0600 permissions instead of the process umask (#12572)

--- a/open-sse/services/adobeFireflyBrowserLogin.ts
+++ b/open-sse/services/adobeFireflyBrowserLogin.ts
@@ -14,10 +14,11 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import http from "node:http";
 import { createServer } from "node:net";
 import { join } from "node:path";
+import { ensureSecureDir, writeSecureFile } from "../utils/secureFileWrite.ts";
 import {
   decodeAdobeJwtPayload,
   isAdobeUserAccessToken,
@@ -410,7 +411,7 @@ export function filterAdobeBrowserCookies(cookies: CdpCookie[]): AdobeBrowserCoo
 
 function adobeBrowserCookieJarPath(sessionKey: string): string {
   const dir = join(resolveAdobeFireflyDataRoot(), "adobe-browser-sessions");
-  mkdirSync(dir, { recursive: true });
+  ensureSecureDir(dir);
   return join(dir, `${adobeFireflyBrowserSessionKey(sessionKey)}.json`);
 }
 
@@ -427,10 +428,9 @@ function loadAdobeBrowserCookies(sessionKey: string): AdobeBrowserCookie[] {
 
 function saveAdobeBrowserCookies(sessionKey: string, cookies: CdpCookie[]): void {
   try {
-    writeFileSync(
+    writeSecureFile(
       adobeBrowserCookieJarPath(sessionKey),
-      JSON.stringify(filterAdobeBrowserCookies(cookies)),
-      "utf8"
+      JSON.stringify(filterAdobeBrowserCookies(cookies))
     );
   } catch {
     // Best-effort: login still returns the portable JWT + Firefly risk cookies.

--- a/open-sse/services/adobeFireflySession.ts
+++ b/open-sse/services/adobeFireflySession.ts
@@ -13,8 +13,9 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { ensureSecureDir, writeSecureFile } from "../utils/secureFileWrite.ts";
 import {
   AdobeFireflyError,
   buildAdobeArpSessionId,
@@ -147,7 +148,7 @@ function dataDir(): string {
 function sessionFilePath(fingerprint: string): string {
   const dir = join(dataDir(), SESSION_DIR_NAME);
   try {
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    ensureSecureDir(dir);
   } catch {
     /* ignore */
   }
@@ -232,7 +233,7 @@ export function markAdobeFireflyArpSuccess(fingerprint: string, arpSessionId: st
         const obj = JSON.parse(readFileSync(path, "utf8")) as AdobeFireflySession;
         obj.arpSessionId = arp;
         obj.updatedAt = Date.now();
-        writeFileSync(path, JSON.stringify(obj, null, 2), "utf8");
+        writeSecureFile(path, JSON.stringify(obj, null, 2));
         sessionCache.set(fp, { ...obj, fingerprint: fp });
       }
     } catch {
@@ -455,7 +456,7 @@ function saveDiskSession(session: AdobeFireflySession): void {
   if (!diskSessionsEnabled()) return;
   try {
     const path = sessionFilePath(session.fingerprint);
-    writeFileSync(path, JSON.stringify(session, null, 2), "utf8");
+    writeSecureFile(path, JSON.stringify(session, null, 2));
   } catch {
     /* best-effort */
   }

--- a/open-sse/utils/secureFileWrite.ts
+++ b/open-sse/utils/secureFileWrite.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared helpers for persisting credential/session material (tokens, cookie jars) to disk
+ * with restrictive permissions — 0700 directories, 0600 files — instead of inheriting the
+ * process umask (typically 0755/0644).
+ *
+ * Mirrors the established pattern in src/lib/vncSession/service.ts::createProfileDir.
+ * `chmodSync` is applied even on an already-existing directory so a dir created before this
+ * hardening (or by any looser writer) is tightened rather than silently trusted.
+ */
+
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+
+const SECURE_DIR_MODE = 0o700;
+const SECURE_FILE_MODE = 0o600;
+
+/** Create `dir` (recursively) with 0700 permissions, tightening it if it already exists. */
+export function ensureSecureDir(dir: string): void {
+  mkdirSync(dir, { recursive: true, mode: SECURE_DIR_MODE });
+  chmodSync(dir, SECURE_DIR_MODE);
+}
+
+/** Write `data` to `path` as utf8 with 0600 permissions. */
+export function writeSecureFile(path: string, data: string): void {
+  writeFileSync(path, data, { encoding: "utf8", mode: SECURE_FILE_MODE });
+}

--- a/tests/unit/adobe-firefly-session-file-perms.test.ts
+++ b/tests/unit/adobe-firefly-session-file-perms.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Point DATA_DIR at a throwaway tmp dir BEFORE importing the module under test, since
+// adobeFireflySession.ts reads process.env.DATA_DIR lazily via dataDir().
+const probeDataDir = mkdtempSync(join(tmpdir(), "adobe-firefly-perm-"));
+process.env.DATA_DIR = probeDataDir;
+
+test.after(() => {
+  try {
+    rmSync(probeDataDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+test("Adobe Firefly session dir/file are created with restrictive permissions (0700/0600)", async () => {
+  const { markAdobeFireflyArpSuccess, fingerprintAdobeCredential } = await import(
+    "../../open-sse/services/adobeFireflySession.ts"
+  );
+
+  const fp = fingerprintAdobeCredential("probe-credential-blob");
+
+  // Triggers sessionFilePath() -> ensureSecureDir(dir) with no cached session and no
+  // pre-existing file on disk (mirrors first-touch creation of the adobe-firefly-sessions
+  // directory in production).
+  markAdobeFireflyArpSuccess(fp, "arp-probe-1");
+
+  const sessionDir = join(probeDataDir, "adobe-firefly-sessions");
+  const dirMode = statSync(sessionDir).mode & 0o777;
+
+  assert.equal(
+    dirMode & 0o077,
+    0,
+    `expected adobe-firefly-sessions dir to be 0700 (no group/other access), got mode ${dirMode.toString(8)}`
+  );
+});
+
+test("ensureSecureDir tightens an already-existing looser directory to 0700", async () => {
+  const { ensureSecureDir } = await import("../../open-sse/utils/secureFileWrite.ts");
+  const dir = join(probeDataDir, "already-loose-dir");
+  mkdirSync(dir, { recursive: true, mode: 0o777 });
+  chmodSync(dir, 0o777);
+
+  ensureSecureDir(dir);
+
+  const dirMode = statSync(dir).mode & 0o777;
+  assert.equal(
+    dirMode & 0o077,
+    0,
+    `expected already-loose-dir to be tightened to 0700, got mode ${dirMode.toString(8)}`
+  );
+});
+
+test("writeSecureFile writes files with 0600 permissions", async () => {
+  const { writeSecureFile, ensureSecureDir } = await import(
+    "../../open-sse/utils/secureFileWrite.ts"
+  );
+  const dir = join(probeDataDir, "secure-file-write-probe");
+  ensureSecureDir(dir);
+  const filePath = join(dir, "probe.json");
+  writeSecureFile(filePath, JSON.stringify({ hello: "world" }));
+
+  const fileMode = statSync(filePath).mode & 0o777;
+  assert.equal(
+    fileMode & 0o177,
+    0,
+    `expected probe.json to be 0600 (no group/other access), got mode ${fileMode.toString(8)}`
+  );
+});


### PR DESCRIPTION
Closes #12572

## Root cause

`open-sse/services/adobeFireflySession.ts` and `open-sse/services/adobeFireflyBrowserLogin.ts` persist Adobe Firefly session state — including a live IMS Bearer JWT (`accessToken`) and the full Adobe cookie jar — to disk via `mkdirSync(dir, { recursive: true })` and `writeFileSync(path, ..., "utf8")` with no `mode` argument, so the directory/file inherit the process umask (0755/0644 typically) instead of the restrictive `0700`/`0600` pattern already established in this repo for the analogous case (`src/lib/vncSession/service.ts::createProfileDir`).

The Notion half of the original report is a confirmed false positive (`notionThreadSessions.ts`'s `ThreadSessionEntry` never persists a cookie/token) and is intentionally out of scope, per the plan-file analysis.

## Fix

- Added a shared `open-sse/utils/secureFileWrite.ts` (`ensureSecureDir` / `writeSecureFile`) mirroring the `vncSession/service.ts::createProfileDir` pattern (`mkdirSync(..., mode: 0o700)` + `chmodSync(..., 0o700)` for dirs; `writeFileSync(..., mode: 0o600)` for files) so a future browser-login integration can't reintroduce the unhardened pattern.
- `adobeFireflySession.ts`: `sessionFilePath()` directory creation, the `markAdobeFireflyArpSuccess()` disk-fallback write, and `saveDiskSession()` now go through the shared helper.
- `adobeFireflyBrowserLogin.ts`: `adobeBrowserCookieJarPath()` directory creation and `saveAdobeBrowserCookies()` now go through the shared helper.

## Regression test

`tests/unit/adobe-firefly-session-file-perms.test.ts` (TDD, reusing the plan-file's proven-red repro mechanics):
- `markAdobeFireflyArpSuccess()` on a fresh `DATA_DIR` creates `adobe-firefly-sessions/` at mode 0700.
- `ensureSecureDir()` tightens an already-existing 0777 directory back to 0700.
- `writeSecureFile()` writes files at mode 0600.

The plan-file's own repro (`markAdobeFireflyArpSuccess` on a fresh mkdtemp `DATA_DIR`) was already proven RED against the current release/v3.8.51 tip (910f58c5): `AssertionError: expected adobe-firefly-sessions dir to be 0700 ..., got mode 775`. The same call path is exercised by the new test suite above, now GREEN against the fix.

```
node --import tsx/esm --test tests/unit/adobe-firefly-session-file-perms.test.ts
✔ Adobe Firefly session dir/file are created with restrictive permissions (0700/0600)
✔ ensureSecureDir tightens an already-existing looser directory to 0700
✔ writeSecureFile writes files with 0600 permissions
ℹ tests 3, pass 3, fail 0
```

## Gates run

- `node scripts/check/check-file-size.mjs` → OK (no violations attributable to changed files)
- `node scripts/check/check-complexity.mjs` → OK — 2798 violations (baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK — 1265 violations (baseline 1437)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → clean
- New regression test: 3/3 pass
- Existing Adobe Firefly test suites (`adobe-firefly.test.ts`, `adobe-firefly-browser-login.test.ts`, `adobe-firefly-security.test.ts`): 68/68 pass, unaffected

## Scope

Out of scope per the plan-file (maintainer-confirmed): `notionThreadSessions.ts` (false positive, no credential fields persisted) and `src/lib/db/core.ts` DATA_DIR hardening (related but separate, lower-priority gap).

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync