### PR TITLE
fix(providers): correct opencode-zen muse-spark context length and Responses auth header (#12681, #12633)

### DIFF
--- a/changelog.d/fixes/12633-opencode-zen-responses-auth-header.md
+++ b/changelog.d/fixes/12633-opencode-zen-responses-auth-header.md
@@ -1,0 +1,1 @@
+- fix(providers): send `x-api-key` instead of `Authorization: Bearer` for OpenCode Zen's `/v1/responses` endpoint (Muse Spark Contributor models), fixing a 401 on OmniRoute's auth header (#12633)

--- a/changelog.d/fixes/12681-opencode-muse-spark-context-length.md
+++ b/changelog.d/fixes/12681-opencode-muse-spark-context-length.md
@@ -1,0 +1,1 @@
+- fix(models): declare the real ~1M contextLength for OpenCode Zen's Muse Spark 1.2 models instead of falling back to the 200000 provider default (#12681)

--- a/open-sse/config/providers/registry/opencode/index.ts
+++ b/open-sse/config/providers/registry/opencode/index.ts
@@ -30,17 +30,25 @@ export const opencodeProvider: RegistryEntry = {
     // content (see issue #10867). The opencode provider is passthrough, so
     // declaring them here only sets the wire format / capability flags — the
     // live upstream model list already advertises both ids.
+    // #12681: real window confirmed against the opencode-go registry's own
+    // muse-spark-1.2-contributor entries (contextLength: 1048576, maxOutputTokens:
+    // 131072) — without an explicit value here resolution fell back to the
+    // provider-wide defaultContextLength (200000), understating the real window.
     {
       id: "muse-spark-1.2",
       name: "Muse Spark 1.2",
       supportsReasoning: true,
       targetFormat: "openai-responses",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
     },
     {
       id: "muse-spark-1.2-contributor-free",
       name: "Muse Spark 1.2 Contributor Free",
       supportsReasoning: true,
       targetFormat: "openai-responses",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
     },
     { id: "deepseek-v4-flash-free", name: "DeepSeek V4 Flash Free", supportsReasoning: true },
     // #6998: 2026-07-14 refresh — the upstream free tier rotated its lineup;

--- a/open-sse/config/providers/registry/opencode/zen/index.ts
+++ b/open-sse/config/providers/registry/opencode/zen/index.ts
@@ -63,11 +63,17 @@ export const opencode_zenProvider: RegistryEntry = {
     // targetFormat declaration, so requests routed here still hit
     // /chat/completions with a mismatched or unanswerable body and the
     // upstream returns an empty message.
+    // #12681: real window confirmed against the opencode-go registry's own
+    // muse-spark-1.2-contributor entries (contextLength: 1048576, maxOutputTokens:
+    // 131072) — without an explicit value here resolution fell back to the
+    // provider-wide defaultContextLength (200000), understating the real window.
     {
       id: "muse-spark-1.2",
       name: "Muse Spark 1.2",
       supportsReasoning: true,
       targetFormat: "openai-responses",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
     },
     // Explicit wire-format overlay of the base opencode provider's muse-spark entry
     // (targetFormat: openai-responses). Keep in sync with base on catalog syncs.
@@ -76,6 +82,8 @@ export const opencode_zenProvider: RegistryEntry = {
       name: "Muse Spark 1.2 Contributor Free",
       supportsReasoning: true,
       targetFormat: "openai-responses",
+      contextLength: 1048576,
+      maxOutputTokens: 131072,
     },
 
     // ── DeepSeek ────────────────────────────────────────────────

--- a/open-sse/executors/opencode.ts
+++ b/open-sse/executors/opencode.ts
@@ -32,6 +32,13 @@ import { isOpencodeGeoBlocked, proxyKeyOf } from "./opencodeGeoBlock.ts";
 import { isNetworkRotationSharedEgressGuardEnabled } from "@/shared/utils/featureFlags";
 
 /**
+ * The main OpenCode Zen host, shared by the `opencode` and `opencode-zen`
+ * registry entries. Used to scope the `x-api-key` auth override (#12633) away
+ * from `opencode-go`, which serves a different upstream (`.../zen/go/v1`).
+ */
+const ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+
+/**
  * Per-account proxy configuration, persisted by NoAuthAccountCard under
  * `providerSpecificData.accountProxies` (keyed by the account id, which the UI
  * stores in `providerSpecificData.fingerprints`). Same shape mimocode uses.
@@ -776,6 +783,20 @@ export class OpencodeExecutor extends BaseExecutor {
     }
   }
 
+  /**
+   * #12633: OpenCode Zen's `/v1/responses` endpoint (reached when
+   * `_requestFormat === "openai-responses"`, e.g. Muse Spark Contributor
+   * models) requires `x-api-key`, not `Authorization: Bearer` — unlike the
+   * default `/chat/completions` endpoint on the same host, which accepts
+   * Bearer. Scoped by baseUrl (not provider id/alias) so this only applies to
+   * the main Zen host (`opencode` / `opencode-zen`, both `https://opencode.ai/zen/v1`)
+   * and never to opencode-go, which serves Responses-format models from a
+   * different upstream (`https://opencode.ai/zen/go/v1`) that expects Bearer.
+   */
+  private usesZenApiKeyAuth(): boolean {
+    return this._requestFormat === "openai-responses" && this.config?.baseUrl === ZEN_BASE_URL;
+  }
+
   buildHeaders(
     credentials: ProviderCredentials | null,
     stream = true,
@@ -792,7 +813,7 @@ export class OpencodeExecutor extends BaseExecutor {
       : undefined;
 
     if (key) {
-      if (this._requestFormat === "claude") {
+      if (this._requestFormat === "claude" || this.usesZenApiKeyAuth()) {
         headers["x-api-key"] = key;
       } else {
         headers["Authorization"] = `Bearer ${key}`;

--- a/tests/unit/issue-12633-opencode-zen-responses-auth.test.ts
+++ b/tests/unit/issue-12633-opencode-zen-responses-auth.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { OpencodeExecutor } from "../../open-sse/executors/opencode.ts";
+
+test("#12633: openai-responses format on opencode-zen sends x-api-key, not Authorization Bearer", () => {
+  const executor = new OpencodeExecutor("opencode-zen");
+  executor._requestFormat = "openai-responses";
+  const headers = executor.buildHeaders(
+    { apiKey: "sk-zen-test" },
+    true,
+    null,
+    "muse-spark-1.2-contributor-free"
+  );
+
+  assert.equal(headers["x-api-key"], "sk-zen-test");
+  assert.equal(headers["Authorization"], undefined);
+});
+
+test("#12633: openai-responses format on the base opencode (oc) provider also sends x-api-key", () => {
+  const executor = new OpencodeExecutor("opencode");
+  executor._requestFormat = "openai-responses";
+  const headers = executor.buildHeaders(
+    { apiKey: "sk-oc-test" },
+    true,
+    null,
+    "muse-spark-1.2-contributor-free"
+  );
+
+  assert.equal(headers["x-api-key"], "sk-oc-test");
+  assert.equal(headers["Authorization"], undefined);
+});
+
+test("#12633: openai-responses format on opencode-go (different upstream endpoint) keeps Authorization Bearer", () => {
+  const executor = new OpencodeExecutor("opencode-go");
+  executor._requestFormat = "openai-responses";
+  const headers = executor.buildHeaders(
+    { apiKey: "sk-go-test" },
+    true,
+    null,
+    "muse-spark-1.2-contributor"
+  );
+
+  assert.equal(headers["Authorization"], "Bearer sk-go-test");
+  assert.equal(headers["x-api-key"], undefined);
+});
+
+test("#12633: claude format keeps sending x-api-key (unchanged behavior)", () => {
+  const executor = new OpencodeExecutor("opencode-zen");
+  executor._requestFormat = "claude";
+  const headers = executor.buildHeaders({ apiKey: "sk-claude-test" }, true, null, "some-model");
+
+  assert.equal(headers["x-api-key"], "sk-claude-test");
+  assert.equal(headers["Authorization"], undefined);
+});

--- a/tests/unit/issue-12681-opencode-muse-spark-context.test.ts
+++ b/tests/unit/issue-12681-opencode-muse-spark-context.test.ts
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { REGISTRY } from "../../open-sse/config/providerRegistry.ts";
+import { getTokenLimit } from "../../open-sse/services/contextManager.ts";
+
+test("#12681: opencode registry declares an explicit real contextLength for muse-spark-1.2 models", () => {
+  const opencode = REGISTRY["opencode"];
+  const museSpark = opencode.models.find((m) => m.id === "muse-spark-1.2");
+  const museSparkFree = opencode.models.find((m) => m.id === "muse-spark-1.2-contributor-free");
+  assert.notEqual(
+    museSpark?.contextLength,
+    undefined,
+    "muse-spark-1.2 should declare its own real contextLength instead of relying on the 200000 provider default"
+  );
+  assert.notEqual(
+    museSparkFree?.contextLength,
+    undefined,
+    "muse-spark-1.2-contributor-free should declare its own real contextLength instead of relying on the 200000 provider default"
+  );
+});
+
+test("#12681: opencode-zen registry declares an explicit real contextLength for muse-spark-1.2 models", () => {
+  const zen = REGISTRY["opencode-zen"];
+  const museSpark = zen.models.find((m) => m.id === "muse-spark-1.2");
+  const museSparkFree = zen.models.find((m) => m.id === "muse-spark-1.2-contributor-free");
+  assert.notEqual(museSpark?.contextLength, undefined);
+  assert.notEqual(museSparkFree?.contextLength, undefined);
+});
+
+test("#12681: contextManager.getTokenLimit resolves muse-spark-1.2-contributor-free to its real 1M+ window, not the 200000 provider default", () => {
+  assert.equal(getTokenLimit("opencode", "muse-spark-1.2-contributor-free"), 1048576);
+  assert.equal(getTokenLimit("opencode-zen", "muse-spark-1.2-contributor-free"), 1048576);
+});


### PR DESCRIPTION
## Summary

Two related, small OpenCode Zen registry/executor bugs fixed together (both files: `open-sse/config/providers/registry/opencode/zen/index.ts` / `open-sse/config/providers/registry/opencode/index.ts` for #12681, `open-sse/executors/opencode.ts` for #12633):

Closes #12681
Closes #12633

### #12681 — wrong context_length for Muse Spark 1.2 (200000 vs real ~1M)

**Root cause**: `muse-spark-1.2` and `muse-spark-1.2-contributor-free` were declared in the `opencode` and `opencode-zen` registry entries without their own `contextLength` — unlike sibling models in the same list. With no per-model window, `contextManager.resolveTokenLimit()` fell back to the provider-wide `defaultContextLength: 200000`.

**Fix**: declared the real window (`contextLength: 1048576`, `maxOutputTokens: 131072`) on both Muse Spark 1.2 entries in both files. This value is not invented — it mirrors the *same model family* already declared correctly on `opencode-go`'s `muse-spark-1.2-contributor*` entries (`open-sse/config/providers/registry/opencode/go/index.ts`), which are exercised by existing tests (`tests/unit/opencode-go-catalog-alignment.test.ts`).

**Regression test**: `tests/unit/issue-12681-opencode-muse-spark-context.test.ts`
- RED (before fix): `muse-spark-1.2`/`-contributor-free` had `contextLength === undefined` in both registries; `getTokenLimit("opencode", "muse-spark-1.2-contributor-free")` resolved to `200000`.
- GREEN (after fix): both entries declare `contextLength: 1048576`; `getTokenLimit()` resolves to `1048576` on both `opencode` and `opencode-zen`.

Note: the plan-file also flagged a second, architecturally larger bug — vendor-prefixed passthrough ids reached through `nous-research`/`kilocode` (e.g. `poolside/laguna-s-2.1`) not cross-referencing the vendor's own registry entry in `contextManager.resolveTokenLimit()`. That is a separate, larger design change (a new cross-reference resolution step) that is out of scope for this small, TDD-scoped fix and is not addressed here.

### #12633 — OpenCode Zen Responses models reject the OmniRoute auth header

**Root cause**: `OpencodeExecutor.buildHeaders()` only special-cased `x-api-key` for `_requestFormat === "claude"`; every other format — including `"openai-responses"`, used by Muse Spark Contributor models routed to `/v1/responses` — fell through to `Authorization: Bearer <key>`. OpenCode Zen's `/v1/responses` endpoint actually requires `x-api-key`, matching the reporter's live upstream 401.

**Fix**: added a `usesZenApiKeyAuth()` helper that also emits `x-api-key` when `_requestFormat === "openai-responses"` **and** the executor's `baseUrl` is the main Zen host (`https://opencode.ai/zen/v1`, shared by the `opencode` and `opencode-zen` registry entries). Scoped by `baseUrl` rather than provider id/alias so `opencode-go` — a separate upstream (`https://opencode.ai/zen/go/v1`) that already works with `Bearer` for its own Responses-routed models (grok-4.5, deepseek-v4-pro, muse-spark-1.2-contributor) — is unaffected.

**Regression test**: `tests/unit/issue-12633-opencode-zen-responses-auth.test.ts`
- RED (before fix): `openai-responses` format on `opencode`/`opencode-zen` sent `Authorization: Bearer`, no `x-api-key`.
- GREEN (after fix): both send `x-api-key`, no `Authorization`; `opencode-go` (negative control, different upstream) still correctly sends `Authorization: Bearer`; `claude` format behavior unchanged.

**Scope note**: the plan-file's open "Scope Question" (is `x-api-key` required only for Muse Contributor, or every Zen Responses model?) is answered by scoping to the whole Zen host rather than guessing per-model — any current or future model routed to `openai-responses` on the main Zen host now gets the correct header, without touching `opencode-go`. The plan-file's secondary checkbox (adding `muse-spark-1.3`/`muse-spark-1.3-contributor-free` registry entries) is **not** included here — that model's real capability metadata is unconfirmed and is already the subject of a separate open contributor PR (#12675, opencode-go's 1.3 registration), so adding it here as well would risk a conflicting/duplicate registration.

## Gates run

- `node --import tsx/esm --test tests/unit/issue-12681-opencode-muse-spark-context.test.ts tests/unit/issue-12633-opencode-zen-responses-auth.test.ts` — 7/7 pass
- Existing area tests (buildHeaders, target-format, muse-spark routing/output, opencode-go catalog alignment, account rotation, ambient proxy, stream payload collector, etc. — ~289 tests across 24 files) — all pass, unchanged
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2798 vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 vs baseline 1437)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
