### PR TITLE
fix(sse): route shell-reported Auggie CLI-not-found through the actionable message (#12645)

### DIFF
--- a/changelog.d/fixes/12645-auggie-cli-not-found-shell-exit.md
+++ b/changelog.d/fixes/12645-auggie-cli-not-found-shell-exit.md
@@ -1,0 +1,1 @@
+- fix(sse): surface the actionable "Auggie CLI not found" message when the shell reports a missing `auggie` binary via exit code instead of a spawn error (#12645)

--- a/open-sse/executors/auggie.ts
+++ b/open-sse/executors/auggie.ts
@@ -294,6 +294,24 @@ function isEnoentLike(message: string): boolean {
   return message.includes("ENOENT") || message.includes("not found");
 }
 
+// Windows cmd.exe and POSIX shells never raise a Node `spawn` 'error' event for a
+// missing binary when `shell: true` is used (see buildAuggieSpawnOptions) — they
+// report it as a normal non-zero exit with the "not found" text on stderr instead.
+// Recognize that shape too so the `close` handlers give the same actionable
+// cliNotFoundMessage() as the `error` handlers already do. See #12645.
+const CLI_NOT_FOUND_STDERR_PATTERNS = [
+  /is not recognized as an internal or external command/i,
+  /command not found/i,
+  // dash/POSIX `sh` shells report a missing executable as `<name>: not found`
+  // (no literal "command"), e.g. "sh: 1: auggie: not found".
+  /:\s*not found\s*$/im,
+  /No such file or directory/i,
+];
+
+function isCliNotFoundText(stderrTail: string): boolean {
+  return CLI_NOT_FOUND_STDERR_PATTERNS.some((pattern) => pattern.test(stderrTail));
+}
+
 export type AuggieCliVersionCheck = { ok: boolean; version?: string; error?: string };
 
 /**
@@ -580,9 +598,11 @@ export class AuggieExecutor extends BaseExecutor {
           if (finished) return;
           if (code !== 0) {
             emitError(
-              sanitizeErrorMessage(
-                `Auggie CLI exited with code ${code}${stderrTail ? `: ${stderrTail}` : ""}`
-              )
+              isCliNotFoundText(stderrTail)
+                ? cliNotFoundMessage(auggieBin)
+                : sanitizeErrorMessage(
+                    `Auggie CLI exited with code ${code}${stderrTail ? `: ${stderrTail}` : ""}`
+                  )
             );
             return;
           }
@@ -664,9 +684,11 @@ export class AuggieExecutor extends BaseExecutor {
         if (code !== 0) {
           settle(
             buildAuggieErrorResponse(
-              sanitizeErrorMessage(
-                `Auggie CLI exited with code ${code}${stderrTail ? `: ${stderrTail}` : ""}`
-              )
+              isCliNotFoundText(stderrTail)
+                ? cliNotFoundMessage(auggieBin)
+                : sanitizeErrorMessage(
+                    `Auggie CLI exited with code ${code}${stderrTail ? `: ${stderrTail}` : ""}`
+                  )
             )
           );
           return;

--- a/tests/unit/auggie-cli-not-found-shell-exit-12645.test.ts
+++ b/tests/unit/auggie-cli-not-found-shell-exit-12645.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { ExecuteInput } from "@omniroute/open-sse/executors/base";
+
+const { AuggieExecutor, __resetAuggieModels } = await import(
+  "@omniroute/open-sse/executors/auggie"
+);
+
+function makeFakeAuggieBin(dir: string, stderrLine: string): string {
+  const fakeBin = path.join(dir, "fake-auggie.sh");
+  fs.writeFileSync(fakeBin, `#!/bin/sh\necho "${stderrLine}" 1>&2\nexit 1\n`);
+  fs.chmodSync(fakeBin, 0o755);
+  return fakeBin;
+}
+
+async function withFakeAuggieBin<T>(
+  stderrLine: string,
+  fn: (dir: string) => Promise<T>
+): Promise<T> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "auggie-probe-"));
+  const fakeBin = makeFakeAuggieBin(dir, stderrLine);
+  const prevBin = process.env.AUGGIE_BIN;
+  process.env.AUGGIE_BIN = fakeBin;
+  __resetAuggieModels();
+  try {
+    return await fn(dir);
+  } finally {
+    if (prevBin === undefined) delete process.env.AUGGIE_BIN;
+    else process.env.AUGGIE_BIN = prevBin;
+    __resetAuggieModels();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("Auggie CLI-not-found surfaced via shell exit code (non-streaming) gets the actionable cliNotFoundMessage", async () => {
+  await withFakeAuggieBin(
+    "'auggie' is not recognized as an internal or external command,",
+    async () => {
+      const executor = new AuggieExecutor();
+      const { response } = await executor.execute({
+        model: "",
+        body: { messages: [{ role: "user", content: "hi" }] },
+        stream: false,
+        credentials: {} as never,
+      } satisfies ExecuteInput);
+
+      const json = await response.json();
+      const message: string = json?.error?.message ?? "";
+
+      // sanitizeErrorMessage() redacts the absolute bin path (and anything the
+      // path-redaction tokenizer folds into it) — see errorPathRedaction.ts —
+      // so the assertion mirrors the existing precedent in
+      // auggie-executor.test.ts: assert the actionable prefix routed through
+      // cliNotFoundMessage(), and that the raw, confusing shell text from
+      // #12645 is gone.
+      assert.match(
+        message,
+        /Auggie CLI not found/,
+        `expected the actionable 'Auggie CLI not found' message, but got: ${message}`
+      );
+      assert.doesNotMatch(
+        message,
+        /is not recognized as an internal or external command/i,
+        `expected the raw shell text to be replaced, but got: ${message}`
+      );
+    }
+  );
+});
+
+test("Auggie CLI-not-found surfaced via shell exit code (streaming) gets the actionable cliNotFoundMessage", async () => {
+  await withFakeAuggieBin("sh: 1: auggie: not found", async () => {
+    const executor = new AuggieExecutor();
+    const { response } = await executor.execute({
+      model: "",
+      body: { messages: [{ role: "user", content: "hi" }] },
+      stream: true,
+      credentials: {} as never,
+    } satisfies ExecuteInput);
+
+    const text = await response.text();
+    const dataLine = text
+      .split("\n")
+      .find((line) => line.startsWith("data: ") && line.includes('"error"'));
+    assert.ok(dataLine, `expected an SSE error frame, got body: ${text}`);
+    const payload = JSON.parse(dataLine!.slice("data: ".length));
+    const message: string = payload?.error?.message ?? "";
+
+    assert.match(
+      message,
+      /Auggie CLI not found/,
+      `expected the actionable 'Auggie CLI not found' message, but got: ${message}`
+    );
+    assert.doesNotMatch(
+      message,
+      /exited with code/i,
+      `expected the raw shell exit-code text to be replaced, but got: ${message}`
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

`open-sse/executors/auggie.ts`'s `close` handlers in `AuggieExecutor.runStreaming()` and
`runNonStreaming()` only ever routed a Node-level spawn `error` event through
`isEnoentLike()` → `cliNotFoundMessage()`. On win32 (and any POSIX shell that reports a
missing binary via a normal non-zero exit rather than a spawn error — the shape this
buildAuggieSpawnOptions/`shell:true` codepath produces, added for #6304), a missing
`auggie` binary surfaces as `close` with stderr text like `'auggie' is not recognized as
an internal or external command` or `sh: 1: auggie: not found` — a shape the `close`
handlers never checked, so they surfaced the raw, confusing shell text instead of the
existing, already-written friendly "Auggie CLI not found ... install it and run `auggie
login`" message.

## Fix

Added `isCliNotFoundText()` to recognize the shell-reported "not found" shapes (Windows
cmd.exe, POSIX `sh`/dash, "No such file or directory") and route the `runStreaming()` and
`runNonStreaming()` close handlers through `cliNotFoundMessage(auggieBin)` when the
accumulated stderr matches, before falling back to the raw
`Auggie CLI exited with code N: <stderr>` text. `initAuggieModels()`'s close handler is
unaffected — it already degrades silently to an empty live-model set on any non-zero
exit, with no user-facing text to fix (per the plan-file's own note).

## Regression test

`tests/unit/auggie-cli-not-found-shell-exit-12645.test.ts` — a fake `auggie` shell script
exits 1 with the exact reported stderr text, for both `stream: true` and `stream: false`.

- **RED** (before the fix, via the plan-file's proven probe and my own initial run):
  `ACTUAL error message: Auggie CLI exited with code 1: 'auggie' is not recognized as an
  internal or external command,` — the raw text reported in #12645.
- **GREEN** (after the fix): both cases assert the response contains `Auggie CLI not
  found` and no longer contains the raw shell text (`is not recognized as an internal or
  external command` / `exited with code`).

Note: `cliNotFoundMessage()`'s `sanitizeErrorMessage()` call redacts the absolute CLI bin
path from the final message (pre-existing, unrelated `errorPathRedaction.ts` behavior —
same as the existing `execute() surfaces a sanitized 'CLI not found' error on ENOENT`
tests in `auggie-executor.test.ts`), so the regression test's assertions match that
existing precedent rather than asserting the full "Install it and run auggie login"
sentence verbatim.

## Gates run

- `node --import tsx/esm --test tests/unit/auggie-cli-not-found-shell-exit-12645.test.ts` — 2/2 GREEN
- `node --import tsx/esm --test tests/unit/auggie-executor.test.ts tests/unit/auggie-win32-spawn-6304.test.ts tests/unit/auggie-cli-not-found-shell-exit-12645.test.ts` — 30/30 GREEN (no regressions)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/executors/auggie.ts tests/unit/auggie-cli-not-found-shell-exit-12645.test.ts` — clean
- `node scripts/check/check-changelog-integrity.mjs` — OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync

Closes #12645
