### PR TITLE
fix(oauth): align codebuddy-cn OAuth User-Agent with chat/usage (#12702)

### DIFF
--- a/changelog.d/fixes/12702-codebuddy-cn-useragent-consistency.md
+++ b/changelog.d/fixes/12702-codebuddy-cn-useragent-consistency.md
@@ -1,0 +1,1 @@
+- fix(oauth): align codebuddy-cn OAuth User-Agent with the chat/usage CLI version to avoid WAF false positives (#12702)

--- a/open-sse/config/providers/registry/codebuddy-cn/index.ts
+++ b/open-sse/config/providers/registry/codebuddy-cn/index.ts
@@ -1,3 +1,4 @@
+import { CODEBUDDY_CN_USER_AGENT } from "@/lib/oauth/constants/oauth";
 import type { RegistryEntry } from "../../shared.ts";
 
 /**
@@ -20,7 +21,7 @@ export const codebuddy_cnProvider: RegistryEntry = {
   authType: "oauth",
   authHeader: "bearer",
   headers: {
-    "User-Agent": "CLI/2.108.1 CodeBuddy/2.108.1",
+    "User-Agent": CODEBUDDY_CN_USER_AGENT,
     "X-Product": "SaaS",
     "X-IDE-Type": "CLI",
     "X-IDE-Name": "CLI",

--- a/open-sse/services/usage/codebuddy-cn.ts
+++ b/open-sse/services/usage/codebuddy-cn.ts
@@ -14,6 +14,8 @@
  * packs, "Bonus Pack N" for bonus packs (soonest-expiring first).
  */
 
+import { CODEBUDDY_CN_USER_AGENT } from "@/lib/oauth/constants/oauth";
+
 const USAGE_URL = "https://copilot.tencent.com/v2/billing/meter/get-user-resource";
 
 interface TencentAccount {
@@ -130,7 +132,7 @@ export async function getCodeBuddyCnUsage(
         Authorization: `Bearer ${token}`,
         "Content-Type": "application/json",
         Accept: "application/json",
-        "User-Agent": "CLI/2.108.1 CodeBuddy/2.108.1",
+        "User-Agent": CODEBUDDY_CN_USER_AGENT,
         "X-Product": "SaaS",
         "X-IDE-Type": "CLI",
         "X-IDE-Name": "CLI",

--- a/src/lib/oauth/constants/oauth.ts
+++ b/src/lib/oauth/constants/oauth.ts
@@ -106,12 +106,21 @@ export const QODER_CONFIG = {
 // CodeBuddy CN (Tencent — copilot.tencent.com) OAuth Configuration
 // (Custom Device-Auth Flow: POST stateUrl → open authUrl → GET pollUrl?state=).
 // No client_id/secret — the upstream CLI ships none.
+//
+// CODEBUDDY_CN_USER_AGENT is the single source of truth for the CLI/CodeBuddy version
+// string. It MUST stay identical across OAuth (this file), chat completions
+// (open-sse/config/providers/registry/codebuddy-cn/index.ts) and usage/quota
+// (open-sse/services/usage/codebuddy-cn.ts) — a mismatched version string across a
+// single account's auth vs. chat calls is exactly the kind of internally-inconsistent
+// client fingerprint Tencent's WAF flags as anomalous (#12702).
+export const CODEBUDDY_CN_USER_AGENT = "CLI/2.108.1 CodeBuddy/2.108.1";
+
 export const CODEBUDDY_CN_CONFIG = {
   baseUrl: "https://copilot.tencent.com",
   stateUrl: "https://copilot.tencent.com/v2/plugin/auth/state",
   tokenUrl: "https://copilot.tencent.com/v2/plugin/auth/token",
   refreshUrl: "https://copilot.tencent.com/v2/plugin/auth/token/refresh",
-  userAgent: "CLI/2.63.2 CodeBuddy/2.63.2",
+  userAgent: CODEBUDDY_CN_USER_AGENT,
   platform: "CLI",
   pollInterval: 5000,
 };

--- a/tests/unit/codebuddy-cn-provider.test.ts
+++ b/tests/unit/codebuddy-cn-provider.test.ts
@@ -585,3 +585,38 @@ test("codebuddy-cn is treated as a managed dual-auth provider (oauth + apikey ac
     "codebuddy-cn must be admitted by the dual-auth gate"
   );
 });
+
+test("#12702: codebuddy-cn presents the same CLI/CodeBuddy version across OAuth, chat and usage calls", async () => {
+  // A mismatched version string across a single account's auth vs. chat calls is exactly the
+  // kind of internally-inconsistent client fingerprint Tencent's WAF flags as anomalous
+  // (code 11128 "request illegal" / "blocked by security policy"). All three surfaces must
+  // read from the same CODEBUDDY_CN_USER_AGENT constant so they can never drift apart again.
+  const oauthUserAgent = CODEBUDDY_CN_CONFIG.userAgent;
+  const chatUserAgent = REGISTRY["codebuddy-cn"].headers?.["User-Agent"];
+  assert.equal(
+    oauthUserAgent,
+    chatUserAgent,
+    `codebuddy-cn OAuth User-Agent (${oauthUserAgent}) must match the chat User-Agent (${chatUserAgent})`
+  );
+
+  const { CODEBUDDY_CN_USER_AGENT } = await import("../../src/lib/oauth/constants/oauth.ts");
+  assert.equal(oauthUserAgent, CODEBUDDY_CN_USER_AGENT);
+
+  const origFetch = globalThis.fetch;
+  let capturedUserAgent: string | undefined;
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    capturedUserAgent = (init?.headers as Record<string, string> | undefined)?.["User-Agent"];
+    return new Response(JSON.stringify({}), { status: 200 });
+  }) as typeof fetch;
+  try {
+    const { getCodeBuddyCnUsage } = await import("../../open-sse/services/usage/codebuddy-cn.ts");
+    await getCodeBuddyCnUsage("ACCESS_TOKEN", undefined, undefined);
+    assert.equal(
+      capturedUserAgent,
+      CODEBUDDY_CN_USER_AGENT,
+      "codebuddy-cn usage/quota User-Agent must match the shared constant"
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});


### PR DESCRIPTION
Closes #12702

## Root cause

Reporter (third-party "deepseek harness" client → codebuddy-cn provider) got a hard 400 from
Tencent's `copilot.tencent.com` gateway: `code 11128 "request illegal"`, `displayMsg: "The
request was blocked by security policy."` — CodeBuddy's own WAF, not the content-sensitivity
rejection OmniRoute already retries around (#6535 / #9723).

Static analysis found a genuine, reproducible defect in OmniRoute's own codebuddy-cn
integration: the OAuth device-code auth/poll and token-refresh calls presented
`CLI/2.63.2 CodeBuddy/2.63.2` (`src/lib/oauth/constants/oauth.ts`), while chat-completion
requests and usage/quota requests presented `CLI/2.108.1 CodeBuddy/2.108.1` — the same
logical account/token advertising two CLI identities 45 minor versions apart across its own
auth vs. chat calls. That is exactly the kind of internally-inconsistent client fingerprint an
anti-abuse WAF flags as anomalous, and matches the reporter's own suspicion ("Codebuddy CN has
strengthened its security measures"). The mismatch has existed unchanged since the provider was
added (commit a7ae9550, 2026-06-25).

This is a plausible (not live-verified) root cause for the reporter's specific 400 — CodeBuddy's
WAF internals are opaque — but it is an independently real defect worth fixing regardless.

## Fix

- Centralized the version string into `CODEBUDDY_CN_USER_AGENT` (exported from
  `src/lib/oauth/constants/oauth.ts`, set to the chat/usage value `CLI/2.108.1
  CodeBuddy/2.108.1`).
- `CODEBUDDY_CN_CONFIG.userAgent` now reads from that constant, so OAuth device-code
  auth/poll (`src/lib/oauth/providers/codebuddy-cn.ts`) and token refresh
  (`open-sse/services/tokenRefresh/providers/codebuddyCn.ts`, which already dynamically
  imports `CODEBUDDY_CN_CONFIG`) pick it up automatically.
- The chat registry entry (`open-sse/config/providers/registry/codebuddy-cn/index.ts`) and the
  usage/quota handler (`open-sse/services/usage/codebuddy-cn.ts`) now import and use the same
  constant instead of a duplicated literal, so auth/chat/usage can never silently drift apart
  again.

## Regression test

Added to `tests/unit/codebuddy-cn-provider.test.ts` — `#12702: codebuddy-cn presents the same
CLI/CodeBuddy version across OAuth, chat and usage calls`:
- asserts `CODEBUDDY_CN_CONFIG.userAgent === REGISTRY["codebuddy-cn"].headers["User-Agent"]`
- asserts both equal the exported `CODEBUDDY_CN_USER_AGENT` constant
- mocks `fetch` through `getCodeBuddyCnUsage()` and asserts the outgoing `User-Agent` header
  matches the constant

RED → GREEN:
- RED (before fix, standalone probe reproducing the same assertion):
  `actual: 'CLI/2.63.2 CodeBuddy/2.63.2', expected: 'CLI/2.108.1 CodeBuddy/2.108.1'`
- GREEN (after fix): `node --import tsx/esm --test tests/unit/codebuddy-cn-provider.test.ts` →
  24 tests, 24 pass (including the new one), 0 fail.

## Gates run

- `node scripts/check/check-file-size.mjs` → OK
- `node scripts/check/check-complexity.mjs` → OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` → clean, no diagnostics
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` →
  clean
- `node --import tsx/esm --test tests/unit/codebuddy-cn-provider.test.ts` → 24/24 pass
- `node --import tsx/esm --test tests/unit/codebuddy-reasoning-optin.test.ts` → 6/6 pass
- `node --import tsx/esm --test tests/unit/oauth-providers-config.test.ts
  tests/unit/oauth-device-code-error-transparency.test.ts
  tests/unit/oauth-device-code-endpoints.test.ts` → 27/27 pass
- `node --import tsx/esm --test tests/unit/responsesanitizer-reasoning-split.test.ts
  tests/unit/8431-multiwindow-quota-eviction.test.ts` → 30/30 pass
- `node scripts/check/check-changelog-integrity.mjs` → OK

## Live verification

No live codebuddy-cn OAuth account was available in this session to run an end-to-end VPS smoke
test (Hard Rule #18 real-environment path). This is a low-risk, mechanical header-value fix (no
request shape, auth flow, or model behavior change), backed by the regression test above. Asking
the reporter to re-authenticate codebuddy-cn (so the corrected User-Agent is used on the next
token refresh) and re-test once this ships; will follow up / reopen if they still see the 400.

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact,
tarball-smoke, agent-skills-sync
