### PR TITLE
fix(sse): parse Ollama Cloud's current usage markup (#12749)

### DIFF
--- a/changelog.d/fixes/12749-ollama-cloud-usage-cookie.md
+++ b/changelog.d/fixes/12749-ollama-cloud-usage-cookie.md
@@ -1,0 +1,1 @@
+- fix(sse): parse Ollama Cloud's current usage markup (`$X of $Y used` aria-label, nested width style) (#12749)

--- a/open-sse/services/opencodeOllamaUsage.ts
+++ b/open-sse/services/opencodeOllamaUsage.ts
@@ -77,16 +77,36 @@ function normalizeOllamaCloudCookie(value: string): string {
     : trimmed;
 }
 
+function clampPercent(pct: number): number | null {
+  return Number.isFinite(pct) && pct >= 0 && pct <= 100 ? pct : null;
+}
+
+function extractAriaLabelPercent(tagHeader: string): number | null {
+  const directMatch = tagHeader.match(/(\d+(?:\.\d+)?)%\s*used/);
+  if (directMatch) return clampPercent(toNumber(directMatch[1], Number.NaN));
+  const ratioMatch = tagHeader.match(/\$\s*([0-9.]+)\s*of\s*\$\s*([0-9.]+)\s*used/i);
+  if (!ratioMatch) return null;
+  const used = toNumber(ratioMatch[1], Number.NaN);
+  const total = toNumber(ratioMatch[2], Number.NaN);
+  if (!Number.isFinite(used) || !Number.isFinite(total) || total <= 0) return null;
+  return clampPercent((used / total) * 100);
+}
+
+function extractWidthStylePercent(html: string): number | null {
+  const styleMatches = html.matchAll(/style="([^"]*)"/g);
+  for (const match of styleMatches) {
+    const pct = toNumber(match[1].match(/(?:^|;)\s*width\s*:\s*([0-9.]+)%/)?.[1], Number.NaN);
+    const clamped = clampPercent(pct);
+    if (clamped !== null) return clamped;
+  }
+  return null;
+}
+
 function extractOllamaUsagePercent(trackHtml: string): number | null {
   const tagHeader = trackHtml.match(/^[^>]*/)?.[0] ?? "";
-  const ariaMatch = tagHeader.match(/(\d+(?:\.\d+)?)%\s*used/);
-  if (ariaMatch) {
-    const pct = toNumber(ariaMatch[1], Number.NaN);
-    if (Number.isFinite(pct) && pct >= 0 && pct <= 100) return pct;
-  }
-  const style = tagHeader.match(/style="([^"]*)"/)?.[1] ?? "";
-  const pct = toNumber(style.match(/(?:^|;)\s*width\s*:\s*([0-9.]+)%/)?.[1], Number.NaN);
-  return Number.isFinite(pct) && pct >= 0 && pct <= 100 ? pct : null;
+  const ariaPercent = extractAriaLabelPercent(tagHeader);
+  if (ariaPercent !== null) return ariaPercent;
+  return extractWidthStylePercent(trackHtml);
 }
 
 function parseOllamaCloudSettingsHtml(html: string): OllamaCloudUsage | null {

--- a/tests/unit/ollama-cloud-usage.test.ts
+++ b/tests/unit/ollama-cloud-usage.test.ts
@@ -189,3 +189,79 @@ test("getUsageForProvider reports expired Ollama Cloud cookies on redirect", asy
     else process.env.OLLAMA_USAGE_COOKIE = originalCookie;
   }
 });
