### PR TITLE
fix(sse): surface an error for a truly empty Claude stream (#12398)

### DIFF
--- a/changelog.d/fixes/12398-claude-truly-empty-stream.md
+++ b/changelog.d/fixes/12398-claude-truly-empty-stream.md
@@ -1,0 +1,1 @@
+- fix(sse): surface an error instead of a silent empty 200 when a Claude stream closes with zero bytes (#12398)

--- a/open-sse/utils/stream.ts
+++ b/open-sse/utils/stream.ts
@@ -27,6 +27,7 @@ import {
   injectThinkingSignature,
 } from "./streamHelpers.ts";
 import { rejectEmptyChoicesStream, buildEmptyChoicesStreamError } from "./streamEmptyChoices.ts";
+import { shouldAbortEmptyClaudeStream } from "./streamClaudeEmptyBody.ts";
 import { calculateCost } from "@/lib/usage/costCalculator";
 import { buildOmniRouteSseMetadataComment } from "@/domain/omnirouteResponseMeta";
 import { sseCommentsEnabled } from "./sseHeartbeat.ts";
@@ -502,11 +503,6 @@ function shouldInjectClaudeEmptyResponseBeforeCurrentEvent(
   return type === "message_delta" || type === "message_stop";
 }
 
-function shouldInjectClaudeEmptyResponseOnFlush(lifecycle: ClaudeEmptyResponseLifecycle): boolean {
-  if (lifecycle.hasError || lifecycle.hasContentBlock) return false;
-  return hasClaudeAssistantLifecycle(lifecycle);
-}
-
 function shouldInjectClaudeMissingFinalizersOnFlush(
   lifecycle: ClaudeEmptyResponseLifecycle
 ): boolean {
@@ -875,6 +871,10 @@ export function createSSEStream(options: StreamOptions = {}) {
   let idleTimer: ReturnType<typeof setInterval> | null = null;
   let streamTimedOut = false;
   const claudeEmptyResponseLifecycle = createClaudeEmptyResponseLifecycle();
+  // #12398: `timing.firstByteAt` doubles as "any upstream chunk ever arrived".
+  const shouldAbortClaudeStream = () =>
+    clientExpectsClaudeStream &&
+    shouldAbortEmptyClaudeStream(claudeEmptyResponseLifecycle, timing.firstByteAt !== null);
   // `event:` framing is only part of the SSE protocol for OpenAI Responses API
   // and Claude Messages API passthrough; a plain OpenAI Chat-Completions-format
   // client has no `event:` field at all, so it is dropped to stop upstream
@@ -2487,7 +2487,7 @@ export function createSSEStream(options: StreamOptions = {}) {
               }
             }
 
-            if (shouldInjectClaudeEmptyResponseOnFlush(claudeEmptyResponseLifecycle)) {
+            if (shouldAbortClaudeStream()) {
               emitClaudeEmptyStreamErrorAndAbort(controller);
               return;
             } else if (shouldInjectClaudeMissingFinalizersOnFlush(claudeEmptyResponseLifecycle)) {
@@ -2840,7 +2840,7 @@ export function createSSEStream(options: StreamOptions = {}) {
           }
 
           if (sourceFormat === FORMATS.CLAUDE) {
-            if (shouldInjectClaudeEmptyResponseOnFlush(claudeEmptyResponseLifecycle)) {
+            if (shouldAbortClaudeStream()) {
               emitClaudeEmptyStreamErrorAndAbort(controller);
               return;
             } else if (shouldInjectClaudeMissingFinalizersOnFlush(claudeEmptyResponseLifecycle)) {

--- a/open-sse/utils/streamClaudeEmptyBody.ts
+++ b/open-sse/utils/streamClaudeEmptyBody.ts
@@ -1,0 +1,34 @@
+/**
+ * #12398 — decides whether a Claude-format stream must be aborted with an
+ * upstream error at flush time because the client got no usable content.
+ *
+ * Covers two shapes:
+ *  - "partial lifecycle": message_start (and optionally message_delta /
+ *    message_stop) arrived but no content block ever did — this was already
+ *    correctly handled before #12398 and is preserved here unchanged.
+ *  - "truly empty": the upstream connection closed having sent literally
+ *    zero bytes (HTTP 200, not even a message_start). The lifecycle flags
+ *    above can never catch this shape since none of them are ever set — the
+ *    caller must additionally know whether ANY upstream chunk ever arrived.
+ *
+ * Callers must additionally require a Claude-format client (this function
+ * does not take that flag — both call sites in stream.ts only ever reach
+ * here already scoped to a Claude-format response).
+ */
+type ClaudeEmptyLifecycleLike = {
+  hasError: boolean;
+  hasContentBlock: boolean;
+  hasMessageStart: boolean;
+  hasMessageDelta: boolean;
+  hasMessageStop: boolean;
+};
+
+export function shouldAbortEmptyClaudeStream(
+  lifecycle: ClaudeEmptyLifecycleLike,
+  sawAnyUpstreamPayload: boolean
+): boolean {
+  if (lifecycle.hasError || lifecycle.hasContentBlock) return false;
+  const hasPartialLifecycle =
+    lifecycle.hasMessageStart || lifecycle.hasMessageDelta || lifecycle.hasMessageStop;
+  return hasPartialLifecycle || !sawAnyUpstreamPayload;
+}

--- a/tests/unit/claude-stream-truly-empty-body.test.ts
+++ b/tests/unit/claude-stream-truly-empty-body.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression test for issue #12398 — claude-fable-5-max returns an empty
+ * stream past ~1800 messages when stream=true.
+ *
+ * `createSSEStream()`'s Claude-empty-response detector used to only fire
+ * when at least one Claude SSE lifecycle event (message_start /
+ * message_delta / message_stop) had been observed. When the upstream
+ * connection closes having sent
+ * LITERALLY ZERO bytes (no message_start at all — e.g. the connection is
+ * held open, then closes with nothing on it, matching the reporter's
+ * "~14.5s before flush" timing), the flush path used to silently complete
+ * the client stream with a 200 and no content instead of surfacing a 502 —
+ * exactly the reported symptom ("The request does not error; it completes
+ * with no content").
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { createPassthroughStreamWithLogger } = await import("../../open-sse/utils/stream.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+
+async function drainTransform(
+  transform: TransformStream<Uint8Array, Uint8Array>,
+  upstream: ReadableStream<Uint8Array>
+) {
+  const writer = transform.writable.getWriter();
+  const pump = (async () => {
+    const reader = upstream.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await writer.write(value);
+    }
+    await writer.close();
+  })();
+
+  const reader = transform.readable.getReader();
+  const chunks: Uint8Array[] = [];
+  let readError: unknown = null;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+  } catch (e) {
+    readError = e;
+  }
+  try {
+    await pump;
+  } catch (e) {
+    readError = readError ?? e;
+  }
+  const decoded = new TextDecoder().decode(Buffer.concat(chunks.map((c) => Buffer.from(c))));
+  return { chunks, decoded, readError };
+}
+
+test("#12398 truly empty upstream Claude stream (zero bytes, no message_start) surfaces an error", async () => {
+  let failureCalled: unknown = null;
+  let completeCalled: unknown = null;
+
+  const transform = createPassthroughStreamWithLogger(
+    "claude",
+    null,
+    null,
+    "claude-fable-5-max",
+    null,
+    { stream: true },
+    (payload: unknown) => {
+      completeCalled = payload;
+    },
+    null,
+    (failure: unknown) => {
+      failureCalled = failure;
+      return false;
+    },
+    FORMATS.CLAUDE
+  );
+
+  // Upstream connection opens (HTTP 200) but closes having emitted literally
+  // zero bytes — the "held open ~14s then closed with nothing on it" case
+  // from the issue report.
+  const upstream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+  const { decoded, readError } = await drainTransform(transform, upstream);
+
+  const sawClientVisibleError =
+    decoded.includes('"type":"error"') || decoded.includes("event: error");
+  const surfacedAsFailure = readError !== null || failureCalled !== null || sawClientVisibleError;
+
+  assert.equal(
+    surfacedAsFailure,
+    true,
+    "a truly empty (zero-byte) upstream Claude stream must be surfaced as an error " +
+      "(readError, onFailure callback, or a client-visible error SSE event) instead of " +
+      "silently completing with 200 and no content"
+  );
+  assert.equal(
+    completeCalled,
+    null,
+    "onComplete must not fire with a fabricated 200 success payload for a truly empty stream"
+  );
+});
+
+test("#12398 companion: partial-lifecycle empty Claude stream (message_start + message_stop, no content) still errors", async () => {
+  let failureCalled: unknown = null;
+
+  const transform = createPassthroughStreamWithLogger(
+    "claude",
+    null,
+    null,
+    "claude-fable-5-max",
+    null,
+    { stream: true },
+    () => {},
+    null,
+    (failure: unknown) => {
+      failureCalled = failure;
+      return false;
+    },
+    FORMATS.CLAUDE
+  );
+
+  const encoder = new TextEncoder();
+  const upstream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `event: message_start\ndata: ${JSON.stringify({
+            type: "message_start",
+            message: { id: "msg_1", model: "claude-fable-5-max", usage: {} },
+          })}\n\n`
+        )
+      );
+      controller.enqueue(
+        encoder.encode(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`)
+      );
+      controller.close();
+    },
+  });
+
+  const { readError } = await drainTransform(transform, upstream);
+
+  assert.equal(
+    readError !== null || failureCalled !== null,
+    true,
+    "the pre-existing partial-lifecycle empty-response detector (#3685) must keep working"
+  );
+});


### PR DESCRIPTION
Closes #12398

## Root cause

`open-sse/utils/stream.ts`'s Claude empty-response detector
(`hasClaudeAssistantLifecycle()`) only fired once at least one Claude SSE
lifecycle event (`message_start` / `message_delta` / `message_stop`) had
been observed. When an upstream Claude-format response closes having sent
**literally zero bytes** (HTTP 200, not even a `message_start` — the shape
a connection held open for ~14.5s and then closed with nothing on it would
produce), `transform()` is never even invoked, so none of the lifecycle
flags get set and the flush path silently completed the client stream with
a 200 and no content instead of surfacing a 502. This matches the reported
symptom for `claude-fable-5-max` past ~1800 messages ("the request does not
error; it completes with no content").

The *other* variant (`message_start` arrives, then `message_delta`/
`message_stop` with no content block) was already correctly detected and
turned into a 502 — that path (#3685) is unchanged and still covered by
`tests/unit/claude-empty-stream-error-3685.test.ts`.

## Fix

Extended the detector so a Claude-format client that never saw a single
upstream chunk (`timing.firstByteAt === null` at flush time) is also
aborted with the existing `emitClaudeEmptyStreamErrorAndAbort()` 502 path,
at both flush call sites (PASSTHROUGH and TRANSLATE). The combined check
lives in a new `open-sse/utils/streamClaudeEmptyBody.ts` module so the
frozen `open-sse/utils/stream.ts` file size does not grow (net line count
unchanged — an old single-purpose helper was folded into the new combined
one).

Per the plan's own risk note, this fix does **not** attempt an automatic
upstream retry-on-empty-stream — that needs response buffering before any
bytes reach the client and is a materially larger change; left as a
follow-up if wanted.

## Regression test

`tests/unit/claude-stream-truly-empty-body.test.ts` — RED before the fix,
GREEN after:

```
✖ #12398 truly empty upstream Claude stream (zero bytes, no message_start) surfaces an error
  AssertionError: a truly empty (zero-byte) upstream Claude stream must be surfaced as an error ...
  false !== true
```

```
✔ #12398 truly empty upstream Claude stream (zero bytes, no message_start) surfaces an error
✔ #12398 companion: partial-lifecycle empty Claude stream (message_start + message_stop, no content) still errors
```

(RED confirmed by running the test against `origin/release/v3.8.51`'s
unmodified `open-sse/utils/stream.ts` via `git show`, then restoring the
fix — never via `git stash`.)

## Gates run

- `node scripts/check/check-file-size.mjs` — OK (`stream.ts` net line count
  unchanged: 3097 → 3097)
- `node scripts/check/check-complexity.mjs` — OK, 2798 violations (baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK, 1265 violations (baseline 1437)
- `npm run typecheck:core` — clean
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json` on all changed files — clean
- New test: `node --import tsx/esm --test tests/unit/claude-stream-truly-empty-body.test.ts` — 2/2 pass
- Existing Claude/stream-area tests re-run (not just the new one): 179 tests across
  `claude-empty-stream-error-3685`, `stream-claude-delta-contract`,
  `claude-stream-reconstructed-body`, `empty-choices-no-inject`,
  `stream-onfailure-callback-logging`, `stream-utils`, `stream-utilities`,
  `responses-continuation-*`, `stream-numeric-ids`,
  `stream-passthrough-error-redaction`, `sse-comments-optout-9305`,
  `sse-finish-reason-synthesis-7800`, `stream-non-json-sse`,
  `10017-sse-control-lines-leak-openai-clients`, `stream-translate-usage-trailing`,
  `nvidia-tool-compatibility-2840`, `stream-prompt-tokens-zero-upstream`,
  `codex-tool-handoff-disconnect-499`, `stream-passthrough-usage-estimation`,
  `transform-stream-hwm`, `responses-commentary-*` — all 179 pass, including
  the idle-timeout test (confirms the new check does not race the idle watchdog).

## VPS follow-up (not part of this PR)

The plan flags a separate VPS validation to confirm *why* Anthropic's
upstream produces this specific shape for `claude-fable-5-max` at ~1800
messages — that requires live OAuth traffic at scale and doesn't change
the code-level fix, which is scoped to always surfacing an error instead
of a silent empty 200 regardless of the exact upstream trigger.

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
