### PR TITLE
fix(sse): cap HuggingChat NDJSON body size and bound the read loop (#12577)

### DIFF
--- a/changelog.d/fixes/12577-huggingchat-buffer-cap.md
+++ b/changelog.d/fixes/12577-huggingchat-buffer-cap.md
@@ -1,0 +1,1 @@
+- fix(sse): cap HuggingChat NDJSON body size and bound the read loop with the fetch timeout so a stalled or hostile upstream cannot buffer unbounded memory (#12577)

--- a/open-sse/config/constants.ts
+++ b/open-sse/config/constants.ts
@@ -55,6 +55,14 @@ export const SSE_HEARTBEAT_INTERVAL_MS = upstreamTimeouts.sseHeartbeatIntervalMs
 // Defaults to FETCH_TIMEOUT_MS. Override with FETCH_BODY_TIMEOUT_MS env var.
 export const FETCH_BODY_TIMEOUT_MS = upstreamTimeouts.fetchBodyTimeoutMs;
 
+// Hard byte cap on the HuggingChat NDJSON body accumulated by
+// open-sse/executors/huggingchat/jsonlStream.ts. Prevents a stalled/hostile upstream that
+// never emits a terminal `finalAnswer` / `status: finished` marker from buffering
+// indefinitely (#12577). Sized generously for legitimate long completions while staying
+// well below a heap-exhausting size — mirrors the readCappedBuffer/readBodyCapped pattern
+// already used by veoaifree-web.ts and context7-fetch.ts.
+export const HUGGINGCHAT_MAX_BODY_BYTES = 4 * 1024 * 1024;
+
 // Provider configurations
 // OAuth credentials read from env vars with hardcoded fallbacks for backward compatibility.
 // Use provider-credentials.json or env vars to override in production.

--- a/open-sse/executors/huggingchat.ts
+++ b/open-sse/executors/huggingchat.ts
@@ -538,7 +538,7 @@ export class HuggingChatExecutor extends BaseExecutor {
         resolvedModel,
         id,
         created,
-        signal,
+        combinedSignal,
         streamCancellationController.signal
       );
 
@@ -626,7 +626,7 @@ export class HuggingChatExecutor extends BaseExecutor {
 
     let fullText: string;
     try {
-      fullText = await readJsonlResponse(upstreamResponse.body, signal);
+      fullText = await readJsonlResponse(upstreamResponse.body, combinedSignal);
     } catch (err) {
       if (!(err instanceof HuggingChatStreamError)) throw err;
       const message = err instanceof Error ? err.message : String(err);

--- a/open-sse/executors/huggingchat/jsonlStream.ts
+++ b/open-sse/executors/huggingchat/jsonlStream.ts
@@ -1,5 +1,10 @@
 // Pure JSONL stream translation (HuggingChat NDJSON -> OpenAI SSE). Verbatim from huggingchat.ts.
 
+import { HUGGINGCHAT_MAX_BODY_BYTES } from "../../config/constants.ts";
+
+const MAX_BODY_EXCEEDED_MESSAGE =
+  "HuggingChat response exceeded the maximum supported size before completing";
+
 export class HuggingChatStreamError extends Error {
   constructor(message: string) {
     super(message);
@@ -74,15 +79,23 @@ export async function* streamJsonlToOpenAi(
   id: string,
   created: number,
   signal?: AbortSignal | null,
-  cancellationSignal?: AbortSignal | null
+  cancellationSignal?: AbortSignal | null,
+  maxBytes: number = HUGGINGCHAT_MAX_BODY_BYTES
 ): AsyncGenerator<string> {
   const reader = body.getReader();
   const unbindReaderCancellation = bindReaderCancellation(reader, cancellationSignal);
+  // Also bind the plain `signal` so an already-in-flight `reader.read()` unblocks the
+  // instant it aborts, instead of only being noticed the next time the loop polls
+  // `signal?.aborted` (#12577 — a stalled upstream can otherwise leave the read
+  // suspended forever even once a caller-supplied timeout signal has fired).
+  const unbindSignalCancellation = bindReaderCancellation(reader, signal);
   const decoder = new TextDecoder();
   let buffer = "";
   let emittedRole = false;
   let fullText = "";
   let finished = false;
+  let totalBytes = 0;
+  let exceededCap = false;
 
   try {
     while (true) {
@@ -90,6 +103,13 @@ export async function* streamJsonlToOpenAi(
 
       const { value, done } = await reader.read();
       if (done) break;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        exceededCap = true;
+        cancelReader(reader);
+        break;
+      }
 
       buffer += decoder.decode(value, { stream: true });
 
@@ -163,7 +183,7 @@ export async function* streamJsonlToOpenAi(
       if (finished) break;
     }
 
-    if (!finished && buffer.trim()) {
+    if (!finished && !exceededCap && buffer.trim()) {
       const parsed = parseJsonlLine(buffer.trim());
       if (parsed.error) {
         throw new HuggingChatStreamError(parsed.error);
@@ -190,7 +210,24 @@ export async function* streamJsonlToOpenAi(
     }
   } finally {
     unbindReaderCancellation();
+    unbindSignalCancellation();
     reader.releaseLock();
+  }
+
+  if (exceededCap) {
+    yield sseChunk({
+      id,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      error: {
+        message: MAX_BODY_EXCEEDED_MESSAGE,
+        type: "upstream_error",
+        code: "huggingchat_payload_too_large",
+      },
+    });
+    yield "data: [DONE]\n\n";
+    return;
   }
 
   if (!signal?.aborted && !cancellationSignal?.aborted) {
@@ -209,12 +246,19 @@ export async function* streamJsonlToOpenAi(
 
 export async function readJsonlResponse(
   body: ReadableStream<Uint8Array>,
-  signal?: AbortSignal | null
+  signal?: AbortSignal | null,
+  maxBytes: number = HUGGINGCHAT_MAX_BODY_BYTES
 ): Promise<string> {
   const reader = body.getReader();
+  // Bind the signal so an already-in-flight `reader.read()` unblocks the instant it
+  // aborts, instead of only being noticed the next time the loop polls `signal?.aborted`
+  // (#12577 — a stalled upstream can otherwise leave the read suspended forever even
+  // once a caller-supplied timeout signal has fired).
+  const unbindSignalCancellation = bindReaderCancellation(reader, signal);
   const decoder = new TextDecoder();
   let buffer = "";
   let fullText = "";
+  let totalBytes = 0;
 
   try {
     while (true) {
@@ -222,6 +266,12 @@ export async function readJsonlResponse(
 
       const { value, done } = await reader.read();
       if (done) break;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        cancelReader(reader);
+        throw new HuggingChatStreamError(MAX_BODY_EXCEEDED_MESSAGE);
+      }
 
       buffer += decoder.decode(value, { stream: true });
 
@@ -249,6 +299,7 @@ export async function readJsonlResponse(
       if (parsed.error) throw new HuggingChatStreamError(parsed.error);
     }
   } finally {
+    unbindSignalCancellation();
     reader.releaseLock();
   }
 

--- a/tests/unit/huggingchat-jsonlstream-unbounded-buffer.test.ts
+++ b/tests/unit/huggingchat-jsonlstream-unbounded-buffer.test.ts
@@ -1,0 +1,119 @@
+// Regression test for issue #12577: HuggingChat NDJSON executor buffered the
+// upstream body with no byte ceiling and no timeout, so a stalled/hostile
+// upstream that never emits a terminal marker (`finalAnswer` / `status:
+// finished`) drove unbounded memory growth per in-flight request.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  streamJsonlToOpenAi,
+  readJsonlResponse,
+  HuggingChatStreamError,
+} from "../../open-sse/executors/huggingchat/jsonlStream.ts";
+
+const REASONABLE_CAP_BYTES = 2 * 1024 * 1024; // 2 MB
+const TEST_SAFETY_CEILING_BYTES = REASONABLE_CAP_BYTES * 4; // 8 MB
+
+function makeUnboundedStream(): {
+  body: ReadableStream<Uint8Array>;
+  getTotalSent: () => number;
+  getClosedBySafetyCeiling: () => boolean;
+} {
+  const encoder = new TextEncoder();
+  const tokenChunk = "a".repeat(32 * 1024); // 32 KB token payload per line
+  const line = JSON.stringify({ type: "stream", token: tokenChunk }) + "\n";
+  const lineBytes = encoder.encode(line).byteLength;
+
+  let totalSent = 0;
+  let closedBySafetyCeiling = false;
+
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (totalSent >= TEST_SAFETY_CEILING_BYTES) {
+        closedBySafetyCeiling = true;
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(line));
+      totalSent += lineBytes;
+      // Deliberately never emit a finalAnswer/status:finished terminal marker.
+    },
+  });
+
+  return {
+    body,
+    getTotalSent: () => totalSent,
+    getClosedBySafetyCeiling: () => closedBySafetyCeiling,
+  };
+}
+
+test("streamJsonlToOpenAi aborts once accumulated upstream body exceeds a size cap, instead of buffering forever", async () => {
+  const { body, getTotalSent, getClosedBySafetyCeiling } = makeUnboundedStream();
+  const encoder = new TextEncoder();
+
+  let sawUpstreamErrorChunk = false;
+  let bytesReceivedByConsumer = 0;
+
+  for await (const chunk of streamJsonlToOpenAi(
+    body,
+    "gpt-huggingchat",
+    "id-1",
+    0,
+    undefined,
+    undefined,
+    REASONABLE_CAP_BYTES
+  )) {
+    bytesReceivedByConsumer += encoder.encode(chunk).byteLength;
+    if (/upstream_error|too_large|payload.*exceed/i.test(chunk)) {
+      sawUpstreamErrorChunk = true;
+      break;
+    }
+  }
+
+  assert.ok(
+    sawUpstreamErrorChunk,
+    `expected streamJsonlToOpenAi to abort with an upstream-error chunk once the ` +
+      `accumulated body exceeded ~${REASONABLE_CAP_BYTES} bytes, but it kept consuming ` +
+      `upstream data with no ceiling (sent ${getTotalSent()} bytes before the TEST's own ` +
+      `safety ceiling stepped in: closedBySafetyCeiling=${getClosedBySafetyCeiling()}, ` +
+      `bytesReceivedByConsumer=${bytesReceivedByConsumer}). This confirms issue #12577: ` +
+      `no byte cap is enforced on the read loop.`
+  );
+  assert.ok(
+    getTotalSent() < TEST_SAFETY_CEILING_BYTES,
+    "expected the cap to trip well before the test's own 8MB safety ceiling"
+  );
+});
+
+test("readJsonlResponse throws a HuggingChatStreamError once accumulated upstream body exceeds a size cap", async () => {
+  const { body, getClosedBySafetyCeiling } = makeUnboundedStream();
+
+  await assert.rejects(
+    () => readJsonlResponse(body, undefined, REASONABLE_CAP_BYTES),
+    (err: unknown) => err instanceof HuggingChatStreamError
+  );
+  assert.equal(
+    getClosedBySafetyCeiling(),
+    false,
+    "expected the cap to trip well before the test's own 8MB safety ceiling"
+  );
+});
+
+test("streamJsonlToOpenAi terminates the read loop once an idle-timeout signal fires", async () => {
+  const body = new ReadableStream<Uint8Array>({
+    pull() {
+      // Never enqueue and never close: simulates a stalled upstream connection
+      // that sends nothing at all after headers, relying solely on the caller's
+      // timeout signal (mirroring huggingchat.ts's combinedSignal) to unblock.
+    },
+  });
+
+  const idleTimeout = AbortSignal.timeout(50);
+  const chunks: string[] = [];
+
+  for await (const chunk of streamJsonlToOpenAi(body, "gpt-huggingchat", "id-2", 0, idleTimeout)) {
+    chunks.push(chunk);
+  }
+
+  assert.ok(idleTimeout.aborted, "expected the idle-timeout signal to have fired");
+});


### PR DESCRIPTION
Closes #12577

## Root cause

`open-sse/executors/huggingchat/jsonlStream.ts`'s `streamJsonlToOpenAi()` and
`readJsonlResponse()` accumulated the entire upstream NDJSON body into
`buffer`/`fullText` with no byte ceiling and no working timeout — the only
early exit was `signal?.aborted`, checked once per loop iteration, so an
already in-flight `reader.read()` never noticed an abort until the *next*
chunk arrived. Worse, `huggingchat.ts` builds a `combinedSignal` (the request
signal merged with `AbortSignal.timeout(FETCH_TIMEOUT_MS)`) but only wired it
into the two upstream `fetch()` calls — the calls to `streamJsonlToOpenAi`
(~526-532) and `readJsonlResponse` (~563) received the bare `signal`, so the
existing timeout never bounded the body-read phase either. A stalled or
hostile HuggingChat backend that never emits a terminal `finalAnswer` /
`status: finished` marker and never closes the connection could buffer
indefinitely and exhaust the heap.

## Fix

- Added `HUGGINGCHAT_MAX_BODY_BYTES` (4 MiB) in `open-sse/config/constants.ts`
  and threaded a `maxBytes` parameter through both `streamJsonlToOpenAi()` and
  `readJsonlResponse()`. Both now track accumulated bytes per read and cancel
  the reader once the cap is exceeded — the same `readCappedBuffer`/
  `readBodyCapped` pattern already used by `veoaifree-web.ts` and
  `context7-fetch.ts`.
- `streamJsonlToOpenAi()` yields a sanitized `upstream_error` SSE chunk +
  `data: [DONE]` instead of throwing once the cap trips (the HTTP response is
  already committed as 200 by that point). `readJsonlResponse()` throws
  `HuggingChatStreamError`, which `huggingchat.ts`'s existing catch already
  turns into a 502 via `buildErrorBody()` (matching the pre-existing "empty
  response body" 502 pattern) — no new error-response mechanism needed.
- Bound reader cancellation to the plain `signal` (previously only the
  internal `cancellationSignal` was bound) in both functions, so an in-flight
  `reader.read()` unblocks the instant a caller-supplied signal aborts,
  instead of only being noticed on the next loop iteration.
- `huggingchat.ts` now passes `combinedSignal` into both call sites instead of
  the bare `signal`, so the existing `FETCH_TIMEOUT_MS` `AbortSignal.timeout`
  actually bounds the body-read phase too.

## Regression test

`tests/unit/huggingchat-jsonlstream-unbounded-buffer.test.ts` (new file):

- RED (proven against `origin/release/v3.8.51`, unfixed `jsonlStream.ts`):
  `node --import tsx/esm --test tests/unit/huggingchat-jsonlstream-unbounded-buffer.test.ts`
  hung (`SIGTERM` after 60s) — a synthetic upstream emitting only non-terminal
  `stream` token lines drove the read loop past the byte cap with no abort.
- GREEN (fixed): 3/3 tests pass — cap on `streamJsonlToOpenAi()`, cap on
  `readJsonlResponse()`, and idle-timeout-signal termination.

```
✔ streamJsonlToOpenAi aborts once accumulated upstream body exceeds a size cap, instead of buffering forever
✔ readJsonlResponse throws a HuggingChatStreamError once accumulated upstream body exceeds a size cap
✔ streamJsonlToOpenAi terminates the read loop once an idle-timeout signal fires
ℹ tests 3
ℹ pass 3
ℹ fail 0
```

Also re-ran the existing HuggingChat-area suites to confirm no regression:
`executor-huggingchat.test.ts` (6/6 pass), `huggingchat-jsonl-split.test.ts`
(3/3 pass). `huggingchat-stream-error-boundary.test.ts` and
`huggingchat-transport-error-redaction.test.ts` have 1 pre-existing failure
each, confirmed identical on unfixed `origin/release/v3.8.51` (unrelated to
this change).

## Gates run

- `node scripts/check/check-file-size.mjs` → OK
- `node scripts/check/check-complexity.mjs` → OK (2799 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` → clean, exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` → clean
- `node scripts/check/check-changelog-integrity.mjs` → OK
- Focused + existing HuggingChat-area unit tests (see above)

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
