### PR TITLE
fix(usage): fail closed on budget enforcement for unpriced auto alias (#12341)

### DIFF
--- a/changelog.d/fixes/12341-budget-alias-auto.md
+++ b/changelog.d/fixes/12341-budget-alias-auto.md
@@ -1,0 +1,1 @@
+- fix(usage): fail closed on API-key budget enforcement when a provider's `auto` routing alias has no pricing row, instead of silently counting it as $0 (#12341)

--- a/src/lib/usage/apiKeyUsageLimits.ts
+++ b/src/lib/usage/apiKeyUsageLimits.ts
@@ -1,7 +1,7 @@
 import { getDbInstance } from "@/lib/db/core";
 import type { ProviderLimitsCacheEntry } from "@/lib/db/providerLimits";
 import { getProviderQuotaWindowStartIso } from "@/lib/db/quotaResetEvents";
-import { calculateCost } from "./costCalculator";
+import { calculateCostDetailed } from "./costCalculator";
 import { buildErrorBody, sanitizeErrorMessage } from "@omniroute/open-sse/utils/error.ts";
 
 const FORTALEZA_UTC_OFFSET_MS = 3 * 60 * 60 * 1000;
@@ -29,6 +29,15 @@ export interface ApiKeyUsageLimitStatus {
   weeklyResetAtIso: string | null;
   dailyExceeded: boolean;
   weeklyExceeded: boolean;
+  /**
+   * True when at least one usage_history row in the daily/weekly window could not
+   * be priced at all (no pricing row for the provider+model — e.g. a routing
+   * alias such as `auto`, #12341). Enforcement fails closed on this: an unpriced
+   * row forces `*Exceeded = true` rather than silently contributing $0 to spend,
+   * since a real cost may be hiding behind the alias.
+   */
+  dailyHasUnpricedUsage?: boolean;
+  weeklyHasUnpricedUsage?: boolean;
 }
 
 export interface ApiKeyUsageLimitDeps {
@@ -373,8 +382,14 @@ async function getProviderWeeklyWindow(
   };
 }
 
-async function getApiKeyUsdSpendSince(apiKeyId: string, sinceIso: string): Promise<number> {
-  if (!apiKeyId) return 0;
+interface ApiKeyUsdSpend {
+  totalUsd: number;
+  /** True when at least one (provider, model) group had no pricing row at all (#12341). */
+  hasUnpricedUsage: boolean;
+}
+
+async function getApiKeyUsdSpendSince(apiKeyId: string, sinceIso: string): Promise<ApiKeyUsdSpend> {
+  if (!apiKeyId) return { totalUsd: 0, hasUnpricedUsage: false };
   const db = getDbInstance();
   const rows = db
     .prepare(
@@ -398,12 +413,13 @@ async function getApiKeyUsdSpendSince(apiKeyId: string, sinceIso: string): Promi
     .all({ apiKeyId, sinceIso }) as UsageCostRow[];
 
   let total = 0;
+  let hasUnpricedUsage = false;
   for (const row of rows) {
     const provider = typeof row.provider === "string" ? row.provider : "";
     const model = typeof row.model === "string" ? row.model : "";
     if (!provider || !model) continue;
 
-    total += await calculateCost(
+    const { costUsd, priced } = await calculateCostDetailed(
       provider,
       model,
       {
@@ -419,9 +435,17 @@ async function getApiKeyUsdSpendSince(apiKeyId: string, sinceIso: string): Promi
         serviceTier: row.serviceTier || "standard",
       }
     );
+    if (!priced) {
+      hasUnpricedUsage = true;
+      console.warn(
+        `[apiKeyUsageLimits] no pricing found for ${provider}/${model} — usage counted as $0 ` +
+          "and enforcement is failing closed for this window (#12341)"
+      );
+    }
+    total += costUsd;
   }
 
-  return roundUsd(total);
+  return { totalUsd: roundUsd(total), hasUnpricedUsage };
 }
 
 export async function getApiKeyUsageLimitStatus(
@@ -443,10 +467,27 @@ export async function getApiKeyUsageLimitStatus(
   const weeklyLimitUsd = normalizeLimitUsd(metadata.weeklyUsageLimitUsd);
   const enabled = metadata.usageLimitEnabled === true;
 
-  const [dailySpentUsd, weeklySpentUsd] = await Promise.all([
+  const [dailySpend, weeklySpend] = await Promise.all([
     getApiKeyUsdSpendSince(metadata.id, dailyWindowStartIso),
     getApiKeyUsdSpendSince(metadata.id, weeklyWindowStartIso),
   ]);
+  const dailySpentUsd = dailySpend.totalUsd;
+  const weeklySpentUsd = weeklySpend.totalUsd;
+
+  // Fail closed (#12341): a window with a configured limit that also contains
+  // usage which could not be priced at all (e.g. a provider's `auto` routing
+  // alias with no catalog price) must not let that usage silently pass the cap
+  // as an invisible $0 — treat the limit as exceeded rather than trust an
+  // undercounted spend total. A window with no configured limit was never
+  // enforced, so unpriced usage there is only logged, not blocking.
+  const dailyExceeded =
+    enabled &&
+    dailyLimitUsd !== null &&
+    (dailySpentUsd >= dailyLimitUsd || dailySpend.hasUnpricedUsage);
+  const weeklyExceeded =
+    enabled &&
+    weeklyLimitUsd !== null &&
+    (weeklySpentUsd >= weeklyLimitUsd || weeklySpend.hasUnpricedUsage);
 
   return {
     enabled,
@@ -458,8 +499,10 @@ export async function getApiKeyUsageLimitStatus(
     dailyResetAtIso,
     weeklyWindowStartIso,
     weeklyResetAtIso,
-    dailyExceeded: enabled && dailyLimitUsd !== null && dailySpentUsd >= dailyLimitUsd,
-    weeklyExceeded: enabled && weeklyLimitUsd !== null && weeklySpentUsd >= weeklyLimitUsd,
+    dailyExceeded,
+    weeklyExceeded,
+    dailyHasUnpricedUsage: dailySpend.hasUnpricedUsage,
+    weeklyHasUnpricedUsage: weeklySpend.hasUnpricedUsage,
   };
 }
 

--- a/src/lib/usage/costCalculator.ts
+++ b/src/lib/usage/costCalculator.ts
@@ -173,18 +173,31 @@ export function computeCostFromPricing(
   return cost * getCodexFastCostMultiplier(options.provider, options.model, options.serviceTier);
 }
 
-export async function calculateCost(
+/**
+ * Result of a cost calculation that also reports whether the number is backed by
+ * a real pricing row. Budget-enforcement callers (#12341) must be able to tell
+ * "$0, priced" (a genuinely free/flat-rate model) apart from "$0, unpriced" (no
+ * pricing row was ever found — e.g. a routing alias like `auto`) so they can fail
+ * closed on the latter instead of letting it silently pass a hard budget cap.
+ */
+export interface CostCalculationResult {
+  costUsd: number;
+  /** false when no pricing row (direct, normalized, or codex-effortless) was found. */
+  priced: boolean;
+}
+
+export async function calculateCostDetailed(
   provider: string,
   model: string,
   tokens: Record<string, number | undefined> | null | undefined,
   options: CostCalculationOptions = {}
-): Promise<number> {
-  if (!tokens || !provider || !model) return 0;
+): Promise<CostCalculationResult> {
+  if (!tokens || !provider || !model) return { costUsd: 0, priced: true };
 
   // Short-circuit before any pricing DB lookup when an exact, provider-reported
   // cost is present (currently xAI's `cost_in_usd_ticks` — see extractExactCostUsd).
   const exactCostUsd = extractExactCostUsd(tokens);
-  if (exactCostUsd !== null) return exactCostUsd;
+  if (exactCostUsd !== null) return { costUsd: exactCostUsd, priced: true };
 
   try {
     const { getPricingForModel } = await import("@/lib/db/settings");
@@ -204,21 +217,35 @@ export async function calculateCost(
         }
       }
     }
-    if (!pricing) return 0;
+    // No pricing row anywhere — this is the #12341 case (e.g. a provider's own
+    // routing alias such as "auto" that has no catalog price). Report it as
+    // unpriced rather than a bare $0 so budget enforcement can fail closed.
+    if (!pricing) return { costUsd: 0, priced: false };
 
     const pricingRecord =
       pricing && typeof pricing === "object" && !Array.isArray(pricing)
         ? (pricing as Record<string, unknown>)
         : {};
-    return computeCostFromPricing(pricingRecord, tokens, {
+    const costUsd = computeCostFromPricing(pricingRecord, tokens, {
       provider,
       model,
       ...options,
     });
+    return { costUsd, priced: true };
   } catch (error) {
     console.error("Error calculating cost:", error);
-    return 0;
+    return { costUsd: 0, priced: false };
   }
+}
+
+export async function calculateCost(
+  provider: string,
+  model: string,
+  tokens: Record<string, number | undefined> | null | undefined,
+  options: CostCalculationOptions = {}
+): Promise<number> {
+  const result = await calculateCostDetailed(provider, model, tokens, options);
+  return result.costUsd;
 }
 
 type ModalPricing = Record<string, unknown>;

--- a/tests/unit/api-key-budget-alias-auto-12341.test.ts
+++ b/tests/unit/api-key-budget-alias-auto-12341.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-api-key-budget-alias-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = process.env.API_KEY_SECRET || "budget-alias-test-secret";
+
+const core = await import("../../src/lib/db/core.ts");
+const apiKeysDb = await import("../../src/lib/db/apiKeys.ts");
+const usageHistory = await import("../../src/lib/usage/usageHistory.ts");
+const usageLimits = await import("../../src/lib/usage/apiKeyUsageLimits.ts");
+
+const NOW = Date.parse("2026-06-19T20:00:00.000Z");
+
+async function resetStorage() {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  usageHistory.clearPendingRequests();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.beforeEach(async () => {
+  await resetStorage();
+});
+
+test.after(() => {
+  core.resetDbInstance();
+  apiKeysDb.resetApiKeyState();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+async function makeMeteredKey() {
+  const created = await apiKeysDb.createApiKey("Budget Alias Key", "machine-budget-01");
+  await apiKeysDb.updateApiKeyPermissions(created.id, {
+    usageLimitEnabled: true,
+    dailyUsageLimitUsd: 10,
+    weeklyUsageLimitUsd: 50,
+  });
+  apiKeysDb.clearApiKeyCaches();
+  const metadata = await apiKeysDb.getApiKeyMetadata(created.key);
+  assert.ok(metadata);
+  return { created, metadata: metadata! };
+}
+
+test("BUG #12341: a real, billable completion routed through cursor/auto (unpriced) must not silently pass the daily budget cap as $0", async () => {
+  const { created, metadata } = await makeMeteredKey();
+
+  // Cursor's own default routing alias ("Auto (current, default)") has no
+  // pricing row anywhere — this is real, mainstream billable traffic, not an
+  // edge case.
+  await usageHistory.saveRequestUsage({
+    provider: "cursor",
+    model: "auto",
+    apiKeyId: created.id,
+    apiKeyName: "Budget Alias Key",
+    tokens: { input: 1_000_000, output: 1_000_000 },
+    success: true,
+    timestamp: "2026-06-19T12:00:00.000Z",
+  });
+
+  const status = await usageLimits.getApiKeyUsageLimitStatus(
+    { ...metadata, allowedConnections: null },
+    { now: () => NOW }
+  );
+
+  // Fail closed (#12341): unpriced usage in a window with a configured limit
+  // must flip the window to exceeded, even though the naive USD total is $0.
+  assert.equal(status.dailySpentUsd, 0, "cost stays $0 — no pricing row exists for cursor/auto");
+  assert.equal(
+    status.dailyHasUnpricedUsage,
+    true,
+    "status must flag that unpriced usage was seen in the daily window"
+  );
+  assert.equal(
+    status.dailyExceeded,
+    true,
+    "enforcement must fail closed instead of silently allowing unlimited unpriced usage"
+  );
+});
+
+test("control: a priced model routed at the same tokens does NOT trip fail-closed enforcement", async () => {
+  const { updatePricing } = await import("@/lib/db/settings");
+  await updatePricing({
+    openai: {
+      "gpt-4o": { input: 1, cached: 1, output: 1, reasoning: 1, cache_creation: 1 },
+    },
+  });
+
+  const { created, metadata } = await makeMeteredKey();
+
+  await usageHistory.saveRequestUsage({
+    provider: "openai",
+    model: "gpt-4o",
+    apiKeyId: created.id,
+    apiKeyName: "Budget Alias Key",
+    tokens: { input: 1_000_000, output: 0 },
+    success: true,
+    timestamp: "2026-06-19T12:00:00.000Z",
+  });
+
+  const status = await usageLimits.getApiKeyUsageLimitStatus(
+    { ...metadata, allowedConnections: null },
+    { now: () => NOW }
+  );
+
+  assert.equal(status.dailySpentUsd, 1);
+  assert.equal(status.dailyHasUnpricedUsage, false);
+  assert.equal(status.dailyExceeded, false);
+});

--- a/tests/unit/costcalculator-auto-alias-12341.test.ts
+++ b/tests/unit/costcalculator-auto-alias-12341.test.ts
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  calculateCost,
+  calculateCostDetailed,
+  normalizeModelName,
+} from "../../src/lib/usage/costCalculator.ts";
+import { getDefaultPricing } from "../../src/shared/constants/pricing.ts";
+
+const BILLABLE_TOKENS = { input: 1_000_000, output: 1_000_000 };
+const PROVIDERS_WITH_UNPRICED_AUTO_MODEL = ["cursor", "factory", "trae", "dify", "llm-kiwi"];
+
+test('normalizeModelName is a no-op for a bare alias like "auto"', () => {
+  assert.equal(normalizeModelName("auto"), "auto");
+});
+
+test('no pricing source carries an entry for the literal "auto" model id, for providers whose registry offers it as a real model', () => {
+  const pricing = getDefaultPricing() as Record<string, Record<string, unknown>>;
+  for (const provider of PROVIDERS_WITH_UNPRICED_AUTO_MODEL) {
+    const providerPricing = pricing[provider];
+    assert.ok(!providerPricing || !providerPricing["auto"], `expected no DEFAULT_PRICING entry for ${provider}/auto`);
+  }
+});
+
+test('calculateCost() still returns $0 for a real, billable completion routed through the unpriced "auto" alias (unchanged legacy contract)', async () => {
+  const cost = await calculateCost("cursor", "auto", BILLABLE_TOKENS);
+  assert.equal(cost, 0, "calculateCost's numeric contract is unchanged — $0 for unpriced usage");
+});
+
+test('#12341 fix: calculateCostDetailed() flags the "auto" alias as unpriced instead of a bare, indistinguishable $0', async () => {
+  for (const provider of PROVIDERS_WITH_UNPRICED_AUTO_MODEL) {
+    const result = await calculateCostDetailed(provider, "auto", BILLABLE_TOKENS);
+    assert.equal(result.costUsd, 0, `expected $0 for ${provider}/auto`);
+    assert.equal(result.priced, false, `expected ${provider}/auto to be reported as unpriced`);
+  }
+});
+
+test("control: calculateCostDetailed() DOES price a normal, non-alias model correctly and reports it as priced", async () => {
+  const result = await calculateCostDetailed("openai", "gpt-4o", BILLABLE_TOKENS);
+  assert.ok(result.costUsd > 0, `expected a known model to price above $0, got ${result.costUsd}`);
+  assert.equal(result.priced, true);
+});


### PR DESCRIPTION
## Root cause

`src/lib/usage/costCalculator.ts::calculateCost()` silently returns `$0` whenever no
pricing row can be found for a `(provider, model)` pair (`if (!pricing) return 0;`).
`normalizeModelName()` only strips a `provider/` prefix — it has no alias-resolution
logic, so a bare routing alias like `"auto"` never matches any pricing layer.

Several providers register `"auto"` as a real, catalog-listed model with **no
pricing anywhere** in `src/shared/constants/pricing/*`: `cursor` ("Auto (current,
default)" — the provider's own default choice), `factory`, `trae`, `dify`, and
`llm-kiwi`. For four of these five (`factory`, `trae`, `dify`, `llm-kiwi`), `"auto"`
is the provider's own opaque routing sentinel — OmniRoute has no visibility into
which concrete downstream model actually served the request, so there is no
"actually-selected model" to resolve pricing against even in principle.

That silent `$0` flows straight into
`src/lib/usage/apiKeyUsageLimits.ts::getApiKeyUsdSpendSince()`, which sums
per-`(provider, model)` cost from `usage_history` for API-key budget enforcement —
so a real, billable `auto`-routed completion never counts against the key's daily
or weekly USD budget, indefinitely.

## Decision: fail closed (not alias-to-model resolution)

Because most of the affected providers give OmniRoute no way to learn the actually
selected downstream model, resolving the alias to that model's real pricing is not
generally possible. This PR takes the **fail-closed** branch instead:

- `costCalculator.ts` gains `calculateCostDetailed()`, returning
  `{ costUsd, priced }` — `priced: false` when no pricing row (direct, normalized,
  or codex-effortless) was found anywhere. `calculateCost()` keeps its existing
  numeric contract (`$0` for unpriced usage) so no other caller changes behavior.
- `apiKeyUsageLimits.ts::getApiKeyUsdSpendSince()` now uses
  `calculateCostDetailed()` and reports `hasUnpricedUsage` for the window, logging a
  warning per unpriced `(provider, model)` group it sees.
- `getApiKeyUsageLimitStatus()` fails closed: a window **with a configured limit**
  that contains any unpriced usage is now treated as `*Exceeded = true`, instead of
  silently under-counting spend as `$0`. A window with no configured limit was never
  enforced, so unpriced usage there is only logged, not blocking. The new
  `dailyHasUnpricedUsage` / `weeklyHasUnpricedUsage` fields surface this for
  dashboards/observability (optional, additive to `ApiKeyUsageLimitStatus`).

## Regression tests

- `tests/unit/costcalculator-auto-alias-12341.test.ts` — RED→GREEN:
  - Confirms `getDefaultPricing()` has no `auto` entry for `cursor`/`factory`/`trae`/`dify`/`llm-kiwi`.
  - Confirms `calculateCost()`'s legacy numeric contract is unchanged (`$0` for unpriced usage).
  - **New**: `calculateCostDetailed()` reports `priced: false` for all five providers' `auto` alias, and `priced: true` for a normal model.
- `tests/unit/api-key-budget-alias-auto-12341.test.ts` — RED→GREEN:
  - `BUG #12341`: a real 1M+1M-token `cursor/auto` completion in a window with a configured daily limit now flips `dailyExceeded: true` (previously would have stayed `false` forever, since `dailySpentUsd` was always `$0`).
  - Control: a normally-priced model at the same token volume does **not** trip fail-closed enforcement (`dailyHasUnpricedUsage: false`, `dailyExceeded: false`).

Both files run clean: `node --import tsx/esm --test tests/unit/costcalculator-auto-alias-12341.test.ts tests/unit/api-key-budget-alias-auto-12341.test.ts` → 7/7 pass.

Existing suites re-run with no regressions: `api-key-usage-limits`, `flat-rate-cost-5552` (#5552 flat-rate-as-zero behavior preserved), `modalCost`, `reasoning-cost-double-billing`, `reasoning-token-source-6187`, `usage-analytics*`, `xai-exact-cost-2453` — all green.

## Gates run

- `node scripts/check/check-file-size.mjs` — no violations attributable to this diff
- `node scripts/check/check-complexity.mjs` — OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0, no output
- `node scripts/check/check-changelog-integrity.mjs` — OK
- New tests + full existing-area regression suite (see above) — all green

Closes #12341

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
