### PR TITLE
fix(providers): devin-cli spawn error leaves SSE controller closed twice (#12517)

### DIFF
--- a/changelog.d/fixes/12517-devin-cli-sse-double-close.md
+++ b/changelog.d/fixes/12517-devin-cli-sse-double-close.md
@@ -1,0 +1,1 @@
+- fix(providers): stop devin-cli spawn error from double-closing the SSE controller (#12517)

--- a/open-sse/executors/devin-cli.ts
+++ b/open-sse/executors/devin-cli.ts
@@ -170,11 +170,7 @@ export class DevinCliExecutor extends BaseExecutor {
             err.message.includes("ENOENT") || err.message.includes("not found")
               ? `Devin CLI not found: ${devinBin}. Install via https://cli.devin.ai or set CLI_DEVIN_BIN env var.`
               : `Devin CLI spawn error: ${err.message}`;
-          emit(
-            `data: ${JSON.stringify({ error: { message: msg, type: "devin_cli_error", code: "spawn_failed" } })}\n\n`
-          );
-          emit("data: [DONE]\n\n");
-          controller.close();
+          finish(msg);
         });
 
         if (signal) {

--- a/tests/unit/executor-devin-cli-12517-double-close.test.ts
+++ b/tests/unit/executor-devin-cli-12517-double-close.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, after } from "node:test";
+import assert from "node:assert/strict";
+
+const mod = await import("../../open-sse/executors/devin-cli.ts");
+
+describe("DevinCliExecutor — #12517 spawn error must not double-close SSE controller", () => {
+  it("surfaces a sanitized SSE error and never fires uncaughtException on ENOENT spawn", async () => {
+    const previousBin = process.env.CLI_DEVIN_BIN;
+    process.env.CLI_DEVIN_BIN = "/nonexistent/absolute/path/to/devin-bin-12517";
+
+    let caught: unknown = null;
+    const onUncaught = (err: unknown) => {
+      caught = err;
+    };
+    process.on("uncaughtException", onUncaught);
+
+    try {
+      const executor = new mod.DevinCliExecutor();
+      const { response } = await executor.execute({
+        model: "devin-cli",
+        body: { messages: [{ role: "user", content: "hi" }] },
+        stream: true,
+        credentials: {},
+        signal: undefined,
+        log: undefined,
+      } as never);
+
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let payload = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        payload += decoder.decode(value);
+      }
+
+      assert.match(payload, /Devin CLI not found/);
+      assert.match(payload, /data: \[DONE\]/);
+
+      // Give the child's async "close" event (which fires after "error" for a
+      // failed spawn) room to run before asserting no uncaughtException fired.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      assert.equal(caught, null, `expected no uncaughtException, got: ${String(caught)}`);
+    } finally {
+      process.removeListener("uncaughtException", onUncaught);
+      if (previousBin === undefined) delete process.env.CLI_DEVIN_BIN;
+      else process.env.CLI_DEVIN_BIN = previousBin;
+    }
+  });
+
+  after(() => {
+    delete process.env.CLI_DEVIN_BIN;
+  });
+});


### PR DESCRIPTION
Closes #12517

## Root cause

`open-sse/executors/devin-cli.ts`'s `child.on("error", ...)` handler (spawn failure, e.g. ENOENT
when the `devin` binary is missing) manually called `controller.close()` without setting the
`finished` flag. Node still emits `close` afterward for the same failed spawn; the
`child.on("close", ...)` handler checks `if (!finished)`, sees it is still `false`, and calls
`finish()` → `emit()` → a second `controller.enqueue()` on the already-closed controller —
throwing `TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed` as an
uncaughtException, matching the reporter's exact stack trace.

## Fix

The `error` handler now routes through the existing `finish(msg)` helper instead of hand-rolling
its own `emit`/`emit`/`close` sequence. `finish()` already has the correct
`if (finished) return; finished = true;` guard, so the later `close` handler's check works as
intended — the caller still gets a sanitized SSE error event (`Devin CLI not found: …`) followed
by `[DONE]`, exactly once. No error is silently swallowed (project rule: never swallow errors in
SSE streams).

Per the plan's guidance, no guard was added inside the shared `emit()` function itself — since
`finish()` sets `finished = true` *before* calling `emit()`, guarding there would silently drop
the very error message `finish()` is trying to send.

## Scope note

Per the task notes, `open-sse/executors/auggie.ts` was **not** touched — it (and
`devin-cli-agentic.ts`) already funnel every error path through a single `finished`/`settled`-gated
`finish()`/`emitError()` before any close, so this bug does not apply there. That file is left for
the in-flight `fix/12645-auggie-502` branch.

## Regression test

`tests/unit/executor-devin-cli-12517-double-close.test.ts` — forces `CLI_DEVIN_BIN` to a
nonexistent absolute path (ENOENT spawn), drains the SSE stream, and asserts (a) the payload
contains `Devin CLI not found` and (b) no `uncaughtException` fires within a grace window after
the stream completes (long enough for the child's async `close` event to run).

- **RED** (against unfixed `open-sse/executors/devin-cli.ts`):
  ```
  TypeError [ERR_INVALID_STATE]: Invalid state: Controller is already closed
      at ReadableStreamDefaultController.enqueue (node:internal/webstreams/readablestream:1198:13)
      at emit (open-sse/executors/devin-cli.ts:151:51)
      at finish (open-sse/executors/devin-cli.ts:219:13)
      at ChildProcess.<anonymous> (open-sse/executors/devin-cli.ts:466:15)
      at ChildProcess.emit (node:events:514:28)
      at maybeClose (node:internal/child_process:1141:16)
  ```
- **GREEN** (after the fix):
  ```
  ✔ surfaces a sanitized SSE error and never fires uncaughtException on ENOENT spawn (353ms)
  ℹ tests 1 pass 1 fail 0
  ```

## Gates run

- `node scripts/check/check-file-size.mjs` → OK
- `node scripts/check/check-complexity.mjs` → OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` → clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/executors/devin-cli.ts tests/unit/executor-devin-cli-12517-double-close.test.ts` → clean
- New regression test: green (above)
- Existing devin-cli tests (`executor-devin-cli.test.ts`, `executor-devin-cli-acp-protocol-8406.test.ts`,
  `executor-devin-cli-agentic-acp.test.ts`, `executor-devin-cli-agentic-core.test.ts`): 30/30 pass
- `tests/unit/sse-error-passthrough-3324.test.ts` (references devin-cli error strings as fixtures): 10/10 pass
- `node scripts/check/check-changelog-integrity.mjs` → OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
