### PR TITLE
fix(routing): recognize CLIProxyAPI unknown-provider 400 as fallback-worthy (#12800)

### DIFF
--- a/changelog.d/fixes/12800-cliproxyapi-unknown-provider.md
+++ b/changelog.d/fixes/12800-cliproxyapi-unknown-provider.md
@@ -1,0 +1,1 @@
+- fix(routing): recognize CLIProxyAPI's 'unknown provider for model' 400 as fallback-worthy (#12800)

--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -373,7 +373,7 @@ export const MODEL_ACCESS_DENIED_PATTERNS = [
   /\bunsupported\s+model\b/i,
   /\baccess.*denied.*model\b/i,
   /\bmodel.*access.*denied\b/i,
-  /\bplease select a different model\b/i,
+  /\bplease select a different model\b/i, /\bunknown\s+provider\s+for\s+model\b/i,
   // "...access to the requested model" / "model ... access" — bounded lookahead
   // (no nested quantifiers) so it stays ReDoS-safe while requiring BOTH an
   // access/permission word and "model" so a pure auth error never matches.
@@ -413,7 +413,7 @@ const PROVIDER_MODEL_UNSUPPORTED_PATTERNS = [
   /\bmodel\b[\s\S]{0,80}?\b(?:does\s+not\s+support|doesn't\s+support|unsupported)\b/i,
   /\b(?:does\s+not\s+support|doesn't\s+support|unsupported)\b[\s\S]{0,80}?\bmodel\b/i,
   /\bunsupported\s+model\b/i,
-  /\bplease select a different model\b/i,
+  /\bplease select a different model\b/i, /\bunknown\s+provider\s+for\s+model\b/i,
 ];
 
 /**

--- a/tests/unit/cliproxyapi-unknown-provider-400-12800.test.ts
+++ b/tests/unit/cliproxyapi-unknown-provider-400-12800.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MODEL_ACCESS_DENIED_PATTERNS,
+  isProviderModelUnsupported400,
+} from "../../open-sse/services/accountFallback.ts";
+
+const CLIPROXYAPI_ERROR_TEXT = "unknown provider for model Qwen/Qwen3.6-27B-TEE";
+
+describe("#12800 — CLIProxyAPI 'unknown provider for model X' classification", () => {
+  it("MODEL_ACCESS_DENIED_PATTERNS should recognize it as a model-access-denied 400", () => {
+    const matches = MODEL_ACCESS_DENIED_PATTERNS.some((p) => p.test(CLIPROXYAPI_ERROR_TEXT));
+    assert.equal(matches, true);
+  });
+
+  it("isProviderModelUnsupported400() should recognize it as provider-wide unsupported", () => {
+    const result = isProviderModelUnsupported400(400, CLIPROXYAPI_ERROR_TEXT);
+    assert.equal(result, true);
+  });
+
+  it("should not match a genuine auth/credential error", () => {
+    const authText = "invalid api key for model Qwen/Qwen3.6-27B-TEE";
+    assert.equal(isProviderModelUnsupported400(400, authText), false);
+  });
+});


### PR DESCRIPTION
Closes #12800

## Root cause

`open-sse/services/accountFallback.ts`'s 400-classifier (`MODEL_ACCESS_DENIED_PATTERNS` and the
narrower `PROVIDER_MODEL_UNSUPPORTED_PATTERNS` feeding `isProviderModelUnsupported400()`)
recognized OpenAI/Anthropic/Copilot-style "model not supported" phrasings, but had no pattern
matching CLIProxyAPI's own router wording: `unknown provider for model <name>`.

Because of this, `checkFallbackError()`'s BAD_REQUEST branch fell through every specific
classification and landed on the generic "400 is not account-fallback-worthy" branch
(`shouldFallback: false`). A dead CLIProxyAPI hop selected for a family alias (e.g. `qwen` ->
`cpc/Qwen/Qwen3.6-27B-TEE`) was never excluded from routing or treated as a hop-exhausted
condition — the raw 400 reached the client verbatim.

## Fix

Added `/\bunknown\s+provider\s+for\s+model\b/i` to both `MODEL_ACCESS_DENIED_PATTERNS` and
`PROVIDER_MODEL_UNSUPPORTED_PATTERNS`. `open-sse/services/accountFallback.ts` is frozen at its
file-size baseline, so the new pattern was appended on the same line as the existing last array
entry in each list rather than as new lines, keeping the file's line count unchanged (net 0
growth). It does not match `AUTH_CREDENTIAL_ERROR_PATTERNS` (verified by a dedicated test case),
so a real credential error keeps rotating through the normal cooldown path instead of being
misclassified.

## Regression test

`tests/unit/cliproxyapi-unknown-provider-400-12800.test.ts` (new, promoted from the plan-file's
proven-red probe):

- RED (before fix, on `release/v3.8.51` tip): 2/2 relevant assertions failed —
  `AssertionError: false !== true` for both `MODEL_ACCESS_DENIED_PATTERNS` matching and
  `isProviderModelUnsupported400()`.
- GREEN (after fix): all 3 tests pass, including the added negative case confirming a genuine
  `invalid api key for model X` auth error is still NOT classified as model-unsupported.

Also ran the existing `tests/unit/account-fallback-service.test.ts` suite (96 tests) — all pass,
no regressions from the pattern addition.

## Gates run

- `node scripts/check/check-file-size.mjs` → OK (accountFallback.ts stayed at its frozen 2467-line budget)
- `node scripts/check/check-complexity.mjs` → OK (2798 violations vs baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` → OK (1265 violations vs baseline 1437)
- `npm run typecheck:core` → exit 0
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json open-sse/services/accountFallback.ts tests/unit/cliproxyapi-unknown-provider-400-12800.test.ts` → exit 0, no new issues
- `node --import tsx/esm --test tests/unit/cliproxyapi-unknown-provider-400-12800.test.ts` → 3/3 pass
- `node --import tsx/esm --test tests/unit/account-fallback-service.test.ts` → 96/96 pass
- `node scripts/check/check-changelog-integrity.mjs` → OK

## Scope note

This PR implements only the first checkbox item from the plan file (the dispatch-time pattern
classification fix), which is the independently-provable, low-risk defect confirmed by the TDD
probe. The plan file's remaining items (validating `cliproxyapi_model_mapping` targets against
CLIProxyAPI's live `/v1/models`, model-lockout wiring for single-hop family aliases) require
reporter confirmation of their config (still `needs-info` on the issue) and/or a live-network
validation design, and are left for a follow-up once that information is available.

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
