### PR TITLE
feat(usage): show separate Fable weekly limits

### DIFF
--- a/open-sse/services/usage/claude.ts
+++ b/open-sse/services/usage/claude.ts
@@ -9,6 +9,7 @@
  * getClaudePlanLabel (__testing). Behavior-preserving move.
  */
 
+import { z } from "zod";
 import { safePercentage } from "@/shared/utils/formatting";
 import { getClaudeCodeVersion, fetchClaudeBootstrap } from "../../executors/claudeIdentity.ts";
 import { isClaudeOauthUsageCoolingDown, markClaudeOauthUsage429 } from "../claudeUsageCooldown.ts";
@@ -16,6 +17,13 @@ import { toRecord } from "./scalars.ts";
 import { type UsageQuota, parseResetTime } from "./quota.ts";
 
 type JsonRecord = Record<string, unknown>;
+
+const FABLE_WEEKLY_LIMIT_SCHEMA = z.object({
+  kind: z.literal("weekly_scoped"),
+  percent: z.number().min(0).max(100),
+  resets_at: z.string().nullable().optional(),
+  scope: z.object({ model: z.object({ display_name: z.literal("Fable") }) }),
+});
 
 // Claude API config
 const CLAUDE_CONFIG = {
@@ -125,6 +133,17 @@ export async function getClaudeUsage(accessToken?: string) {
         }
       }
 
