### PR TITLE
fix(cli): run Node runtime guard before heavy import chain (#12296)

### DIFF
--- a/bin/omniroute.mjs
+++ b/bin/omniroute.mjs
@@ -50,6 +50,34 @@ if (isVersionFastPath(process.argv)) {
   process.exit(0);
 }
 
+// Detect an unsupported Node.js runtime BEFORE the heavy `tsx/esm` import and
+// Commander's ~70-command registration chain run. That chain pulls in `ora` ->
+// the hoisted `string-width` package, whose module contains top-level ES2024
+// Unicode-set (`v` flag) regex literals. On a Node/V8 build that predates
+// `v`-flag support, those literals fail to even *parse*, throwing a bare
+// `SyntaxError: Invalid regular expression flags` deep inside a transitive
+// dependency instead of an actionable message (#12296). Skip this for the
+// same read-only invocations `shouldProvisionStorageKey` already exempts
+// (`--help`/`-h`, `help`/`completion`) — those still need the full command
+// registry to render their output, so an incompatible runtime crashing there
+// is a separate, pre-existing limitation this fix does not attempt to solve.
+if (shouldProvisionStorageKey(process.argv)) {
+  const nodeSupport = getNodeRuntimeSupport();
+  if (!nodeSupport.nodeCompatible) {
+    const runtimeWarning = getNodeRuntimeWarning() || "Unsupported Node.js runtime detected.";
+    console.error(
+      `\x1b[31m✖ Node.js ${nodeSupport.nodeVersion} is not supported.\x1b[0m\n` +
+        `  ${runtimeWarning}\n` +
+        `  Supported runtimes: ${nodeSupport.supportedDisplay}\n` +
+        `  Recommended: Node.js ${nodeSupport.recommendedVersion}\n` +
+        `  If you installed OmniRoute globally, run \`node -v\` and confirm \`omniroute\` is not resolving to\n` +
+        `  a stale/distro-packaged \`nodejs\` binary (e.g. /usr/bin/node) instead of the version you expect —\n` +
+        `  that mismatch is the most common cause even when package.json's engines range is correct.`
+    );
+    process.exit(1);
+  }
+}
+
 // MCP stdio transport uses stdout exclusively for JSON-RPC messages. Redirect
 // console.log/warn to stderr before anything else runs — including the tsx/esm and
 // polyfill imports below, since those (and their transitive module graphs, e.g. DB

--- a/changelog.d/fixes/12296-node-runtime-guard-early.md
+++ b/changelog.d/fixes/12296-node-runtime-guard-early.md
@@ -1,0 +1,1 @@
+- fix(cli): run the Node.js runtime compatibility guard before the heavy `tsx/esm` + Commander import chain so an unsupported runtime gets a clear message instead of a raw `Invalid regular expression flags` crash (#12296)

--- a/tests/unit/issue-12296-node-runtime-guard.test.ts
+++ b/tests/unit/issue-12296-node-runtime-guard.test.ts
@@ -1,0 +1,63 @@
+// Regression test for issue #12296: "Invalid regular expression flags" crash
+// right after STORAGE_ENCRYPTION_KEY generation on first run.
+//
+// Root cause: bin/omniroute.mjs imports getNodeRuntimeSupport/getNodeRuntimeWarning
+// from ./nodeRuntimeSupport.mjs (intended to detect an unsupported Node.js runtime
+// and print a friendly warning) but never actually CALLED either function before
+// doing the heavy `await import("tsx/esm")` + Commander command-registration import
+// chain. That chain pulls in `ora` -> `string-width@8.x`, whose index.js contains
+// top-level ES2024 Unicode-set (`v` flag) regex literals
+// (e.g. `/^\p{RGI_Emoji}$/v`) that fail to even PARSE on a V8/Node build that
+// predates `v`-flag support - throwing exactly
+// `SyntaxError: Invalid regular expression flags` (no flag value in the message,
+// matching the report) deep inside a transitive dependency's module graph, instead
+// of the intended actionable "Node.js vX is not supported" message.
+//
+// The only two call sites of getNodeRuntimeSupport/getNodeRuntimeWarning in bin/
+// used to be inside `serve.mjs` and `doctor.mjs` - both unreachable if the import
+// chain itself crashed first. This test asserts the guard actually runs (is
+// called) in bin/omniroute.mjs, and that it runs BEFORE the heavy import chain
+// that pulls in string-width.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OMNIROUTE_MJS = join(__dirname, "..", "..", "bin", "omniroute.mjs");
+
+test("bin/omniroute.mjs invokes the Node runtime compatibility guard before the heavy tsx/esm + command-registration import chain", () => {
+  const src = readFileSync(OMNIROUTE_MJS, "utf8");
+
+  const heavyImportIdx = src.indexOf('await import("tsx/esm")');
+  assert.ok(
+    heavyImportIdx > -1,
+    "expected bin/omniroute.mjs to still contain the tsx/esm dynamic import this test anchors on"
+  );
+
+  const callPattern = /getNodeRuntime(?:Support|Warning)\s*\(/g;
+  let firstCallIdx = -1;
+  for (const match of src.matchAll(callPattern)) {
+    firstCallIdx = match.index ?? -1;
+    break;
+  }
+
+  assert.notEqual(
+    firstCallIdx,
+    -1,
+    "getNodeRuntimeSupport()/getNodeRuntimeWarning() is imported in bin/omniroute.mjs but never called there - " +
+      "an unsupported/too-old Node.js runtime gets no early friendly warning and instead crashes with a raw " +
+      "native SyntaxError (e.g. 'Invalid regular expression flags' from string-width@8's v-flag regex literals) " +
+      "deep inside the tsx/esm + Commander import chain. See issue #12296."
+  );
+
+  assert.ok(
+    firstCallIdx < heavyImportIdx,
+    "the Node runtime compatibility guard must run BEFORE `await import(\"tsx/esm\")` and the rest of the heavy " +
+      "import chain (Commander command registry, ora/boxen/update-notifier, etc.) so an unsupported Node.js " +
+      "version is reported with a clear message and a clean exit instead of crashing on a native parse error " +
+      "raised while loading a transitive dependency."
+  );
+});


### PR DESCRIPTION
## Root cause

`bin/omniroute.mjs` imports `getNodeRuntimeSupport`/`getNodeRuntimeWarning` from
`bin/nodeRuntimeSupport.mjs` to detect an unsupported Node.js runtime, but never actually
**calls** either function — only `bin/cli/commands/serve.mjs` and `bin/cli/commands/doctor.mjs`
do, deep inside command handlers that are unreachable if the startup import chain itself crashes
first.

And it does crash first: right after generating `STORAGE_ENCRYPTION_KEY`, the script does
`await import("tsx/esm")` and then loads Commander's ~70 command modules (`bin/cli/program.mjs`),
which pull in `ora` -> the hoisted `string-width@8.x`. That package's `index.js` has top-level
regex literals using the ES2024 `v` (Unicode-set) flag, e.g. `/^\p{RGI_Emoji}$/v`. On a Node/V8
build that predates `v`-flag support, that literal fails to even *parse*, and V8 throws exactly
`SyntaxError: Invalid regular expression flags` — with no flag value in the message, which is why
it looked untraceable. Same class of failure hit pnpm (pnpm/pnpm#11546), root-caused there as
running a too-new dependency on an unsupported/old Node major.

## Fix

Call the existing `getNodeRuntimeSupport()`/`getNodeRuntimeWarning()` check right after the
`--version`/`-V` fast path in `bin/omniroute.mjs`, before the heavy `tsx/esm` + command-
registration import chain. When the runtime is incompatible, print a clear, actionable message
(including a note that a stale/distro-packaged `nodejs` binary is the most common cause) and
`process.exit(1)`. The check is skipped for the same read-only invocations
`shouldProvisionStorageKey` already exempts (`--help`/`-h`, `help`/`completion`) — those still
need the full command registry to render their own output, so an incompatible runtime crashing
there is a separate, pre-existing limitation this fix does not attempt to solve.

The existing calls in `serve.mjs`/`doctor.mjs` are left as-is (harmless duplicate checks).

## Regression test

`tests/unit/issue-12296-node-runtime-guard.test.ts` — asserts `bin/omniroute.mjs` actually calls
`getNodeRuntimeSupport`/`getNodeRuntimeWarning`, and that the call happens before
`await import("tsx/esm")`.

RED (before fix):
```
✖ bin/omniroute.mjs invokes the Node runtime compatibility guard before the heavy tsx/esm + command-registration import chain
AssertionError [ERR_ASSERTION]: getNodeRuntimeSupport()/getNodeRuntimeWarning() is imported in
bin/omniroute.mjs but never called there ...
  actual: -1, expected: -1 (notStrictEqual), tests 1, pass 0, fail 1
```

GREEN (after fix):
```
✔ bin/omniroute.mjs invokes the Node runtime compatibility guard before the heavy tsx/esm + command-registration import chain
tests 1, pass 1, fail 0
```

## Gates run

- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` — clean (exit 0)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean (`bin/**` is excluded from ESLint's scope by project config; the new test file lints clean)
- New regression test — PASS (RED→GREEN evidence above)
- Existing CLI-entrypoint-touching tests re-run individually (not just the new test):
  `cli-entrypoint`, `cli-version-fastpath`, `cli-storage-key-provision`,
  `cli-storage-key-bootstrap`, `bin-omniroute-mcp`, `cli-data-dir-env`,
  `cli-data-dir-env-loading`, `cli-env-collision`, `cli-update-notifier`,
  `cli-update-global-paths-3295`, `reset-password-cli-6261-6258`,
  `cli-electron-to-cli-migration-server-env-7302`, `termux-android-cache-dir`,
  `cli-memory`, `node-runtime-support` — all pass.
  `mcp-stdio-json-purity` fails identically on both the fixed and the pre-fix (baseline) code
  under the current heavy multi-worktree devbox load (61s timeout waiting for the MCP subprocess
  to answer on stdout) — confirmed pre-existing/unrelated by reverting to `HEAD:bin/omniroute.mjs`
  and re-running the same test, which fails with the same timeout and message.
- `node scripts/check/check-changelog-integrity.mjs` — OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync

Closes #12296
