### PR TITLE
fix(dashboard): refresh the providers list after deleting a compatible provider node (#12298)

### DIFF
--- a/changelog.d/fixes/12298-provider-node-delete-refresh.md
+++ b/changelog.d/fixes/12298-provider-node-delete-refresh.md
@@ -1,0 +1,1 @@
+- fix(dashboard): refresh the providers list after deleting a compatible provider node (#12298)

--- a/src/app/(dashboard)/dashboard/providers/[id]/components/CompatibleNodeCard.tsx
+++ b/src/app/(dashboard)/dashboard/providers/[id]/components/CompatibleNodeCard.tsx
@@ -110,6 +110,7 @@ export default function CompatibleNodeCard({
                 });
                 if (res.ok) {
                   router.push("/dashboard/providers");
+                  router.refresh();
                 }
               } catch (error) {
                 console.error("Error deleting provider node:", error);

--- a/tests/unit/ui/compatible-node-card-delete-refresh-12298.test.tsx
+++ b/tests/unit/ui/compatible-node-card-delete-refresh-12298.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import CompatibleNodeCard from "../../../src/app/(dashboard)/dashboard/providers/[id]/components/CompatibleNodeCard";
+
+const router = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => router,
+}));
+
+vi.mock("@/shared/components", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  }) => <button onClick={onClick}>{children}</button>,
+}));
+
+vi.mock("@/shared/components/ProviderIcon", () => ({
+  default: () => null,
+}));
+
+function renderCard(container: HTMLDivElement) {
+  const root = createRoot(container);
+  return root;
+}
+
+describe("CompatibleNodeCard provider deletion (#12298)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    router.push.mockClear();
+    router.refresh.mockClear();
+    vi.stubGlobal("confirm", vi.fn(() => true));
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = renderCard(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function clickDelete() {
+    await act(async () => {
+      root.render(
+        <CompatibleNodeCard
+          providerId="custom-node"
+          providerNode={{ baseUrl: "https://example.test/v1", apiType: "openai" }}
+          isCcCompatible={false}
+          isAnthropicCompatible={false}
+          isAnthropicProtocolCompatible={false}
+          gateConnectionFlow={(callback) => callback()}
+          openApiKeyAddFlow={vi.fn()}
+          onOpenEditNodeModal={vi.fn()}
+          t={(key) => key}
+        />
+      );
+    });
+
+    const deleteButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "delete"
+    );
+    expect(deleteButton).toBeDefined();
+
+    await act(async () => {
+      deleteButton?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    return deleteButton;
+  }
+
+  it("invalidates the cached providers page after a successful delete and navigation", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true } as Response));
+
+    await clickDelete();
+
+    expect(fetch).toHaveBeenCalledWith("/api/provider-nodes/custom-node", {
+      method: "DELETE",
+    });
+    expect(router.push).toHaveBeenCalledWith("/dashboard/providers");
+    expect(router.refresh).toHaveBeenCalledTimes(1);
+    expect(router.push.mock.invocationCallOrder[0]).toBeLessThan(
+      router.refresh.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("does not navigate or refresh when the user cancels the confirm dialog", async () => {
+    vi.stubGlobal("confirm", vi.fn(() => false));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true } as Response));
+
+    await clickDelete();
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(router.push).not.toHaveBeenCalled();
+    expect(router.refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate or refresh when the DELETE response is not ok", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false } as Response));
+
+    await clickDelete();
+
+    expect(router.push).not.toHaveBeenCalled();
+    expect(router.refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate or refresh when the DELETE request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await clickDelete();
+
+    expect(router.push).not.toHaveBeenCalled();
+    expect(router.refresh).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #12298

## Root cause

`CompatibleNodeCard`'s delete handler confirms, sends `DELETE /api/provider-nodes/:id`, and on
`res.ok` only calls `router.push("/dashboard/providers")` — it never calls `router.refresh()` or
otherwise invalidates the destination page's data. The Providers page loads its provider-node list
in a mount-only `useEffect(..., [])`, so a soft navigation back to it can render the stale,
preserved list until a full reload.

Scope note: the issue's model/alias subcase was investigated and NOT reproduced — those deletion
paths already invoke their own refetch callbacks — so this fix stays limited to the confirmed
provider-node deletion path, per the analysis plan-file.

## Fix

Call `router.refresh()` immediately after the successful `router.push()` in
`src/app/(dashboard)/dashboard/providers/[id]/components/CompatibleNodeCard.tsx`, so the
Providers page re-fetches on arrival instead of showing cached, stale data.

## Regression test

`tests/unit/ui/compatible-node-card-delete-refresh-12298.test.tsx`

- RED (before fix): `router.refresh` expected to be called once, but got 0 times (DELETE + push
  assertions passed).
- GREEN (after fix): all 4 assertions pass, including that `push` is called before `refresh`.
- Added negative cases: cancelling the confirm dialog, a non-OK DELETE response, and a network
  failure all correctly skip both navigation and refresh.

Command: `npx vitest run tests/unit/ui/compatible-node-card-delete-refresh-12298.test.tsx --reporter=verbose`

## Gates run

- `npx vitest run tests/unit/ui/compatible-node-card-delete-refresh-12298.test.tsx` — 4/4 passed
- `node scripts/check/check-file-size.mjs` — OK, no new violations
- `node scripts/check/check-complexity.mjs` — OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` — exit 0
- `npm run check:dashboard-typecheck` — exit 0 (this PR touches dashboard `.tsx`)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