+      // Display-only model limits must not enter account-wide routing quotas.
+      const modelQuotas: Record<string, UsageQuota> = {};
+      for (const limit of Array.isArray(data.limits) ? data.limits : []) {
+        const parsed = FABLE_WEEKLY_LIMIT_SCHEMA.safeParse(limit);
+        if (!parsed.success) continue;
+        modelQuotas["weekly fable (7d)"] = createQuotaObject({
+          utilization: parsed.data.percent,
+          resets_at: parsed.data.resets_at,
+        });
+      }
+
       const bootstrap = await bootstrapPromise;
       const plan =
         getClaudePlanLabel(
@@ -137,6 +156,7 @@ export async function getClaudeUsage(accessToken?: string) {
       return {
         ...(plan ? { plan } : {}),
         quotas,
+        modelQuotas,
         extraUsage: data.extra_usage ?? null,
         bootstrap,
       };

--- a/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing.ts
+++ b/src/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing.ts
@@ -267,8 +267,8 @@ function parseClaude(data: any) {
   if (data?.message)
     return [{ name: "error", used: 0, total: 0, resetAt: null, message: data.message }];
 
-  const quotas = quotaEntries(data).map(([name, quota]) =>
-    normalizeQuotaEntry(name, quota, { isPercentageOnly: true })
+  const quotas = quotaEntries({ quotas: { ...data.quotas, ...data.modelQuotas } }).map(
+    ([name, quota]) => normalizeQuotaEntry(name, quota, { isPercentageOnly: true })
   );
 
   if (data?.extraUsage?.is_enabled) {

--- a/src/lib/db/providerLimits.ts
+++ b/src/lib/db/providerLimits.ts
@@ -24,6 +24,7 @@ interface KeyValueRow {
 
 export interface ProviderLimitsCacheEntry {
   quotas: JsonRecord | null;
+  modelQuotas?: JsonRecord;
   plan: unknown;
   message: string | null;
   fetchedAt: string;
@@ -62,9 +63,11 @@ function normalizeCacheEntry(value: unknown): ProviderLimitsCacheEntry | null {
 
   const bankedResetCredits = Number(record.bankedResetCredits);
   const billing = sanitizeProviderBillingStatus(record.billing);
+  const modelQuotas = toRecord(record.modelQuotas);
 
   return {
     quotas: toRecord(record.quotas),
+    ...(modelQuotas ? { modelQuotas } : {}),
     plan: record.plan ?? null,
     message: typeof record.message === "string" ? record.message : null,
     fetchedAt,

--- a/src/lib/usage/providerLimits.ts
+++ b/src/lib/usage/providerLimits.ts
@@ -902,6 +902,7 @@ export async function fetchAndPersistProviderLimits(
     const staleUsage: JsonRecord = {
       ...usage,
       quotas: previous.quotas,
+      modelQuotas: previous.modelQuotas,
       plan: previous.plan ?? usage.plan ?? null,
       bankedResetCredits: previous.bankedResetCredits,
       billing: previous.billing,

--- a/src/lib/usage/providerLimitsCache.ts
+++ b/src/lib/usage/providerLimitsCache.ts
@@ -22,6 +22,7 @@ export function toProviderLimitsCacheEntry(
   const bankedResetCredits = Number(usage.bankedResetCredits);
   return {
     quotas: isRecord(usage.quotas) ? usage.quotas : null,
+    ...(isRecord(usage.modelQuotas) ? { modelQuotas: usage.modelQuotas } : {}),
     plan: usage.plan ?? null,
     message: typeof usage.message === "string" ? usage.message : null,
     fetchedAt,

--- a/tests/unit/claude-fable-usage.test.ts
+++ b/tests/unit/claude-fable-usage.test.ts
@@ -1,0 +1,160 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-fable-usage-"));
+process.env.DATA_DIR = dataDir;
+process.env.API_KEY_SECRET = "fable-usage-test-secret";
+
+const { getClaudeUsage } = await import("../../open-sse/services/usage/claude.ts");
+const { parseQuotaData } =
+  await import("../../src/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing.ts");
+const { GET } = await import("../../src/app/api/usage/[connectionId]/route.ts");
+const { createProviderConnection } = await import("../../src/lib/db/providers.ts");
+const { getProviderLimitsCache } = await import("../../src/lib/db/providerLimits.ts");
+const { getQuotaCache } = await import("../../src/domain/quotaCache.ts");
+const { resetDbInstance } = await import("../../src/lib/db/core.ts");
+const originalFetch = globalThis.fetch;
+const resetAt = "2099-09-10T15:59:59.522764+00:00";
+const normalizedResetAt = "2099-09-10T15:59:59.522Z";
+const fableKey = "weekly fable (7d)";
+
+function scopedLimit(percent: unknown = 100) {
+  return {
+    kind: "weekly_scoped",
+    group: "weekly",
+    percent,
+    resets_at: resetAt,
+    scope: { model: { display_name: "Fable" } },
+  };
+}
+
+function mockUsage(limits: unknown, unavailable = false) {
+  globalThis.fetch = async (url) => {
+    if (String(url).endsWith("/api/oauth/usage") && !unavailable) {
+      return Response.json({
+        five_hour: { utilization: 12, resets_at: "2099-09-10T14:00:00Z" },
+        seven_day: { utilization: 34, resets_at: "2099-09-16T13:00:00Z" },
+        seven_day_omelette: null,
+        limits,
+      });
+    }
+    return new Response(null, { status: 503 });
+  };
+}
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test.after(() => {
+  resetDbInstance();
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+test("Fable percentages remain separate from shared quotas and render as percentage rows", async () => {
+  for (const percent of [0, 27.5, 100]) {
+    mockUsage([scopedLimit(percent)]);
+    const usage = await getClaudeUsage("fable-test-token");
+    const rows = parseQuotaData("claude", usage);
+    const fable = rows.find((row) => row.name === fableKey);
+    assert.ok(fable, `missing Fable row for ${percent}% used`);
+    assert.equal(fable.used, percent);
+    assert.equal(fable.remainingPercentage, 100 - percent);
+    assert.equal(fable.resetAt, normalizedResetAt);
+    assert.ok("modelQuotas" in usage);
+    assert.equal(usage.modelQuotas[fableKey].unlimited, false);
+    assert.notEqual(fable.unlimited, true);
+    assert.equal(fable.isPercentageOnly, true);
+    assert.equal(rows.find((row) => row.name === "session (5h)")?.used, 12);
+    assert.equal(rows.find((row) => row.name === "weekly (7d)")?.used, 34);
+    assert.equal(rows.length, 3);
+  }
+});
+
+test("missing or invalid Fable telemetry never becomes a zero or unlimited quota", async () => {
+  for (const limits of [
+    undefined,
+    null,
+    {},
+    [],
+    [null],
+    [scopedLimit(null)],
+    [scopedLimit("100")],
+    [scopedLimit(-1)],
+    [scopedLimit(101)],
+    [{ ...scopedLimit(), kind: "weekly_all" }],
+    [{ ...scopedLimit(), scope: null }],
+    [{ ...scopedLimit(), scope: { model: { display_name: "Something else" } } }],
+  ]) {
+    mockUsage(limits);
+    const rows = parseQuotaData("claude", await getClaudeUsage("fable-test-token"));
+    assert.equal(rows.length, 2);
+    assert.equal(
+      rows.some((row) => row.name === fableKey),
+      false
+    );
+  }
+});
+
+test("Fable reset data stays independent and missing resets stay unknown", async () => {
+  for (const resets_at of [null, "invalid", "2099-09-17T16:00:00Z"]) {
+    mockUsage([{ ...scopedLimit(), resets_at }]);
+    const rows = parseQuotaData("claude", await getClaudeUsage("fable-test-token"));
+    assert.equal(
+      rows.find((row) => row.name === fableKey)?.resetAt,
+      resets_at === "2099-09-17T16:00:00Z" ? "2099-09-17T16:00:00.000Z" : null
+    );
+  }
+});
+
+test("usage API persists per-account Fable rows without changing account-wide routing quotas", async () => {
+  const ids: string[] = [];
+  for (const percent of [100, 25]) {
+    const connection = await createProviderConnection({
+      provider: "claude",
+      authType: "oauth",
+      name: `Fable usage ${percent}`,
+      email: `fable-${percent}@example.test`,
+      accessToken: `fable-token-${percent}`,
+      isActive: true,
+      expiresAt: "2099-01-01T00:00:00Z",
+    });
+    const id = connection.id as string;
+    ids.push(id);
+    mockUsage([scopedLimit(percent)]);
+    const response = await GET(new Request("http://localhost/api/usage/test"), {
+      params: Promise.resolve({ connectionId: id }),
+    });
+    assert.equal(response.status, 200);
+    const usage = await response.json();
+    assert.equal(
+      parseQuotaData("claude", usage).find((row) => row.name === fableKey)?.used,
+      percent
+    );
+    assert.equal(
+      parseQuotaData("claude", getProviderLimitsCache(id)).find((row) => row.name === fableKey)
+        ?.used,
+      percent
+    );
+    assert.deepEqual(Object.keys(getQuotaCache(id)?.quotas ?? {}).sort(), [
+      "session (5h)",
+      "weekly (7d)",
+    ]);
+  }
+  assert.equal(
+    parseQuotaData("claude", getProviderLimitsCache(ids[0])).find((row) => row.name === fableKey)
+      ?.used,
+    100
+  );
+
+  mockUsage(null, true);
+  const staleResponse = await GET(new Request("http://localhost/api/usage/test"), {
+    params: Promise.resolve({ connectionId: ids[0] }),
+  });
+  const stale = await staleResponse.json();
+  assert.equal(stale._stale, true);
+  assert.equal(parseQuotaData("claude", stale).find((row) => row.name === fableKey)?.used, 100);
+});

--- a/tests/unit/fable-quota-rendering.test.tsx
+++ b/tests/unit/fable-quota-rendering.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, it, vi } from "vitest";
+import { parseQuotaData } from "@/app/(dashboard)/dashboard/usage/components/ProviderLimits/quotaParsing";
+import QuotaCardExpanded from "@/app/(dashboard)/dashboard/usage/components/ProviderLimits/parts/QuotaCardExpanded";
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en-US",
+  useTranslations: () => Object.assign((key: string) => key, { has: () => false }),
+}));
+
+it("renders an exhausted Fable meter beside the independent shared windows", () => {
+  const window = (used: number) => ({
+    used,
+    total: 100,
+    remaining: 100 - used,
+    remainingPercentage: 100 - used,
+    resetAt: "2099-09-10T16:00:00Z",
+    unlimited: false,
+  });
+  const quotas = parseQuotaData("claude", {
+    quotas: { "session (5h)": window(12), "weekly (7d)": window(34) },
+    modelQuotas: { "weekly fable (7d)": window(100) },
+  });
+  const html = renderToStaticMarkup(
+    <QuotaCardExpanded
+      quotas={quotas}
+      providerId="claude"
+      loading={false}
+      error={null}
+      hasStaleData={false}
+      onRefresh={() => {}}
+      onOpenCutoff={() => {}}
+      onOpenCost={() => {}}
+      canEditCutoff={false}
+      hasCutoffOverrides={false}
+    />
+  );
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  expect(root.querySelector('[title="weekly fable (7d)"]')?.textContent).toContain("Weekly Fable");
+  expect(root.querySelector('[title="weekly fable (7d)"]')?.textContent).toContain("0% left");
+  expect(root.querySelector('[title="session (5h)"]')?.textContent).toContain("88% left");
+  expect(root.querySelector('[title="weekly (7d)"]')?.textContent).toContain("66% left");
+});


### PR DESCRIPTION
Closes #13210.

Claude OAuth usage now includes the upstream **weekly Fable limit** in the usage API and
dashboard. shared five-hour and weekly meters remain unchanged.

## why now

Anthropic reports Fable usage as a `limits[]` entry with `kind: "weekly_scoped"` and a
`Fable` model scope. OmniRoute ignored that array, so users could not see the separate pool.

## what changed

| area | change |
|---|---|
| Claude usage parser | validates the scoped Fable entry and converts its used percentage with the existing quota helper |
| provider limits cache | persists `modelQuotas` and restores it on stale-data fallback |
| dashboard parser | renders the model quota beside the shared Claude meters |
| tests | covers used, exhausted, missing, malformed, cached, stale, and per-account data |

`modelQuotas` stays separate from account-wide `quotas`. the Fable meter is display-only and
does not affect routing, account selection, or cooldowns.

## how to test

```sh
node --import tsx/esm --test tests/unit/claude-fable-usage.test.ts
npx vitest run tests/unit/fable-quota-rendering.test.tsx
```

<details><summary>other checks</summary>

targeted ESLint and Prettier checks pass. `npm run typecheck:core` also passes.

</details>
