### PR TITLE
fix(a2a): accept dashboard session auth on /a2a route (#12888)

### DIFF
--- a/changelog.d/fixes/12888-a2a-dashboard-auth.md
+++ b/changelog.d/fixes/12888-a2a-dashboard-auth.md
@@ -1,0 +1,1 @@
+- fix(a2a): accept the dashboard's own session cookie on /a2a so "Run message/send" no longer fails with "Unauthorized: missing or invalid API key" (#12888)

--- a/src/app/(dashboard)/dashboard/endpoint/components/A2ADashboard.tsx
+++ b/src/app/(dashboard)/dashboard/endpoint/components/A2ADashboard.tsx
@@ -201,6 +201,7 @@ export default function A2ADashboardPage() {
       const response = await fetch("/a2a", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
         body: JSON.stringify({
           jsonrpc: "2.0",
           id: "dashboard-send",
@@ -234,6 +235,7 @@ export default function A2ADashboardPage() {
       const response = await fetch("/a2a", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "same-origin",
         body: JSON.stringify({
           jsonrpc: "2.0",
           id: "dashboard-stream",

--- a/src/app/a2a/route.ts
+++ b/src/app/a2a/route.ts
@@ -187,7 +187,7 @@ export async function POST(req: NextRequest) {
   const tm = getTaskManager();
   // GHSA-jcm5-6wpp-wjj8: scope every task read/mutation below to the caller's
   // owner id (hashed API key; undefined under the keyless local-first posture).
-  const callerOwner = resolveA2AOwner(req);
+  const callerOwner = await resolveA2AOwner(req);
 
   // A2A 1.0 method-name compatibility (SendMessage → message/send, etc.)
   const isV1Method = method in V1_METHOD_ALIASES;

--- a/src/app/api/a2a/_auth.ts
+++ b/src/app/api/a2a/_auth.ts
@@ -35,7 +35,7 @@ export async function authorizeA2ATaskRoute(request: Request): Promise<A2ARestAu
   const apiKey = extractApiKey(request);
 
   if (isRequireApiKeyEnabled()) {
-    if (apiKey && (await isValidApiKey(apiKey))) return { owner: resolveA2AOwner(request) };
+    if (apiKey && (await isValidApiKey(apiKey))) return { owner: await resolveA2AOwner(request) };
     const managementError = await requireManagementAuth(request, {
       invalidApiKeyStatus: 401,
       alwaysRequireAuth: true,
@@ -46,6 +46,6 @@ export async function authorizeA2ATaskRoute(request: Request): Promise<A2ARestAu
 
   const managementError = await requireManagementAuth(request, { invalidApiKeyStatus: 401 });
   if (managementError === null) return { owner: undefined };
-  if (apiKey && (await isValidApiKey(apiKey))) return { owner: resolveA2AOwner(request) };
+  if (apiKey && (await isValidApiKey(apiKey))) return { owner: await resolveA2AOwner(request) };
   return managementError;
 }

--- a/src/lib/a2a/authenticate.ts
+++ b/src/lib/a2a/authenticate.ts
@@ -11,6 +11,7 @@
 import { createHash, timingSafeEqual } from "crypto";
 import type { NextRequest } from "next/server";
 import { extractApiKey, isValidApiKey } from "@/sse/services/auth";
+import { isDashboardSessionAuthenticated } from "@/shared/utils/apiAuth";
 import { isRequireApiKeyEnabled } from "@/shared/utils/featureFlags";
 
 function tokensMatch(provided: string, expected: string): boolean {
@@ -29,12 +30,17 @@ function tokensMatch(provided: string, expected: string): boolean {
 export async function authenticateA2ARequest(req: NextRequest | Request): Promise<boolean> {
   const apiKey = extractApiKey(req as NextRequest);
   if (isRequireApiKeyEnabled()) {
-    return apiKey ? await isValidApiKey(apiKey) : false;
+    if (apiKey) return isValidApiKey(apiKey);
+    // #12888: mirror clientApiPolicy's dashboard-session fallback so the
+    // dashboard's own A2A playground (no Authorization header, session
+    // cookie only) is accepted the same way /api/v1/* already accepts it.
+    return isDashboardSessionAuthenticated(req);
   }
 
   const configuredKey = process.env.OMNIROUTE_API_KEY;
   if (configuredKey) {
-    return apiKey ? tokensMatch(apiKey, configuredKey) : false;
+    if (apiKey) return tokensMatch(apiKey, configuredKey);
+    return isDashboardSessionAuthenticated(req);
   }
 
   // No API key required and none configured — allow (keyless local-first).
@@ -43,11 +49,15 @@ export async function authenticateA2ARequest(req: NextRequest | Request): Promis
 
 /**
  * Owner id for task scoping (GHSA-jcm5-6wpp-wjj8): a stable hash of the
- * caller's API key, or `undefined` when the call carries no key (keyless
- * posture — ownerless tasks stay visible to everyone, by design).
+ * caller's API key, `"dashboard"` for a session-authenticated caller with no
+ * API key (#12888 — keeps dashboard-originated tasks scoped consistently
+ * instead of falling into the ownerless keyless bucket), or `undefined` when
+ * the call carries neither (keyless posture — ownerless tasks stay visible to
+ * everyone, by design).
  */
-export function resolveA2AOwner(req: NextRequest | Request): string | undefined {
+export async function resolveA2AOwner(req: NextRequest | Request): Promise<string | undefined> {
   const apiKey = extractApiKey(req as NextRequest);
-  if (!apiKey) return undefined;
-  return createHash("sha256").update(apiKey).digest("hex").slice(0, 32);
+  if (apiKey) return createHash("sha256").update(apiKey).digest("hex").slice(0, 32);
+  if (await isDashboardSessionAuthenticated(req)) return "dashboard";
+  return undefined;
 }

--- a/tests/unit/a2a-dashboard-session-auth.test.ts
+++ b/tests/unit/a2a-dashboard-session-auth.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+process.env.OMNIROUTE_API_KEY = "test-configured-key-12888";
+process.env.JWT_SECRET = "test-jwt-secret-for-probe-12888";
+
+const { authenticateA2ARequest, resolveA2AOwner } = await import("../../src/lib/a2a/authenticate.ts");
+const { isDashboardSessionAuthenticated } = await import("../../src/shared/utils/apiAuth.ts");
+const { SignJWT } = await import("jose");
+
+async function buildSessionRequest(): Promise<unknown> {
+  const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+  const sessionToken = await new SignJWT({ authenticated: true })
+    .setProtectedHeader({ alg: "HS256" })
+    .setExpirationTime("30d")
+    .sign(secret);
+
+  return {
+    headers: new Headers({ cookie: `auth_token=${sessionToken}` }),
+    cookies: { get: () => undefined },
+    nextUrl: { searchParams: new URLSearchParams() },
+    url: "http://localhost:20128/a2a",
+  };
+}
+
+test("A2A route accepts a dashboard-session-authenticated request with no Authorization header (bug #12888)", async () => {
+  const fakeRequest = await buildSessionRequest();
+
+  const dashboardSessionOk = await isDashboardSessionAuthenticated(fakeRequest as never);
+  assert.equal(dashboardSessionOk, true, "expected the dashboard session cookie itself to be valid");
+
+  const a2aAuthOk = await authenticateA2ARequest(fakeRequest as never);
+  assert.equal(
+    a2aAuthOk,
+    true,
+    "/a2a should accept the dashboard's own session-authenticated requests " +
+      "(matching /api/v1/* behavior) but currently requires an explicit Authorization header"
+  );
+});
+
+test("A2A route still rejects a request with neither a valid API key nor a valid session cookie", async () => {
+  const fakeRequest = {
+    headers: new Headers(),
+    cookies: { get: () => undefined },
+    nextUrl: { searchParams: new URLSearchParams() },
+    url: "http://localhost:20128/a2a",
+  };
+
+  const a2aAuthOk = await authenticateA2ARequest(fakeRequest as never);
+  assert.equal(a2aAuthOk, false, "unauthenticated, keyless requests must still be rejected");
+});
+
+test("resolveA2AOwner() returns a stable 'dashboard' owner id for a session-authenticated caller with no API key", async () => {
+  const fakeRequest = await buildSessionRequest();
+  const owner = await resolveA2AOwner(fakeRequest as never);
+  assert.equal(owner, "dashboard");
+});

--- a/tests/unit/a2a-history-route.test.ts
+++ b/tests/unit/a2a-history-route.test.ts
@@ -154,7 +154,7 @@ test("GET history owner-scoping: an API-key caller sees only its own + ownerless
   const ownerAReq = new Request("http://localhost/api/a2a/tasks/history", {
     headers: AUTH_HEADERS,
   });
-  const ownerA = resolveA2AOwner(ownerAReq as never);
+  const ownerA = await resolveA2AOwner(ownerAReq as never);
   assert.ok(ownerA, "the shared key resolves to a stable owner hash");
 
   seedRow({ id: "owned-by-a", apiKeyId: ownerA ?? null, createdAt: "2026-01-01T00:00:00.000Z" });

--- a/tests/unit/a2a-task-owner-idor.test.ts
+++ b/tests/unit/a2a-task-owner-idor.test.ts
@@ -123,7 +123,7 @@ describe("REST /api/a2a/tasks/[id] — authentication (GHSA-jcm5)", () => {
     // And the same task IS visible to its owner (owner hash derived from the key).
     const owned = tm.createTask(
       { skill: "smart-routing", messages: [] },
-      resolveA2AOwner(req as never)
+      await resolveA2AOwner(req as never)
     );
     const res2 = await restGet.GET(
       new Request(`http://localhost/api/a2a/tasks/${owned.id}`, {


### PR DESCRIPTION
Closes #12888

## Root cause

Two related gaps:
1. The A2A dashboard's "Run message/send"/"Run message/stream" buttons (`A2ADashboard.tsx`) call `fetch("/a2a", ...)` with only a `Content-Type` header — no `Authorization`.
2. `authenticateA2ARequest()` (`src/lib/a2a/authenticate.ts`) only checks for a Bearer/x-api-key. Unlike `clientApiPolicy` (used for `/api/v1/*`), which falls back to `isDashboardSessionAuthenticated()` when no key is present, `/a2a` never consulted the dashboard's session cookie at all — so even a logged-in dashboard request hit `Unauthorized: missing or invalid API key` whenever `REQUIRE_API_KEY` or `OMNIROUTE_API_KEY` was configured.

## Fix

- `authenticateA2ARequest()` now falls back to `isDashboardSessionAuthenticated(req)` when no API key is present, mirroring `clientApiPolicy`'s behavior — only adding the dashboard-session path, never widening anonymous access (REQUIRE_API_KEY / OMNIROUTE_API_KEY postures are unchanged for non-dashboard callers).
- `resolveA2AOwner()` now returns a stable `"dashboard"` owner id for a session-authenticated caller with no API key, instead of `undefined`, so dashboard-originated tasks are scoped consistently (it's now `async` — the two call sites in `src/app/a2a/route.ts` and `src/app/api/a2a/_auth.ts` were updated to `await` it).
- `A2ADashboard.tsx`'s `handleSmokeSend`/`handleSmokeStream` fetches now send `credentials: "same-origin"` (defense-in-depth; same-origin fetch already sends cookies by default, but explicit matches the existing `playgroundAuth.ts` convention).

## Regression test

`tests/unit/a2a-dashboard-session-auth.test.ts` (new):
- RED (pre-fix): a request carrying a valid dashboard session cookie and no Authorization header passed `isDashboardSessionAuthenticated()` but `authenticateA2ARequest()` returned `false`.
- GREEN (post-fix): same request now passes `authenticateA2ARequest()`; a request with neither a valid key nor a valid session cookie is still rejected; `resolveA2AOwner()` returns `"dashboard"` for the session-only caller.

Also updated two existing tests (`tests/unit/a2a-task-owner-idor.test.ts`, `tests/unit/a2a-history-route.test.ts`) to `await resolveA2AOwner(...)` now that it is `async` — legitimate alignment to the corrected (now-async) contract, no assertions weakened.

## Gates run

- `node --import tsx/esm --test tests/unit/a2a-dashboard-session-auth.test.ts` — 3/3 pass
- `node --import tsx/esm --test tests/unit/a2a-task-owner-idor.test.ts tests/unit/a2a-history-route.test.ts tests/unit/a2a-tasks-auth.test.ts tests/unit/dashboard-shell-tabs.test.ts` — 36/36 pass (existing A2A/dashboard coverage, unaffected)
- `node scripts/check/check-file-size.mjs` — OK
- `node scripts/check/check-complexity.mjs` — OK (2798 violations, baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations, baseline 1437)
- `npm run typecheck:core` — exit 0
- `npm run check:dashboard-typecheck` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0
- `node scripts/check/check-changelog-integrity.mjs` — OK

## Scope note

Per task instructions, `src/server/authz/policies/clientApi.ts` was left untouched (another in-flight branch, fix/12745-memory-rerank-auth, also touches it).

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync


---

### CodeQL alert #998 — dismissed as false positive (Hard Rule #14)

`js/insufficient-password-hash` at `src/lib/a2a/authenticate.ts:60`.

That line is `resolveA2AOwner()`, which derives a stable, non-secret **owner-scoping id** for A2A
task visibility (GHSA-jcm5-6wpp-wjj8). It is never compared against a stored credential and never
gates authentication. Real API-key verification lives in the same file: `timingSafeEqual`
(`tokensMatch`) and `isValidApiKey`. Swapping in a KDF would only change the id format and orphan
already-persisted task ownership, with no security gain.

The flagged expression is byte-identical to `release/v3.8.51` — this PR only changed the
surrounding control flow, which is why CodeQL re-reported a pre-existing line as new:

```
git diff origin/release/v3.8.51...origin/fix/12888-a2a-dashboard-auth -- src/lib/a2a/authenticate.ts
```