+
+test("getUsageForProvider parses the current $X-of-$Y aria-label with nested width style (#12749)", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCookie = process.env.OLLAMA_USAGE_COOKIE;
+  const originalOmniCookie = process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE;
+  delete process.env.OLLAMA_USAGE_COOKIE;
+  process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE = "__Secure-session=test-cookie";
+
+  globalThis.fetch = async () =>
+    new Response(
+      [
+        '<span class="capitalize">pro</span>',
+        '<div class="relative h-3 overflow-hidden rounded-full bg-neutral-200" data-usage-track aria-label="Monthly usage $60.01 of $60 used">',
+        '<div class="flex h-full overflow-hidden bg-neutral-950" style="width: 100%; background: #ef4444;"></div>',
+        '<span class="local-time" data-time="2026-06-22T15:00:00.000Z"></span>',
+        "</div>",
+      ].join(""),
+      { status: 200, headers: { "content-type": "text/html" } }
+    );
+
+  try {
+    const result = (await usage.getUsageForProvider({
+      id: "ollama-cloud-new-markup",
+      provider: "ollama-cloud",
+      apiKey: "ollama-chat-key",
+    })) as { message?: string; quotas?: Record<string, { used: number }> };
+
+    assert.ok(
+      result.quotas && Object.keys(result.quotas).length > 0,
+      `expected quotas, got message: ${result.message}`
+    );
+    assert.equal(result.quotas!.session.used, 100);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalCookie === undefined) delete process.env.OLLAMA_USAGE_COOKIE;
+    else process.env.OLLAMA_USAGE_COOKIE = originalCookie;
+    if (originalOmniCookie === undefined) delete process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE;
+    else process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE = originalOmniCookie;
+  }
+});
+
+test("getUsageForProvider still finds width style on a nested child when no aria-label percent exists (#12749)", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCookie = process.env.OLLAMA_USAGE_COOKIE;
+  const originalOmniCookie = process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE;
+  delete process.env.OLLAMA_USAGE_COOKIE;
+  process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE = "__Secure-session=test-cookie";
+
+  globalThis.fetch = async () =>
+    new Response(
+      [
+        '<div class="relative h-3" data-usage-track aria-label="Weekly usage $12 of $60 used">',
+        '<div class="flex h-full" style="width: 20%;"></div>',
+        '<span class="local-time" data-time="2026-06-29T15:00:00.000Z"></span>',
+        "</div>",
+      ].join(""),
+      { status: 200, headers: { "content-type": "text/html" } }
+    );
+
+  try {
+    const result = (await usage.getUsageForProvider({
+      id: "ollama-cloud-nested-width",
+      provider: "ollama-cloud",
+      apiKey: "ollama-chat-key",
+    })) as { quotas?: Record<string, { used: number }> };
+
+    // The aria-label ratio ($12 of $60 = 20%) is used, matching the nested style width fallback.
+    assert.equal(result.quotas!.session.used, 20);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalCookie === undefined) delete process.env.OLLAMA_USAGE_COOKIE;
+    else process.env.OLLAMA_USAGE_COOKIE = originalCookie;
+    if (originalOmniCookie === undefined) delete process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE;
+    else process.env.OMNIROUTE_OLLAMA_USAGE_COOKIE = originalOmniCookie;
+  }
+});


### PR DESCRIPTION
Closes #12749

## Root cause

`extractOllamaUsagePercent()` (`open-sse/services/opencodeOllamaUsage.ts`) derived its
`tagHeader` as only the text up to the FIRST `>` of the `data-usage-track` fragment, then
required either `NN% used` in that tag's `aria-label` or a `style="width:NN%"` attribute on
that same tag. Ollama's current settings page (ollama.com/settings) writes:
- `aria-label="Monthly usage $60.01 of $60 used"` — no `%` anywhere, so the percent regex
  never matched, and
- the `width:NN%` style on a **nested child** `<div>`, not on the `data-usage-track` tag
  itself, so the style fallback never matched either.

Both extraction paths silently returned `null`, `parseOllamaCloudSettingsHtml` returned
`null`, and the UI showed "Ollama Cloud settings page did not contain usage quota tracks."
instead of any usage data — this was a scraper/markup-drift bug, not a cookie/config issue.

## Fix

- Added a `$X of $Y used` aria-label fallback (`used/total*100`, clamped to [0,100]),
  preferring the existing `NN% used` match when present.
- Widened the width-style lookup to scan the whole `data-usage-track` block (all `style="…"`
  occurrences, first match wins) instead of only the tracked element's own opening tag, so a
  `width:NN%` on a nested child div is still found.
- Kept both old markup shapes (aria-label `NN% used` + same-tag `style="width:NN%"`) working
  unchanged.

## Regression test

`tests/unit/ollama-cloud-usage.test.ts` — two new cases:
- `getUsageForProvider parses the current $X-of-$Y aria-label with nested width style (#12749)`
- `getUsageForProvider still finds width style on a nested child when no aria-label percent exists (#12749)`

RED (pre-fix, confirmed via a throwaway probe file with the exact fix under `open-sse/services/opencodeOllamaUsage.ts` reverted):
```
AssertionError [ERR_ASSERTION]: expected quotas, got message: Ollama Cloud settings page did not contain usage quota tracks.
```
GREEN (post-fix): `node --import tsx/esm --test tests/unit/ollama-cloud-usage.test.ts` → 9/9 pass, including the 5 pre-existing cases (old markup shapes unchanged).

## Gates run

- `node scripts/check/check-file-size.mjs` → no violations on touched files
- `node scripts/check/check-complexity.mjs` → OK (2798 vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1265 vs baseline 1437)
- `npm run typecheck:core` → clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/opencodeOllamaUsage.ts tests/unit/ollama-cloud-usage.test.ts` → clean
- `node --import tsx/esm --test tests/unit/ollama-cloud-usage.test.ts` → 9/9 pass
- `node scripts/check/check-changelog-integrity.mjs` → OK
- Swept `tests/unit/` for other Ollama Cloud usage/quota tests (`issue-6638-ollama-quota`, `issue-7071-ollama-session-quota`, `ollama-cloud-weekly-quota-cooldown-3709`) — none touch `opencodeOllamaUsage.ts` or `data-usage-track`, so no cross-test impact.

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
