### PR TITLE
fix(providers): route opencode-go/gpt-5.6-luna to /responses (#12196)

### DIFF
--- a/changelog.d/fixes/12196-opencode-go-gpt56luna.md
+++ b/changelog.d/fixes/12196-opencode-go-gpt56luna.md
@@ -1,0 +1,1 @@
+- fix(providers): route opencode-go/gpt-5.6-luna to /responses instead of /chat/completions (#12196)

--- a/open-sse/config/providers/registry/opencode/go/index.ts
+++ b/open-sse/config/providers/registry/opencode/go/index.ts
@@ -250,6 +250,16 @@ export const opencode_goProvider: RegistryEntry = {
       supportedThinkingEfforts: ["none", "low", "high", "max"],
       targetFormat: "openai-responses",
     },
+    // #12196: the Go upstream serves this model only on /responses —
+    // /chat/completions 500s for it. github already declares the same model
+    // id with targetFormat:"openai-responses" (see github/index.ts).
+    {
+      id: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+      supportsReasoning: true,
+      targetFormat: "openai-responses",
+      maxOutputTokens: 128000,
+    },
     // Console Go free GLM-tier model (live-verified 2026-08-23): the upstream
     // rejects every reasoning_effort outside {low, high, max} whenever tools
     // are present — "[1210] This model always engages in thinking and cannot

--- a/tests/unit/issue-12196-opencode-go-gpt56luna.test.ts
+++ b/tests/unit/issue-12196-opencode-go-gpt56luna.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveOpencodeTargetFormat } from "../../open-sse/executors/opencode.ts";
+
+// Issue #12196: opencode-go/gpt-5.6-luna is served by the Go upstream ONLY on
+// /responses — /chat/completions 500s for this model. The github provider
+// already declares targetFormat:"openai-responses" for the same model id, and
+// opencode-go already does the same for deepseek-v4-pro/deepseek-v4-flash on
+// this exact provider — but gpt-5.6-luna itself is missing from the
+// opencode-go registry, so getModelTargetFormat() falls through to null and
+// resolveOpencodeTargetFormat() defaults to "openai", which makes
+// OpencodeExecutor.buildUrl() post to /chat/completions instead of /responses.
+test("opencode-go/gpt-5.6-luna must resolve to the openai-responses target format", () => {
+  const resolved = resolveOpencodeTargetFormat("opencode-go", "gpt-5.6-luna");
+  assert.equal(
+    resolved,
+    "openai-responses",
+    "opencode-go/gpt-5.6-luna resolved to '" +
+      resolved +
+      "' instead of 'openai-responses' — OpencodeExecutor.buildUrl() will post to " +
+      "/chat/completions, which the Go upstream 500s on for this model (issue #12196)"
+  );
+});
+
+// Control: the sibling deepseek-v4-flash entry on the SAME opencode-go
+// provider already declares targetFormat:"openai-responses" and must keep
+// working — proves the assertion above isn't failing for an unrelated reason
+// (e.g. a broken import or alias resolution).
+test("control: opencode-go/deepseek-v4-flash already resolves to openai-responses", () => {
+  const resolved = resolveOpencodeTargetFormat("opencode-go", "deepseek-v4-flash");
+  assert.equal(resolved, "openai-responses");
+});


### PR DESCRIPTION
Closes #12196

## Root cause

`opencode-go`'s static model registry was missing a `gpt-5.6-luna` entry. Because
`getModelTargetFormat()` (`open-sse/config/providerModels.ts`) only ever searches the static
`PROVIDER_MODELS` registry, it returned `null` for this model and
`resolveOpencodeTargetFormat()` (`open-sse/executors/opencode.ts`) fell back to `"openai"`,
so `OpencodeExecutor.buildUrl()` posted to `/chat/completions` — which the Go upstream 500s
on for this model (it only serves `gpt-5.6-luna` via `/responses`). The `github` provider
already declares `targetFormat: "openai-responses"` for the identical model id, and
`opencode-go` itself already does the same for its `deepseek-v4-pro` / `deepseek-v4-flash`
entries — `gpt-5.6-luna` was simply the missing sibling row.

`modelCompatOverrides` in the DB cannot work around it: `resolveOpencodeTargetFormat()` (used
for URL selection) never consults the DB override, unlike `resolveChatCoreTargetFormat()`
(used for body translation), which does — so the body got translated to Responses shape but
was still sent to the wrong endpoint.

## Fix

Add the missing `gpt-5.6-luna` registry entry to
`open-sse/config/providers/registry/opencode/go/index.ts` with
`targetFormat: "openai-responses"`, mirroring the `github` provider's identical entry and
`opencode-go`'s own `deepseek-v4-pro`/`deepseek-v4-flash` pattern. Purely additive — no other
model id's resolution changes.

Scope note: the DB-override gap in `resolveOpencodeTargetFormat()` and the separate
reasoning-content-block translator issue (`toResponses.ts`) are intentionally **not** bundled
here, per the plan-file and the maintainer's own comment on the issue — tracked separately.

## Regression test

`tests/unit/issue-12196-opencode-go-gpt56luna.test.ts`

RED (before fix):
```
✖ opencode-go/gpt-5.6-luna must resolve to the openai-responses target format
  AssertionError: opencode-go/gpt-5.6-luna resolved to 'openai' instead of 'openai-responses'
✔ control: opencode-go/deepseek-v4-flash already resolves to openai-responses
```

GREEN (after fix):
```
✔ opencode-go/gpt-5.6-luna must resolve to the openai-responses target format
✔ control: opencode-go/deepseek-v4-flash already resolves to openai-responses
```

## Gates run

- `check-file-size.mjs` — clean
- `check-complexity.mjs` — OK (2798 violations vs baseline 3218)
- `check-cognitive-complexity.mjs` — OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` — clean
- `eslint --suppressions-location config/quality/eslint-suppressions.json` on changed files — clean
- New regression test — GREEN (both assertions)
- Existing area tests re-run: `opencode-go-catalog-alignment.test.ts`,
  `opencode-go-effort-aliases-8353.test.ts`, `opencode-go-effort-aliases-6922.test.ts`,
  `opencodeReasoningSanitizer.test.ts`, `custom-model-target-format.test.ts` — 81/81 pass
- `check-changelog-integrity.mjs` — OK

## Note on the concurrent #12681 PR

`open-sse/executors/opencode.ts` is also touched by the open PR for #12681/#12633 (adds a
`usesZenApiKeyAuth()` helper scoped to the `opencode.ai/zen/v1` host, inside `buildHeaders`).
This PR does not touch `opencode.ts` at all — the fix is confined to the `opencode-go`
registry file — so the two branches merge cleanly with no overlap.

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
