### PR TITLE
fix(sse): require Responses-shaped body before native OpenAI-compatible passthrough (#12129)

### DIFF
--- a/changelog.d/fixes/12129-context-handoff-native-passthrough-shape.md
+++ b/changelog.d/fixes/12129-context-handoff-native-passthrough-shape.md
@@ -1,0 +1,1 @@
+- fix(sse): require Responses-shaped body before native OpenAI-compatible passthrough (#12129)

--- a/open-sse/handlers/chatCore.ts
+++ b/open-sse/handlers/chatCore.ts
@@ -731,6 +731,7 @@ export async function handleChatCore({
       sourceFormat,
       endpointPath,
       providerSpecificData: credentials?.providerSpecificData,
+      body,
     });
   const responsesInputItems = Array.isArray(body?.input) ? body.input : [];
   const customToolNames = collectCustomToolNamesForSourceFormat(

--- a/open-sse/handlers/chatCore/passthroughHelpers.ts
+++ b/open-sse/handlers/chatCore/passthroughHelpers.ts
@@ -53,19 +53,35 @@ export function stampNativeResponsesPassthroughBody(
   return { ...body, _nativeOpenAICompatibleResponsesPassthrough: true };
 }
 
+// A body only qualifies for the native-Responses passthrough fast path when it is
+// actually shaped like a Responses API request (`input`, no `messages`). Endpoint
+// path alone is not sufficient: an internally-synthesized Chat Completions-shaped
+// body (e.g. the context-handoff summary request) can be dispatched through a
+// closure that still carries the original client request's `/responses` endpoint,
+// which otherwise makes `sourceFormat` resolve to "openai-responses" even though
+// the body itself was never translated. See issue #12129.
+function isResponsesShapedBody(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const candidate = body as Record<string, unknown>;
+  return candidate.input !== undefined && candidate.messages === undefined;
+}
+
 export function shouldUseNativeOpenAICompatibleResponsesPassthrough({
   provider,
   sourceFormat,
   endpointPath,
   providerSpecificData,
+  body,
 }: {
   provider?: string | null;
   sourceFormat?: string | null;
   endpointPath?: string | null;
   providerSpecificData?: unknown;
+  body?: unknown;
 }): boolean {
   if (!provider?.startsWith("openai-compatible-")) return false;
   if (sourceFormat !== FORMATS.OPENAI_RESPONSES) return false;
+  if (body !== undefined && !isResponsesShapedBody(body)) return false;
   if (providerSpecificData && typeof providerSpecificData === "object") {
     const psd = providerSpecificData as Record<string, unknown>;
     if (psd.apiType === "responses" || psd._omnirouteForceResponsesUpstream === true) {

--- a/tests/unit/context-handoff-native-passthrough-bug.test.ts
+++ b/tests/unit/context-handoff-native-passthrough-bug.test.ts
@@ -1,0 +1,86 @@
+// Regression test for issue #12129: an internal context-handoff summary request (built in
+// Chat Completions shape -- `messages`, no `input`) is dispatched through the SAME
+// handleSingleModel closure that carries the ORIGINAL client request's endpoint.
+// When that original endpoint matched `/responses` and the resolved handoff-model
+// provider is an openai-compatible-* connection configured with apiType "responses",
+// the pipeline used to decide the body was already native-Responses-shaped and skip
+// chat->responses translation entirely (`_nativeOpenAICompatibleResponsesPassthrough`),
+// so the upstream received `messages` on `/v1/responses` and rejected it with zero input.
+//
+// Fix: `shouldUseNativeOpenAICompatibleResponsesPassthrough` now requires the body to
+// actually look Responses-shaped (`input` present, `messages` absent) before allowing
+// the passthrough fast path, so an internally-synthesized chat-shaped body is routed
+// through the normal chat->responses translation layer instead.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveChatCoreRequestFormat } from "../../open-sse/handlers/chatCore/requestFormat.ts";
+import { shouldUseNativeOpenAICompatibleResponsesPassthrough } from "../../open-sse/handlers/chatCore/passthroughHelpers.ts";
+
+test("internal chat-shaped handoff body is no longer treated as native Responses passthrough", () => {
+  const clientRawRequest = {
+    endpoint: "/v1/responses",
+    headers: new Headers(),
+  };
+
+  const summaryBody = {
+    model: "some-handoff-model",
+    messages: [{ role: "user", content: "Summarize this conversation." }],
+    stream: false,
+    max_tokens: 800,
+    temperature: 0.1,
+    _omnirouteSkipContextRelay: true,
+    _omnirouteInternalRequest: "context-handoff",
+  };
+
+  const { sourceFormat, endpointPath } = resolveChatCoreRequestFormat({
+    clientRawRequest,
+    body: summaryBody,
+    provider: "openai-compatible-responses-cliproxy",
+    userAgent: null,
+  });
+
+  assert.equal(sourceFormat, "openai-responses");
+  assert.equal(endpointPath, "/v1/responses");
+
+  const providerSpecificData = { apiType: "responses" };
+
+  const nativePassthrough = shouldUseNativeOpenAICompatibleResponsesPassthrough({
+    provider: "openai-compatible-responses-cliproxy",
+    sourceFormat,
+    endpointPath,
+    providerSpecificData,
+    body: summaryBody,
+  });
+
+  assert.equal(
+    nativePassthrough,
+    false,
+    "fixed: chat-shaped internal body must not take the native-Responses passthrough shortcut"
+  );
+
+  assert.equal((summaryBody as Record<string, unknown>).input, undefined);
+  assert.ok(Array.isArray(summaryBody.messages) && summaryBody.messages.length > 0);
+});
+
+test("genuine Responses-shaped body still takes the native passthrough fast path", () => {
+  const genuineResponsesBody = {
+    model: "gpt-5.6-sol",
+    input: [{ role: "user", content: [{ type: "input_text", text: "Hello" }] }],
+    stream: false,
+  };
+
+  const nativePassthrough = shouldUseNativeOpenAICompatibleResponsesPassthrough({
+    provider: "openai-compatible-responses-cliproxy",
+    sourceFormat: "openai-responses",
+    endpointPath: "/v1/responses",
+    providerSpecificData: { apiType: "responses" },
+    body: genuineResponsesBody,
+  });
+
+  assert.equal(
+    nativePassthrough,
+    true,
+    "a genuine Responses-shaped client body must keep the zero-translation fast path"
+  );
+});


### PR DESCRIPTION
Closes #12129

## Root cause

The internal context-handoff / universal-handoff summary request is built in Chat Completions
shape (`messages`, no `input`) and dispatched through the *same* `handleSingleModel` closure
that still carries the *original client request's* endpoint (`src/sse/handlers/chat.ts`,
reused by `maybeGenerateHandoff` in `open-sse/services/combo.ts`).

`resolveChatCoreRequestFormat` derives `sourceFormat` purely from that inherited endpoint path
via `detectFormatFromEndpoint` (`open-sse/services/provider.ts`), which returns
`"openai-responses"` for any `/responses` path unconditionally — it never inspects body shape
on that branch. `shouldUseNativeOpenAICompatibleResponsesPassthrough`
(`open-sse/handlers/chatCore/passthroughHelpers.ts`) then decided to skip all
chat→responses translation purely from `sourceFormat === "openai-responses"` +
`providerSpecificData.apiType === "responses"`, with no way to tell a genuinely
Responses-shaped client body apart from an internally-synthesized chat-shaped one. The upstream
ended up receiving the raw `messages` array on `/v1/responses` with no `input`, and rejected it.

## Fix

`shouldUseNativeOpenAICompatibleResponsesPassthrough` now takes the request `body` and requires
it to actually look Responses-shaped (`input` present, `messages` absent) before allowing the
native-passthrough fast path — mirroring the shape check `detectFormatFromEndpoint` already
applies on its chat/completions branch. The call site in `open-sse/handlers/chatCore.ts` now
passes `body` through. A genuine client Responses-API request still gets the zero-translation
shortcut; the internally-synthesized chat-shaped handoff body is now routed through the normal
chat→responses translation layer instead of being hand-forwarded.

## Regression test

`tests/unit/context-handoff-native-passthrough-bug.test.ts`

- RED (pre-fix, code temporarily reverted to confirm): `nativePassthrough` returned `true` for
  the chat-shaped internal handoff body — assertion failed with `true !== false`.
- GREEN (post-fix): same case now returns `false`; a companion case confirms a genuine
  Responses-shaped body (`input`, no `messages`) still returns `true`, protecting the legitimate
  passthrough optimization for real Responses-API clients.

## Gates run

- `node scripts/check/check-file-size.mjs` — no violations on touched files
- `node scripts/check/check-complexity.mjs` — OK (2798 violações, baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violações, baseline 1437)
- `npm run typecheck:core` — exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — exit 0, no output
- New regression test: 2/2 passing
- Existing tests of the touched area (all passing): `tests/unit/responses-passthrough-openai-compatible.test.ts`,
  `tests/unit/chatcore-request-format.test.ts`, `tests/unit/xai-agent-tools-passthrough.test.ts`,
  `tests/unit/anthropic-thinking-signature-recovery.test.ts` (40 tests),
  `tests/unit/universal-handoff.test.ts` (24), `tests/unit/context-handoff.test.ts` (19),
  `tests/unit/service-context-handoff.test.ts` (11), `tests/unit/chat-context-relay.test.ts` (2),
  `tests/unit/combo-context-relay.test.ts` (13)
- `node scripts/check/check-changelog-integrity.mjs` — OK

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
