### PR TITLE
fix(providers): minimax-m3 collapses manual thinking.type:enabled to adaptive (#12132)

### DIFF
--- a/changelog.d/fixes/12132-minimax-m3-adaptive-thinking.md
+++ b/changelog.d/fixes/12132-minimax-m3-adaptive-thinking.md
@@ -1,0 +1,1 @@
+- fix(providers): minimax-m3 now collapses manual thinking.type:"enabled" to adaptive, preventing upstream 400 (2013) (#12132)

--- a/src/shared/constants/modelSpecs.ts
+++ b/src/shared/constants/modelSpecs.ts
@@ -680,12 +680,16 @@ export const MODEL_SPECS: Record<string, ModelSpec> = {
   // ── MiniMax M3 (1M context, 512K max output) ─────────────────────
   // max output verified against MiniMax docs / OpenRouter / Artificial
   // Analysis (Nov 2025 launch): 1,048,576-token context, up to 512K output.
+  // Adaptive-thinking-only: MiniMax rejects manual budget_tokens /
+  // thinking.type:"enabled" with 400 (2013) — "invalid thinking.type:
+  // \"enabled\" (allowed: adaptive, disabled)" (#12132).
   "minimax-m3": {
     maxOutputTokens: 512000,
     contextWindow: 1048576,
     thinkingBudgetCap: 32768,
     supportsThinking: true,
     supportsTools: true,
+    adaptiveThinkingOnly: true,
     aliases: ["MiniMax-M3", "MiniMaxAI/MiniMax-M3"],
   },
 

--- a/tests/unit/minimax-m3-adaptive-thinking-12132.test.ts
+++ b/tests/unit/minimax-m3-adaptive-thinking-12132.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isAdaptiveThinkingOnly } from "@/shared/constants/modelSpecs.ts";
+import { normalizeClaudeAdaptiveThinking } from "@omniroute/open-sse/services/claudeAdaptiveThinking.ts";
+
+// Issue #12132: MiniMax M3 rejects thinking.type:"enabled" with 400 (2013)
+// ("invalid thinking.type: \"enabled\" (allowed: adaptive, disabled)"), but the
+// modelSpecs entry for minimax-m3 was never given `adaptiveThinkingOnly: true`
+// (the change #9155 proposed and claimed to have landed). Because every
+// normalization site that would collapse `enabled` -> `adaptive` gates on
+// `isAdaptiveThinkingOnly()`, a manual thinking.type:"enabled" request that
+// resolves to MiniMax M3 (via either the `minimax` or `minimax-cn` provider,
+// since both alias to the same spec entry) was forwarded unchanged and
+// upstream 400s.
+
+test("minimax-m3 is flagged adaptiveThinkingOnly so manual thinking.type is collapsed", () => {
+  assert.equal(
+    isAdaptiveThinkingOnly("minimax-m3"),
+    true,
+    "minimax-m3 modelSpec is missing adaptiveThinkingOnly: true"
+  );
+  assert.equal(
+    isAdaptiveThinkingOnly("MiniMax-M3"),
+    true,
+    "MiniMax-M3 alias must resolve to the same adaptive-thinking-only spec"
+  );
+});
+
+test("normalizeClaudeAdaptiveThinking collapses enabled->adaptive for MiniMax M3", () => {
+  const body = {
+    thinking: { type: "enabled", budget_tokens: 20000 },
+    output_config: { effort: "max" },
+  };
+
+  const result = normalizeClaudeAdaptiveThinking(body, "MiniMax-M3");
+
+  assert.equal(
+    (result.thinking as Record<string, unknown>).type,
+    "adaptive",
+    "thinking.type:\"enabled\" must be collapsed to \"adaptive\" for MiniMax M3, " +
+      "otherwise upstream rejects it with 400 (2013)"
+  );
+  assert.equal(
+    (result.thinking as Record<string, unknown>).budget_tokens,
+    undefined,
+    "budget_tokens must be dropped once thinking is collapsed to adaptive"
+  );
+});


### PR DESCRIPTION
Closes #12132

## Root cause

The `minimax-m3` entry in `src/shared/constants/modelSpecs.ts` never actually got `adaptiveThinkingOnly: true` — issue #9155 proposed the one-line change and was closed as "already in progress", but no PR ever landed it.

Both consuming call sites gate purely on `isAdaptiveThinkingOnly(model)`:
- `normalizeClaudeAdaptiveThinking()` in `open-sse/services/claudeAdaptiveThinking.ts:41`
- the explicit `thinking.type:"enabled"` branch in `open-sse/translator/request/openai-to-claude.ts:196,226`

Since the flag was missing, every path forwarding a manual `thinking.type:"enabled"` to MiniMax M3 (direct, combo, cache-rebuild — `minimax` and `minimax-cn` alike, since both resolve to the same modelSpec via alias matching) was unprotected and got rejected upstream with `400 (2013)` (`invalid thinking.type: "enabled" (allowed: adaptive, disabled)`).

## Fix

Added `adaptiveThinkingOnly: true` to the `minimax-m3` spec entry — no other code changes needed, since both normalization sites already handle every other adaptive-only model correctly.

## Regression test

`tests/unit/minimax-m3-adaptive-thinking-12132.test.ts`

RED (before fix):
```
✖ minimax-m3 is flagged adaptiveThinkingOnly so manual thinking.type is collapsed
  AssertionError: minimax-m3 modelSpec is missing adaptiveThinkingOnly: true
  false !== true
✖ normalizeClaudeAdaptiveThinking collapses enabled->adaptive for MiniMax M3
  AssertionError: thinking.type:"enabled" must be collapsed to "adaptive" for MiniMax M3...
  + actual 'enabled'  - expected 'adaptive'
```

GREEN (after fix):
```
✔ minimax-m3 is flagged adaptiveThinkingOnly so manual thinking.type is collapsed
✔ normalizeClaudeAdaptiveThinking collapses enabled->adaptive for MiniMax M3
tests 2, pass 2, fail 0
```

## Gates run

- `node --import tsx/esm --test tests/unit/minimax-m3-adaptive-thinking-12132.test.ts` — GREEN
- `node --import tsx/esm --test tests/unit/nvidia-minimax-thinking-strip.test.ts tests/unit/translator-redacted-thinking-model-aware-4479.test.ts tests/unit/minimax-m3-maxtokens.test.ts tests/unit/minimax-m3-model-registry.test.ts` — 23/23 pass (existing minimax/thinking-adjacent tests unaffected)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2798 violations, baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations, baseline 1437)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json src/shared/constants/modelSpecs.ts tests/unit/minimax-m3-adaptive-thinking-12132.test.ts` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Follow-up

Will close #9155 with a comment noting it is now actually implemented (it was previously closed without a landing PR).

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
