### PR TITLE
fix(dashboard): allow deleting the last extra-upstream-header row even when invalid (#12251)

### DIFF
--- a/changelog.d/fixes/12251-extra-upstream-headers-delete.md
+++ b/changelog.d/fixes/12251-extra-upstream-headers-delete.md
@@ -1,0 +1,1 @@
+- fix(dashboard): allow deleting the last extra-upstream-header row even when invalid (#12251)

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/ModelCompatPopover.tsx
@@ -707,7 +707,10 @@ export default function ModelCompatPopover({
                       </div>
                       <button
                         type="button"
-                        disabled={disabled || headerRows.length <= 1}
+                        disabled={
+                          disabled ||
+                          (headerRows.length <= 1 && !row.name.trim() && !row.value.trim())
+                        }
                         onClick={() => removeHeaderRow(row.id)}
                         title={t("compatUpstreamRemoveRow")}
                         className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border/80 text-text-muted hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-text-muted transition-colors"

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-12251-delete-invalid-header.test.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-12251-delete-invalid-header.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+// Repro for #12251
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ModelCompatPopover from "../ModelCompatPopover";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function openPopover() {
+  const trigger = container.querySelector("button") as HTMLButtonElement;
+  await act(async () => trigger.click());
+  await flushEffects();
+}
+
+describe("ModelCompatPopover upstream headers — invalid single row cannot be deleted (#12251)", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  it("lets the user delete the invalid header via the delete icon when it is the ONLY row present", async () => {
+    const onCompatPatch = vi.fn();
+
+    act(() => {
+      root.render(
+        <ModelCompatPopover
+          t={(key) => key}
+          providerId="openai"
+          modelId="gpt-test"
+          effectiveModelNormalize={() => false}
+          effectiveModelPreserveDeveloper={() => true}
+          getUpstreamHeadersRecord={() => ({
+            "https://evil.example.com/callback": "some-secret-value",
+          })}
+          onCompatPatch={onCompatPatch}
+        />
+      );
+    });
+
+    await openPopover();
+
+    const nameInput = document.querySelector(
+      'input[placeholder="compatUpstreamHeaderNamePlaceholder"]'
+    ) as HTMLInputElement;
+    expect(nameInput).toBeTruthy();
+    expect(nameInput.value).toBe("https://evil.example.com/callback");
+
+    const rowButtons = document.querySelectorAll('button[title="compatUpstreamRemoveRow"]');
+    expect(rowButtons.length).toBe(1);
+
+    const removeButton = rowButtons[0] as HTMLButtonElement;
+
+    // EXPECTED (fixed) behavior: a populated row should always be removable via
+    // its own delete icon, even when it is the only row.
+    expect(removeButton.disabled).toBe(false);
+
+    await act(async () => removeButton.click());
+    await flushEffects();
+
+    expect(onCompatPatch).toHaveBeenCalledWith("openai", { upstreamHeaders: {} });
+  });
+
+  it("keeps the delete button disabled when the sole row is genuinely blank", async () => {
+    const onCompatPatch = vi.fn();
+
+    act(() => {
+      root.render(
+        <ModelCompatPopover
+          t={(key) => key}
+          providerId="openai"
+          modelId="gpt-test"
+          effectiveModelNormalize={() => false}
+          effectiveModelPreserveDeveloper={() => true}
+          getUpstreamHeadersRecord={() => ({})}
+          onCompatPatch={onCompatPatch}
+        />
+      );
+    });
+
+    await openPopover();
+
+    const rowButtons = document.querySelectorAll('button[title="compatUpstreamRemoveRow"]');
+    expect(rowButtons.length).toBe(1);
+
+    const removeButton = rowButtons[0] as HTMLButtonElement;
+
+    // A blank sole row must stay non-deletable so the form always shows an
+    // editable add-affordance.
+    expect(removeButton.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #12251

## Root cause

In `ModelCompatPopover.tsx` (the "Extra upstream headers" editor opened from a model row's compat popover), the delete ("X") button next to each header row was unconditionally disabled whenever there was only one row left:

```tsx
disabled={disabled || headerRows.length <= 1}
```

This check only looked at row *count*, not whether that sole row actually held content. So once a mistaken entry (e.g. a full URL typed into the header-name field, invalid per both the client render and the server's `upstreamHeaderNameSchema`) ended up as the ONLY row in the popover, the delete icon was permanently disabled and clicking it did nothing — `removeHeaderRow`/`tryCommitHeaderRows` were never even called, so no save was attempted. That matches the report: "When I click the delete icon ... the dashboard fails to save the deletion."

## Fix

`ModelCompatPopover.tsx:710` — only force-disable the sole row's delete button when that row is *already* blank:

```tsx
disabled={
  disabled ||
  (headerRows.length <= 1 && !row.name.trim() && !row.value.trim())
}
```

A populated last row (valid or invalid) can now always be removed directly, while a genuinely empty sole row still can't be deleted below the always-show-one-editable-row floor (preserving the original UX intent).

## Regression test

`src/app/(dashboard)/dashboard/providers/[id]/components/__tests__/modelCompatPopover-12251-delete-invalid-header.test.tsx`

RED (before fix):
```
AssertionError: expected true to be false
 ❯ ...test.tsx:87:35   expect(removeButton.disabled).toBe(false);
Test Files  1 failed (1)
     Tests  1 failed (1)
```

GREEN (after fix):
```
Test Files  1 passed (1)
     Tests  2 passed (2)
```

The companion test asserts a genuinely blank sole row still keeps its delete button disabled (no regression on the original "always keep one editable row" UX).

Full directory suite (13 files / 45 tests, includes the other `modelCompatPopover-param-filter*` suites sharing this component) — all passing, no regressions.

## Gates run

- `npx vitest run "src/.../__tests__/modelCompatPopover-12251-delete-invalid-header.test.tsx"` — GREEN (2/2)
- `npx vitest run 'src/.../[id]/components/__tests__/'` — GREEN (45/45, 13 files)
- `node scripts/check/check-file-size.mjs` — no violation on touched files
- `node scripts/check/check-complexity.mjs` — OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
