### PR TITLE
fix(routing): stop reactive-compaction log from lying when compression is disabled (#11977)

### DIFF
--- a/changelog.d/fixes/11977-antigravity-stale-compaction-log.md
+++ b/changelog.d/fixes/11977-antigravity-stale-compaction-log.md
@@ -1,0 +1,1 @@
+- fix(routing): stop the reactive-compaction debug log from lying when compression is globally disabled (#11977)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -1958,7 +1958,9 @@ export async function handleChatCore({
     if (!promptCompressionEnabled) {
       log?.debug?.(
         "CONTEXT",
-        "Prompt Compression engines disabled; reactive context compaction still applies when over threshold"
+        reactiveContextCompactionEnabled
+          ? "Prompt Compression engines disabled; reactive context compaction still applies when over threshold"
+          : "Prompt Compression engines disabled; reactive context compaction is ALSO disabled — large histories will NOT be trimmed before reaching the upstream provider"
       );
     }
     if (isCombo && comboName) {

--- a/tests/unit/chatcore-stale-compaction-log.test.mjs
+++ b/tests/unit/chatcore-stale-compaction-log.test.mjs
@@ -1,0 +1,71 @@
+// Regression guard for #11977: the diagnostic log fired unconditionally whenever
+// promptCompressionEnabled was false, claiming "reactive context compaction still
+// applies when over threshold" even on a default install where
+// reactiveContextCompactionEnabled is ALSO false (DEFAULT_COMPRESSION_CONFIG.enabled
+// === false, per #9200's gating). That left operators with zero diagnostic signal for
+// the real failure mode: large histories reaching the upstream provider untrimmed
+// (e.g. Antigravity's 400 once session history grows past its real request-size
+// ceiling). The fix branches the log on reactiveContextCompactionEnabled so the
+// message reflects which safety net, if any, is actually still active.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(
+  new URL("../../open-sse/handlers/chatCore.ts", import.meta.url),
+  "utf8"
+);
+
+test("gating expressions exist as documented (sanity check, tracks real source)", () => {
+  assert.match(
+    source,
+    /let promptCompressionEnabled =\s*\n\s*compressionSettingsResult\.enabled && !compressionExcluded && apiKeyCompressionEnabled;/
+  );
+  assert.match(
+    source,
+    /reactiveContextCompactionEnabled = compressionSettingsResult\.enabled && !compressionExcluded;/
+  );
+});
+
+test("on default install, reactiveContextCompactionEnabled is provably false whenever the log fires", () => {
+  const compressionSettingsResultEnabled = false; // DEFAULT_COMPRESSION_CONFIG.enabled
+  const compressionExcluded = false;
+  const apiKeyCompressionEnabled = true;
+
+  const promptCompressionEnabled =
+    compressionSettingsResultEnabled && !compressionExcluded && apiKeyCompressionEnabled;
+  const reactiveContextCompactionEnabled = compressionSettingsResultEnabled && !compressionExcluded;
+
+  const logFires = !promptCompressionEnabled;
+
+  assert.equal(logFires, true, "the log fires on every default-config request");
+  assert.equal(
+    reactiveContextCompactionEnabled,
+    false,
+    "reactive compaction is ALSO disabled here — the old unconditional message was false for this branch"
+  );
+});
+
+test("the log statement branches on reactiveContextCompactionEnabled so it stays accurate in both cases", () => {
+  const blockMatch = source.match(
+    /if \(!promptCompressionEnabled\) \{[\s\S]{0,400}\}/
+  );
+  assert.ok(blockMatch, "expected to find the promptCompressionEnabled debug-log block");
+  const block = blockMatch[0];
+
+  assert.match(
+    block,
+    /reactiveContextCompactionEnabled/,
+    "expected the debug-log block to branch on reactiveContextCompactionEnabled"
+  );
+  assert.match(
+    block,
+    /still applies when over threshold/,
+    "expected the true-branch message (reactive compaction still active) to be preserved"
+  );
+  assert.match(
+    block,
+    /reactive context compaction is ALSO disabled/,
+    "expected a distinct false-branch message for the fully-disabled default-install case"
+  );
+});


### PR DESCRIPTION
Closes #11977

## Root cause

On a default install `DEFAULT_COMPRESSION_CONFIG.enabled = false`
(`open-sse/services/compression/types.ts:418`), and PR #9200 deliberately tied the
built-in reactive/last-resort context-compaction safety net to that same global
toggle (`reactiveContextCompactionEnabled = compressionSettingsResult.enabled &&
!compressionExcluded;`, `open-sse/handlers/chatCore.ts:1361`). With compression off
by default, nothing trims a growing session history before it is forwarded upstream,
and Antigravity's real `daily-cloudcode-pa.googleapis.com` request-size ceiling is far
below the advertised Gemini 3.7 context window, so requests eventually get a bare 400
once history has grown — reproducing on every subsequent turn.

**Scope of this fix** (per the analyzed plan-file, main-thread-audited): the
code-provable, safely-fixable defect is the diagnostic log in `chatCore.ts` that fired
unconditionally whenever `promptCompressionEnabled` was false, claiming "reactive
context compaction still applies when over threshold" — even in the default-install
branch where `reactiveContextCompactionEnabled` is ALSO false, i.e. no safety net is
actually active. Operators got zero diagnostic signal for the real failure mode. This
PR does **not** touch the #9200 gating itself (deliberate fix for tool-call-history
corruption on Pi/Codex) and does **not** attempt to guess a lower per-provider request
cap for Antigravity — that remains a separate, larger design question the owner
already flagged as unresolved.

## Fix

`open-sse/handlers/chatCore.ts`: the `if (!promptCompressionEnabled)` debug-log block
now branches on `reactiveContextCompactionEnabled` — the existing message is kept when
reactive compaction is still active (per-key opt-out case), and a new distinct message
("...reactive context compaction is ALSO disabled — large histories will NOT be
trimmed before reaching the upstream provider") is logged for the default-install case
this issue is about.

## Regression test — RED → GREEN

`tests/unit/chatcore-stale-compaction-log.test.mjs` (new file, reusing the proven
plan-file probe):

RED (before fix):
```
✖ BUG: the log statement does not branch on reactiveContextCompactionEnabled, so it cannot ever be accurate
  AssertionError [ERR_ASSERTION]: expected the debug-log block guarded by "!promptCompressionEnabled"
  to also branch on reactiveContextCompactionEnabled ...
tests 3 / pass 2 / fail 1
```

GREEN (after fix):
```
✔ gating expressions exist as documented (sanity check, tracks real source)
✔ on default install, reactiveContextCompactionEnabled is provably false whenever the log fires
✔ the log statement branches on reactiveContextCompactionEnabled so it stays accurate in both cases
tests 3 / pass 3 / fail 0
```

Existing regression test for the #9200 gating itself (untouched, still green):
`node --test tests/unit/reactive-context-compaction-policy.test.mjs` → 1/1 pass.
Adjacent test also re-run and unaffected: `tests/unit/codex-prompt-compression-passthrough.test.ts` → 3/3 pass.

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` → OK (chatCore.ts stays under its frozen ceiling)
- `node scripts/check/check-complexity.mjs` → OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/handlers/chatCore.ts tests/unit/chatcore-stale-compaction-log.test.mjs` → exit 0
- `node scripts/check/check-changelog-integrity.mjs` → OK
- New test: `node --test tests/unit/chatcore-stale-compaction-log.test.mjs` → 3/3 pass
- Existing adjacent tests re-run: `reactive-context-compaction-policy.test.mjs` (1/1), `codex-prompt-compression-passthrough.test.ts` (3/3)

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
