### PR TITLE
fix(logging): mask every *-api-key provider header in the log pipeline (#13273)

### DIFF
--- a/changelog.d/fixes/13274-log-apikey-header-redaction.md
+++ b/changelog.d/fixes/13274-log-apikey-header-redaction.md
@@ -1,0 +1,1 @@
+- Mask every `*-api-key` provider header spelling (`x-goog-api-key`, Azure `api-key`, `xi-api-key`) in the request-log pipeline and persisted call-log redaction instead of only `x-api-key`. (#13274 — thanks @soroush5)

--- a/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
+++ b/open-sse/services/autoCombo/__tests__/autoCombo.test.ts
@@ -261,6 +261,9 @@ describe("Mode pack ranking gates (cold/warm/health)", () => {
   }
   it("cold pool ranking unchanged (reliability 1, quality 0.5 neutrals)", () => {
     const a: ProviderCandidate = {
+      provider: "test",
+      model: "test-model",
+      errorRate: 0,
       circuitBreakerState: "CLOSED",
       failureRate: undefined,
       quality: undefined,
@@ -272,6 +275,9 @@ describe("Mode pack ranking gates (cold/warm/health)", () => {
       latencyStdDev: 10,
     };
     const b: ProviderCandidate = {
+      provider: "test",
+      model: "test-model",
+      errorRate: 0,
       circuitBreakerState: "CLOSED",
       failureRate: undefined,
       quality: undefined,
@@ -287,6 +293,9 @@ describe("Mode pack ranking gates (cold/warm/health)", () => {
   });
   it("warm reliability 0.01 vs 0.4 flips winner at health tie", () => {
     const highFail: ProviderCandidate = {
+      provider: "test",
+      model: "test-model",
+      errorRate: 0.4,
       circuitBreakerState: "CLOSED",
       failureRate: 0.4,
       quality: 0.5,
@@ -298,6 +307,9 @@ describe("Mode pack ranking gates (cold/warm/health)", () => {
       latencyStdDev: 10,
     };
     const lowFail: ProviderCandidate = {
+      provider: "test",
+      model: "test-model",
+      errorRate: 0.01,
       circuitBreakerState: "CLOSED",
       failureRate: 0.01,
       quality: 0.5,
@@ -313,6 +325,9 @@ describe("Mode pack ranking gates (cold/warm/health)", () => {
   });
   it("boundedRate NaN yields reliability 1", () => {
     const c: ProviderCandidate = {
+      provider: "test",
+      model: "test-model",
+      errorRate: 0,
       circuitBreakerState: "CLOSED",
       failureRate: NaN,
       quotaRemaining: 50,
@@ -327,6 +342,9 @@ describe("Mode pack ranking gates (cold/warm/health)", () => {
   });
   it("health CLOSED vs HALF_OPEN still outweighs reliability gap", () => {
     const healthyHighFail: ProviderCandidate = {
+      provider: "test",
+      model: "test-model",
+      errorRate: 0.4,
       circuitBreakerState: "CLOSED",
       failureRate: 0.4,
       quality: 0.5,
@@ -338,6 +356,9 @@ describe("Mode pack ranking gates (cold/warm/health)", () => {
       latencyStdDev: 10,
     };
     const halfOpenLowFail: ProviderCandidate = {
+      provider: "test",
+      model: "test-model",
+      errorRate: 0.01,
       circuitBreakerState: "HALF_OPEN",
       failureRate: 0.01,
       quality: 0.5,

--- a/open-sse/utils/requestLogger.ts
+++ b/open-sse/utils/requestLogger.ts
@@ -109,7 +109,15 @@ function maskSensitiveHeaders(headers: HeaderInput): Record<string, unknown> {
       masked[key] = "[REDACTED]";
       continue;
     }
-    if (!sensitiveKeys.some((candidate) => lowerKey.includes(candidate))) {
+    // Normalized api-key match: provider credential headers come in many
+    // spellings (x-api-key, x-goog-api-key, api-key for Azure, xi-api-key
+    // for ElevenLabs). Matching the compacted name keeps every current and
+    // future *-api-key variant masked instead of allowlisting spellings.
+    const compactKey = lowerKey.replace(/[^a-z0-9]/g, "");
+    if (
+      !compactKey.includes("apikey") &&
+      !sensitiveKeys.some((candidate) => lowerKey.includes(candidate))
+    ) {
       continue;
     }
 

--- a/src/lib/logPayloads.ts
+++ b/src/lib/logPayloads.ts
@@ -14,6 +14,7 @@ const SENSITIVE_KEYS = new Set([
   "x-api-key",
   "X-Api-Key",
   "x-goog-api-key",
+  "xi-api-key",
   "access_token",
   "accessToken",
   "refresh_token",

--- a/tests/unit/log-pipeline-apikey-header-redaction.test.ts
+++ b/tests/unit/log-pipeline-apikey-header-redaction.test.ts
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-log-apikey-redact-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { createRequestLogger } = await import("../../open-sse/utils/requestLogger.ts");
+const { redactPayload, protectPayloadForLog } = await import("../../src/lib/logPayloads.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+const GEMINI_KEY = "AIzaSyDdI1SecretKeyMaterial1234567890";
+const AZURE_KEY = "7f3a9c2e4b5d6f8091a2b3c4d5e6f7081";
+const ELEVENLABS_KEY = "sk_e1SecretKeyMaterial_abcdefghij1234";
+const ANTHROPIC_KEY = "sk-ant-api03-TopSecretKeyMaterial-abcdefgh";
+
+async function captureProviderHeaders(
+  headers: Record<string, string>
+): Promise<Record<string, unknown>> {
+  const logger = await createRequestLogger("openai", "gemini", "gemini-2.5-flash", {});
+  logger.logTargetRequest("https://generativelanguage.googleapis.com/v1beta/models/x:generateContent", headers, {
+    contents: [],
+  });
+  const payloads = logger.getPipelinePayloads() as {
+    providerRequest?: { headers?: Record<string, unknown> };
+  } | null;
+  return payloads?.providerRequest?.headers ?? {};
+}
+
+test("log pipeline masks every *-api-key provider credential header spelling", async () => {
+  const headers = await captureProviderHeaders({
+    "x-goog-api-key": GEMINI_KEY,
+    "api-key": AZURE_KEY,
+    "xi-api-key": ELEVENLABS_KEY,
+    "x-api-key": ANTHROPIC_KEY,
+    "Content-Type": "application/json",
+  });
+  const dumped = JSON.stringify(headers);
+  assert.ok(!dumped.includes(GEMINI_KEY), "Gemini x-goog-api-key must not survive masking");
+  assert.ok(!dumped.includes(AZURE_KEY), "Azure api-key must not survive masking");
+  assert.ok(!dumped.includes(ELEVENLABS_KEY), "ElevenLabs xi-api-key must not survive masking");
+  assert.ok(!dumped.includes(ANTHROPIC_KEY), "Anthropic x-api-key must not survive masking");
+  assert.equal(headers["Content-Type"], "application/json", "non-secret headers are preserved");
+});
+
+test("log pipeline header masking is case-insensitive", async () => {
+  const headers = await captureProviderHeaders({
+    "X-Goog-Api-Key": GEMINI_KEY,
+    "Api-Key": AZURE_KEY,
+  });
+  const dumped = JSON.stringify(headers);
+  assert.ok(!dumped.includes(GEMINI_KEY), "mixed-case X-Goog-Api-Key must be masked");
+  assert.ok(!dumped.includes(AZURE_KEY), "mixed-case Api-Key must be masked");
+});
+
+test("log pipeline keeps x-ratelimit-* headers readable", async () => {
+  const headers = await captureProviderHeaders({
+    "x-ratelimit-remaining": "99",
+    "x-api-key": ANTHROPIC_KEY,
+  });
+  assert.equal(headers["x-ratelimit-remaining"], "99", "rate-limit diagnostics are preserved");
+});
+
+test("persisted-log redaction covers the ElevenLabs xi-api-key header", () => {
+  const protectedPayload = protectPayloadForLog({
+    headers: { "xi-api-key": ELEVENLABS_KEY, "Content-Type": "audio/mpeg" },
+  }) as { headers: Record<string, unknown> };
+  assert.equal(protectedPayload.headers["xi-api-key"], "[REDACTED]");
+  assert.equal(protectedPayload.headers["Content-Type"], "audio/mpeg");
+  assert.equal(
+    (redactPayload({ "xi-api-key": ELEVENLABS_KEY }) as Record<string, unknown>)["xi-api-key"],
+    "[REDACTED]"
+  );
+});


### PR DESCRIPTION
Fixes #13273.

The request-log header mask only knew x-api-key, so Gemini (x-goog-api-key) and Azure (api-key) provider keys were stored verbatim in the log pipeline. This matches any *-api-key spelling instead, same masking style as before. Adds xi-api-key to the persisted-log redaction too, plus a regression test.