### PR TITLE
fix(cache): include tool_choice/tools/response_format in semantic cache signature (#12734)

### DIFF
--- a/changelog.d/fixes/12734-semantic-cache-tool-choice.md
+++ b/changelog.d/fixes/12734-semantic-cache-tool-choice.md
@@ -1,0 +1,1 @@
+- fix(cache): fold tool_choice/tools/response_format into the semantic cache signature so a cached tool_calls response can no longer be replayed for a request whose tool policy forbids it (#12734)

--- a/open-sse/handlers/chatCore/semanticCache.ts
+++ b/open-sse/handlers/chatCore/semanticCache.ts
@@ -29,7 +29,13 @@ export async function checkSemanticCache({
   semanticCacheEnabled: boolean;
   // Only the fields this read path actually touches are named; everything else
   // on the request body stays `unknown` via the index signature.
-  body: Record<string, unknown> & { temperature?: number; top_p?: number };
+  body: Record<string, unknown> & {
+    temperature?: number;
+    top_p?: number;
+    tool_choice?: unknown;
+    tools?: unknown;
+    response_format?: unknown;
+  };
   clientRawRequest: { headers?: unknown } | null;
   model: string;
   provider: string;
@@ -51,7 +57,8 @@ export async function checkSemanticCache({
       body.messages ?? body.input,
       body.temperature,
       body.top_p,
-      apiKeyId ?? undefined
+      apiKeyId ?? undefined,
+      { toolChoice: body.tool_choice, tools: body.tools, responseFormat: body.response_format }
     );
     const cached = getCachedResponse(signature);
     if (cached) {

--- a/open-sse/handlers/chatCore/semanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/semanticCacheStore.ts
@@ -22,6 +22,9 @@ type CacheBody = {
   input?: unknown;
   temperature?: number;
   top_p?: number;
+  tool_choice?: unknown;
+  tools?: unknown;
+  response_format?: unknown;
 };
 
 type UsageLike = { prompt_tokens?: number; completion_tokens?: number } | null | undefined;
@@ -65,7 +68,12 @@ export function storeSemanticCacheResponse(
     args.body.messages ?? args.body.input,
     args.body.temperature,
     args.body.top_p,
-    args.apiKeyId ?? undefined
+    args.apiKeyId ?? undefined,
+    {
+      toolChoice: args.body.tool_choice,
+      tools: args.body.tools,
+      responseFormat: args.body.response_format,
+    }
   );
   const tokensSaved = args.usage?.prompt_tokens + args.usage?.completion_tokens || 0;
   deps.setCachedResponse(signature, args.model, args.translatedResponse, tokensSaved);

--- a/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
+++ b/open-sse/handlers/chatCore/streamingSemanticCacheStore.ts
@@ -23,6 +23,9 @@ type CacheBody = {
   input?: unknown;
   temperature?: number;
   top_p?: number;
+  tool_choice?: unknown;
+  tools?: unknown;
+  response_format?: unknown;
 };
 
 export interface StreamingSemanticCacheStoreDeps {
@@ -69,7 +72,12 @@ function writeStreamingCacheEntry(
       args.body.messages ?? args.body.input,
       args.body.temperature,
       args.body.top_p,
-      args.apiKeyId ?? undefined
+      args.apiKeyId ?? undefined,
+      {
+        toolChoice: args.body.tool_choice,
+        tools: args.body.tools,
+        responseFormat: args.body.response_format,
+      }
     );
     const tokensSaved = streamTokensSaved(args.streamUsage);
     deps.setCachedResponse(sig, args.model, cleanBody, tokensSaved);

--- a/src/lib/semanticCache.ts
+++ b/src/lib/semanticCache.ts
@@ -138,12 +138,51 @@ export function clearMemoryCache(): void {
 // ─── Signature Generation ─────────────────
 
 /**
+ * Behavior-changing generation constraints that MUST be folded into the cache signature
+ * (#12734). Without these, a cached response produced under one `tool_choice`/`tools`/
+ * `response_format` could be replayed for a later request that forbids or changes that
+ * behavior (e.g. a cached `tool_calls` response served to a `tool_choice: "none"` request).
+ */
+export interface SignatureConstraints {
+  toolChoice?: unknown;
+  tools?: unknown;
+  responseFormat?: unknown;
+}
+
+/** Normalize a single tool definition, keeping only the fields that define its policy. */
+function normalizeTool(tool: unknown): unknown {
+  const record = asRecord(tool);
+  const fn = asRecord(record.function);
+  if (Object.keys(fn).length === 0 && Object.keys(record).length === 0) return tool;
+  return {
+    type: typeof record.type === "string" ? record.type : "function",
+    function: {
+      name: fn.name,
+      description: fn.description,
+      parameters: fn.parameters,
+    },
+  };
+}
+
+/**
+ * Normalize `tools` for consistent hashing (mirrors `normalizeConversation` for messages):
+ * strips volatile/irrelevant fields while keeping name/description/parameters, which are
+ * what actually define the tool policy a cached response was generated under.
+ */
+function normalizeTools(tools: unknown): unknown {
+  if (!Array.isArray(tools) || tools.length === 0) return undefined;
+  return tools.map(normalizeTool);
+}
+
+/**
  * Generate deterministic cache signature from request params.
  * @param {string} model
  * @param {Array} messages - Normalized messages array
  * @param {number} temperature
  * @param {number} topP
  * @param {string} [apiKeyId] - API key ID for per-key isolation (prevents cross-user cache hits)
+ * @param {SignatureConstraints} [constraints] - tool_choice/tools/response_format (#12734):
+ *   these change model behavior and must not collide with a signature computed without them.
  * @returns {string} hex signature
  */
 export function generateSignature(
@@ -151,13 +190,17 @@ export function generateSignature(
   conversation,
   temperature = 0,
   topP = 1,
-  apiKeyId?: string
+  apiKeyId?: string,
+  constraints?: SignatureConstraints
 ) {
   const payload = JSON.stringify({
     model,
     messages: normalizeConversation(conversation),
     temperature,
     top_p: topP,
+    tool_choice: constraints?.toolChoice,
+    tools: normalizeTools(constraints?.tools),
+    response_format: constraints?.responseFormat,
   });
   const digest = crypto.createHash("sha256").update(payload).digest("hex");
   // Per-key cache isolation (#3740) namespaces the signature with the apiKeyId as a

--- a/tests/unit/chatcore-semantic-cache-store.test.ts
+++ b/tests/unit/chatcore-semantic-cache-store.test.ts
@@ -135,3 +135,38 @@ test("missing usage → tokensSaved coerces to 0 (NaN || 0)", () => {
   storeSemanticCacheResponse(baseArgs({ usage: undefined }), deps);
   assert.equal(stored[0].tokens, 0);
 });
+
+// #12734: tool_choice/tools/response_format must reach generateSignature so a cached
+// tool_calls response cannot be replayed under a stricter tool policy.
+test("signature is called with tool_choice/tools/response_format from body (#12734)", () => {
+  let captured: unknown[] = [];
+  const { deps } = makeDeps({
+    generateSignature: (...a: unknown[]) => {
+      captured = a;
+      return "sig";
+    },
+  });
+  const tools = [{ type: "function", function: { name: "get_weather" } }];
+  storeSemanticCacheResponse(
+    baseArgs({
+      body: {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0,
+        top_p: 1,
+        tool_choice: "none",
+        tools,
+        response_format: { type: "json_object" },
+      },
+    }),
+    deps
+  );
+  // args: (model, messages ?? input, temperature, top_p, apiKeyId, constraints)
+  const constraints = captured[5] as {
+    toolChoice: unknown;
+    tools: unknown;
+    responseFormat: unknown;
+  };
+  assert.equal(constraints.toolChoice, "none");
+  assert.deepEqual(constraints.tools, tools);
+  assert.deepEqual(constraints.responseFormat, { type: "json_object" });
+});

--- a/tests/unit/chatcore-semantic-cache.test.ts
+++ b/tests/unit/chatcore-semantic-cache.test.ts
@@ -180,12 +180,14 @@ function makeHitArgs(overrides: Record<string, unknown> = {}) {
 
 // Seed the cache under the EXACT signature checkSemanticCache rebuilds for `args`.
 function seedHit(args: ReturnType<typeof makeHitArgs>["args"], response: unknown) {
+  const body = args.body as Record<string, unknown>;
   const signature = generateSignature(
     args.model,
-    args.body.messages ?? (args.body as Record<string, unknown>).input,
+    body.messages ?? body.input,
     args.body.temperature,
-    (args.body as Record<string, unknown>).top_p,
-    args.apiKeyId ?? undefined
+    body.top_p,
+    args.apiKeyId ?? undefined,
+    { toolChoice: body.tool_choice, tools: body.tools, responseFormat: body.response_format }
   );
   setCachedResponse(signature, args.model, response);
   return signature;
@@ -491,4 +493,77 @@ test("checkSemanticCache HIT includes X-OmniRoute-Cache-Latency: synthetic heade
     "synthetic",
     "HIT response carries X-OmniRoute-Cache-Latency: synthetic marker"
   );
+});
+
+// ─── tool_choice / tools / response_format must be part of the signature (#12734) ────────────
+
+test("#12734: cached tool_calls response must NOT be replayed for tool_choice: 'none'", async () => {
+  clearCache();
+  const messages = [{ role: "user", content: "what is 2+2?" }];
+  const toolCallResponse = {
+    id: "chatcmpl-tool-calls",
+    choices: [
+      {
+        index: 0,
+        finish_reason: "tool_calls",
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "call_1", type: "function", function: { name: "memory_search", arguments: "{}" } },
+          ],
+        },
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+  // Stored under a body with NO tool_choice (mirrors the real pipeline: the cache check
+  // runs before memory/skill tool injection, so the signature it stores under never saw
+  // tool_choice at all).
+  const { args: storeArgs } = makeHitArgs({ body: { model: "gpt-4o", messages, temperature: 0 } });
+  seedHit(storeArgs, toolCallResponse);
+
+  const { args: forbidArgs } = makeHitArgs({
+    body: { model: "gpt-4o", messages, temperature: 0, tool_choice: "none" },
+  });
+  const result = await checkSemanticCache(forbidArgs as Parameters<typeof checkSemanticCache>[0]);
+
+  assert.equal(
+    result,
+    null,
+    "a tool_choice:'none' request must be a cache MISS against a tool_calls response cached without tool_choice"
+  );
+});
+
+test("#12734: identical tool_choice/tools/response_format across requests still HITs", async () => {
+  clearCache();
+  const messages = [{ role: "user", content: "what is the weather?" }];
+  const tools = [
+    {
+      type: "function",
+      function: { name: "get_weather", description: "Get the weather", parameters: { type: "object" } },
+    },
+  ];
+  const cached = {
+    id: "chatcmpl-tool-config-hit",
+    choices: [
+      { index: 0, message: { role: "assistant", content: "sunny" }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 8, completion_tokens: 2, total_tokens: 10 },
+  };
+  const body = {
+    model: "gpt-4o",
+    messages,
+    temperature: 0,
+    tool_choice: "auto",
+    tools,
+    response_format: { type: "json_object" },
+  };
+  const { args: storeArgs } = makeHitArgs({ body });
+  seedHit(storeArgs, cached);
+
+  const { args: readArgs } = makeHitArgs({ body: { ...body } });
+  const result = await checkSemanticCache(readArgs as Parameters<typeof checkSemanticCache>[0]);
+
+  assert.ok(result, "identical tool_choice/tools/response_format must still HIT");
 });

--- a/tests/unit/chatcore-streaming-cache-store.test.ts
+++ b/tests/unit/chatcore-streaming-cache-store.test.ts
@@ -127,3 +127,38 @@ test("a throwing dep is swallowed (fail-open, non-critical)", () => {
   });
   assert.doesNotThrow(() => storeStreamingSemanticCacheResponse(baseArgs(), deps));
 });
+
+// #12734: tool_choice/tools/response_format must reach generateSignature so a cached
+// tool_calls streaming response cannot be replayed under a stricter tool policy.
+test("signature is called with tool_choice/tools/response_format from body (#12734)", () => {
+  let captured: unknown[] = [];
+  const { deps } = makeDeps({
+    generateSignature: (...a: unknown[]) => {
+      captured = a;
+      return "sig";
+    },
+  });
+  const tools = [{ type: "function", function: { name: "get_weather" } }];
+  storeStreamingSemanticCacheResponse(
+    baseArgs({
+      body: {
+        messages: [{ role: "user", content: "hi" }],
+        temperature: 0,
+        top_p: 1,
+        tool_choice: "none",
+        tools,
+        response_format: { type: "json_object" },
+      },
+    }),
+    deps
+  );
+  // args: (model, messages ?? input, temperature, top_p, apiKeyId, constraints)
+  const constraints = captured[5] as {
+    toolChoice: unknown;
+    tools: unknown;
+    responseFormat: unknown;
+  };
+  assert.equal(constraints.toolChoice, "none");
+  assert.deepEqual(constraints.tools, tools);
+  assert.deepEqual(constraints.responseFormat, { type: "json_object" });
+});

--- a/tests/unit/semantic-cache.test.ts
+++ b/tests/unit/semantic-cache.test.ts
@@ -107,6 +107,81 @@ describe("Semantic Cache", () => {
       const sigKeyless = generateSignature("gpt-4o", messages, 0, 1, undefined);
       assert.notEqual(sigKeyed, sigKeyless);
     });
+
+    // #12734: tool_choice/tools/response_format change model behavior and must not be
+    // ignored by the signature — otherwise a cached tool_calls response can be replayed
+    // for a request whose tool policy forbids it.
+    describe("tool_choice / tools / response_format (#12734)", () => {
+      const messages = [{ role: "user", content: "what is 2+2?" }];
+
+      it("generates different signatures for different tool_choice ('auto' vs 'none')", () => {
+        const sig1 = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          toolChoice: "auto",
+        });
+        const sig2 = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          toolChoice: "none",
+        });
+        assert.notEqual(sig1, sig2);
+      });
+
+      it("generates different signatures for a forced-function tool_choice", () => {
+        const sig1 = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          toolChoice: "auto",
+        });
+        const sig2 = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          toolChoice: { type: "function", function: { name: "get_weather" } },
+        });
+        assert.notEqual(sig1, sig2);
+      });
+
+      it("generates different signatures for no tool_choice vs an explicit one (the #12734 collision)", () => {
+        const sigNoToolChoice = generateSignature("gpt-4o", messages, 0, 1);
+        const sigWithToolChoice = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          toolChoice: "none",
+        });
+        assert.notEqual(sigNoToolChoice, sigWithToolChoice);
+      });
+
+      it("generates different signatures for different tools arrays", () => {
+        const tools1 = [{ type: "function", function: { name: "get_weather", parameters: {} } }];
+        const tools2 = [{ type: "function", function: { name: "get_stock_price", parameters: {} } }];
+        const sig1 = generateSignature("gpt-4o", messages, 0, 1, undefined, { tools: tools1 });
+        const sig2 = generateSignature("gpt-4o", messages, 0, 1, undefined, { tools: tools2 });
+        assert.notEqual(sig1, sig2);
+      });
+
+      it("generates different signatures for different response_format", () => {
+        const sig1 = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          responseFormat: { type: "text" },
+        });
+        const sig2 = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          responseFormat: { type: "json_object" },
+        });
+        assert.notEqual(sig1, sig2);
+      });
+
+      it("generates identical signatures when constraints are identical (no hit-rate regression)", () => {
+        const tools = [{ type: "function", function: { name: "get_weather", parameters: {} } }];
+        const constraints = {
+          toolChoice: "auto",
+          tools,
+          responseFormat: { type: "json_object" },
+        };
+        const sig1 = generateSignature("gpt-4o", messages, 0, 1, undefined, constraints);
+        const sig2 = generateSignature("gpt-4o", messages, 0, 1, undefined, {
+          toolChoice: "auto",
+          tools: [{ type: "function", function: { name: "get_weather", parameters: {} } }],
+          responseFormat: { type: "json_object" },
+        });
+        assert.equal(sig1, sig2);
+      });
+
+      it("generates identical signatures for omitted constraints vs an explicitly empty constraints object", () => {
+        const sig1 = generateSignature("gpt-4o", messages, 0, 1, undefined);
+        const sig2 = generateSignature("gpt-4o", messages, 0, 1, undefined, {});
+        assert.equal(sig1, sig2);
+      });
+    });
   });
 
   describe("isCacheableForRead", () => {


### PR DESCRIPTION
Closes #12734

## Root cause

`generateSignature()` in `src/lib/semanticCache.ts` hashed only `model + normalized messages + temperature + top_p`. It never saw `tool_choice`, `tools`, or `response_format`, and all three call sites that build a cache signature (the read-path check `checkSemanticCache`, the non-streaming write `storeSemanticCacheResponse`, and the streaming write `storeStreamingSemanticCacheResponse`) only ever passed those same four fields.

Because `checkSemanticCache` runs before `injectMemoryAndSkills` in `open-sse/handlers/chatCore.ts`, a tool-less request could get memory tools injected downstream, produce a `finish_reason: tool_calls` response, and have it cached under a signature computed only from `messages`/`model`/`temperature`/`top_p`. A later request with identical messages/model/temperature but `tool_choice: "none"` (or any other tool policy) hashed to the exact same signature and was served the cached tool-call response, silently violating its tool policy.

## Fix

- `generateSignature()` now accepts an optional 6th `constraints` parameter (`{ toolChoice, tools, responseFormat }`) and folds a deterministic, normalized representation of all three into the hashed payload alongside the existing fields.
- `tools` is normalized the same way messages are (keeps `type`/`function.name`/`function.description`/`function.parameters`, drops volatile/irrelevant fields) so unrelated metadata doesn't cause spurious misses; `tool_choice` and `response_format` are hashed as-is.
- All three call sites (`open-sse/handlers/chatCore/semanticCache.ts`, `semanticCacheStore.ts`, `streamingSemanticCacheStore.ts`) now pass `body.tool_choice`/`body.tools`/`body.response_format` through, and their local `body`/`CacheBody` types were widened to name those fields.
- Omitted constraints still normalize to the same signature as before (verified by tests), so the common non-tool, non-JSON-mode case is unaffected. Old cache rows computed under the narrower scheme simply age out via the existing `semantic_cache.expires_at` TTL — no migration needed.

## Regression tests

`tests/unit/semantic-cache.test.ts` (`generateSignature`, `tool_choice / tools / response_format (#12734)` block): RED→GREEN — different `tool_choice`/`tools`/`response_format` now produce different signatures; identical constraints (including omitted vs. explicit `{}`) still produce identical signatures.

`tests/unit/chatcore-semantic-cache.test.ts` — added the exact repro from the issue:
```
node --import tsx/esm --test tests/unit/chatcore-semantic-cache.test.ts
```
- Before the fix: `checkSemanticCache` returned the cached `tool_calls` response for a `tool_choice: "none"` request (proved RED with the throwaway probe test from the plan-file, `AssertionError: - null / + { success: true, response: Response {} }`).
- After the fix: same scenario asserts `result === null` (MISS) — GREEN. Also added the inverse smoke test: identical `tool_choice`/`tools`/`response_format` across requests still HIT.

`tests/unit/chatcore-semantic-cache-store.test.ts` and `tests/unit/chatcore-streaming-cache-store.test.ts` — added assertions that `storeSemanticCacheResponse` / `storeStreamingSemanticCacheResponse` call `generateSignature` with the new `constraints` argument built from `args.body.tool_choice/tools/response_format`.

All 63 tests across the 4 touched files pass; also re-ran `tests/unit/cache-signature-roundtrip.test.ts`, `tests/unit/chat-combo-live-test.test.ts`, and the cache-related subset of `tests/unit/chatcore-translation-paths.test.ts` (existing callers of `generateSignature`/`checkSemanticCache`) — all still green, confirming the additive constraints parameter doesn't regress existing cache-hit behavior.

## Gates run

- `node scripts/check/check-file-size.mjs` → OK
- `node scripts/check/check-complexity.mjs` → OK (ratchet, no regression)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (ratchet, no regression)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → exit 0
- `node --import tsx/esm --test tests/unit/semantic-cache.test.ts tests/unit/chatcore-semantic-cache.test.ts tests/unit/chatcore-semantic-cache-store.test.ts tests/unit/chatcore-streaming-cache-store.test.ts` → 63/63 pass
- `node scripts/check/check-changelog-integrity.mjs` → OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
