### PR TITLE
fix(sse): register Arcee AI in the executor provider registry (#12784)

### DIFF
--- a/changelog.d/fixes/12784-arcee-ai-provider-registry.md
+++ b/changelog.d/fixes/12784-arcee-ai-provider-registry.md
@@ -1,0 +1,1 @@
+- fix(sse): register Arcee AI in the executor provider registry so requests reach api.arcee.ai instead of silently falling back to OpenAI (#12784)

--- a/open-sse/config/providers/index.ts
+++ b/open-sse/config/providers/index.ts
@@ -136,6 +136,7 @@ import { freemodel_devProvider } from "./registry/freemodel-dev/index.ts";
 import { gitlawb_gmiProvider } from "./registry/gitlawb/gmi/index.ts";
 import { gitlawbProvider } from "./registry/gitlawb/index.ts";
 import { liquidProvider } from "./registry/liquid/index.ts";
+import { arceeAiProvider } from "./registry/arcee-ai/index.ts";
 import { deepinfraProvider } from "./registry/deepinfra/index.ts";
 import { agyProvider } from "./registry/agy/index.ts";
 import { agnesProvider } from "./registry/agnes/index.ts";
@@ -407,6 +408,7 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   "gitlawb-gmi": gitlawb_gmiProvider,
   gitlawb: gitlawbProvider,
   liquid: liquidProvider,
+  "arcee-ai": arceeAiProvider,
   deepinfra: deepinfraProvider,
   agy: agyProvider,
   agnes: agnesProvider,

--- a/open-sse/config/providers/registry/arcee-ai/index.ts
+++ b/open-sse/config/providers/registry/arcee-ai/index.ts
@@ -1,0 +1,10 @@
+import type { RegistryEntry } from "../../shared.ts";
+import { buildOpenAiCompatibleRegistryEntry } from "../../shared.ts";
+
+export const arceeAiProvider: RegistryEntry = buildOpenAiCompatibleRegistryEntry({
+  id: "arcee-ai",
+  alias: "arcee",
+  baseUrl: "https://api.arcee.ai/api/v1/chat/completions",
+  models: [],
+  passthroughModels: true,
+});

--- a/tests/unit/arcee-ai-provider.test.ts
+++ b/tests/unit/arcee-ai-provider.test.ts
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-arcee-provider-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const { PROVIDERS } = await import("../../open-sse/config/constants.ts");
+const { REGISTRY: providerRegistry } = await import("../../open-sse/config/providerRegistry.ts");
+const { APIKEY_PROVIDERS } = await import("../../src/shared/constants/providers.ts");
+const { DefaultExecutor } = await import("../../open-sse/executors/default.ts");
+const dbCore = await import("../../src/lib/db/core.ts");
+
+test.after(() => {
+  dbCore.closeDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+const ARCEE_CHAT_URL = "https://api.arcee.ai/api/v1/chat/completions";
+
+test("arcee-ai is offered in the onboarding catalog", () => {
+  assert.ok(APIKEY_PROVIDERS["arcee-ai"]);
+});
+
+test("arcee-ai has a routing entry in the executor REGISTRY", () => {
+  const entry = providerRegistry["arcee-ai"];
+  assert.ok(entry, "providerRegistry['arcee-ai'] must be defined");
+  assert.equal(entry.id, "arcee-ai");
+  assert.equal(entry.alias, "arcee");
+  assert.equal(entry.format, "openai");
+  assert.equal(entry.executor, "default");
+  assert.equal(entry.baseUrl, ARCEE_CHAT_URL);
+  assert.equal(entry.authType, "apikey");
+  assert.equal(entry.authHeader, "bearer");
+  assert.equal(entry.passthroughModels, true);
+});
+
+test("DefaultExecutor routes arcee-ai to Arcee's own base URL, not OpenAI's", () => {
+  const executor = new DefaultExecutor("arcee-ai");
+  assert.equal(executor.config.baseUrl, ARCEE_CHAT_URL);
+  assert.notEqual(executor.config.baseUrl, PROVIDERS.openai.baseUrl);
+});


### PR DESCRIPTION
## Root cause

Arcee AI was added to the dashboard onboarding catalog (`src/shared/constants/providers/apikey/frontier-labs.ts:288-301`, `passthroughModels: true`, with an `authHint`) so users could add an Arcee API key — but it had **no entry in the runtime routing REGISTRY** (`open-sse/config/providers/index.ts`). `DefaultExecutor`'s constructor does `PROVIDERS[provider] || PROVIDERS.openai` (`open-sse/executors/default.ts:221`), so any unregistered provider id silently falls back to OpenAI's own base URL/format. That meant every Arcee chat request was sent to `https://api.openai.com/v1` with the user's Arcee key as the Bearer token — which OpenAI correctly rejects as an invalid API key. This exactly matches the report ("errors that the api key is invalid, but that wouldn't make sense").

Confirmed against Arcee's live docs (`docs.arcee.ai/api-reference/your-first-api-call`): real endpoint is `https://api.arcee.ai/api/v1/chat/completions`, Bearer auth, no `GET /models` endpoint (hence `passthroughModels: true`, `models: []`, no `modelsUrl` — mirrors the `meganova-ai` registry entry pattern).

## Fix

- New `open-sse/config/providers/registry/arcee-ai/index.ts` — `arceeAiProvider: RegistryEntry` built via `buildOpenAiCompatibleRegistryEntry` (id `arcee-ai`, alias `arcee`, format `openai`, executor `default`, baseUrl `https://api.arcee.ai/api/v1/chat/completions`, apikey/bearer auth, `passthroughModels: true`).
- Wired into `open-sse/config/providers/index.ts` (import + `REGISTRY` entry) next to the sibling `liquid` entry, so `generateLegacyProviders()` picks up the real base URL/format.

Additive-only change; no existing provider behavior changes.

## Regression test

`tests/unit/arcee-ai-provider.test.ts` (new file):
- RED (pre-fix, on `release/v3.8.51` tip): `providerRegistry["arcee-ai"]` undefined; `new DefaultExecutor("arcee-ai").config.baseUrl === PROVIDERS.openai.baseUrl` — 2/3 assertions failed.
- GREEN (post-fix): all 3 pass — `providerRegistry["arcee-ai"]` defined with the correct shape, and `DefaultExecutor("arcee-ai").config.baseUrl === "https://api.arcee.ai/api/v1/chat/completions"` (not OpenAI's).

Run: `node --import tsx/esm --test tests/unit/arcee-ai-provider.test.ts` → `tests 3 / pass 3 / fail 0`.

## Gates run

- `node scripts/check/check-file-size.mjs` → OK
- `node scripts/check/check-complexity.mjs` → OK (2798 violations, baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1265 violations, baseline 1437)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → exit 0, no output
- New test: `tests/unit/arcee-ai-provider.test.ts` → 3/3 pass
- Existing area tests re-run: `tests/unit/check-provider-consistency.test.ts`, `tests/unit/canonical-provider-order.test.ts`, `tests/unit/cli-provider-catalog-full-10080.test.ts`, `tests/unit/check-docs-counts-sync.test.ts`, `tests/unit/removed-providers-blocklist.test.ts` → all pass (54/23/11 as applicable)
- `node scripts/check/check-docs-counts-sync.mjs` (live, not just its unit test) → `✓ All checks pass.` (includes the STRICT free-tier leaf∩registry gate, unaffected since it's a synthetic-input test)
- `node scripts/check/check-changelog-integrity.mjs` → OK
- Confirmed `docs/reference/REMOVED_PROVIDERS.md` has no `arcee` entry — this is not a reintroduction of a removed provider.

Closes #12784

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
