### PR TITLE
fix(dashboard): honor active compression profile in effective-pipeline preview (#12063)

### DIFF
--- a/changelog.d/fixes/12063-compression-profile-header.md
+++ b/changelog.d/fixes/12063-compression-profile-header.md
@@ -1,0 +1,1 @@
+- fix(dashboard): make the compression "Effective pipeline" preview honor the active profile and warn when the master switch is off (#12063)

--- a/open-sse/services/compression/deriveEffectivePreviewPlan.ts
+++ b/open-sse/services/compression/deriveEffectivePreviewPlan.ts
@@ -1,0 +1,33 @@
+import type { CompressionConfig, CompressionPipelineStep } from "./types.ts";
+import { deriveDefaultPlan, type DerivedPlan } from "./deriveDefaultPlan.ts";
+
+/** Named-combo map: combo id -> its stacked pipeline (operator-defined profiles). */
+export type NamedCombos = Record<string, CompressionPipelineStep[]>;
+
+/**
+ * Derives the plan a live request would actually run, for STATIC preview surfaces (the
+ * Settings-page "Effective pipeline" text — issue #12063). Mirrors resolveBasePlan's
+ * precedence for the two layers that apply to an at-rest preview — the master switch, then an
+ * explicit active profile — but skips the request-scoped layers that don't apply outside a
+ * live call (request header, routing-combo override, auto-trigger): those need per-request
+ * context this static preview does not have.
+ *
+ * Precedence (mirrors strategySelector.ts's resolveBasePlan):
+ *   1. masterEnabled=false                  -> off
+ *   2. activeComboId resolves in combos     -> that profile's stacked pipeline (an explicit
+ *      operator choice, which resolveBasePlan gives precedence over the plain engines-derived
+ *      default)
+ *   3. otherwise                            -> deriveDefaultPlan(engines, enabled)
+ */
+export function deriveEffectivePreviewPlan(
+  config: Pick<CompressionConfig, "engines" | "enabled" | "activeComboId">,
+  combos: NamedCombos = {}
+): DerivedPlan {
+  if (!config.enabled) return { mode: "off", stackedPipeline: [] };
+
+  if (config.activeComboId && combos[config.activeComboId]) {
+    return { mode: "stacked", stackedPipeline: combos[config.activeComboId] };
+  }
+
+  return deriveDefaultPlan(config.engines, config.enabled);
+}

--- a/scripts/ad-hoc/add-12063-i18n-keys.mjs
+++ b/scripts/ad-hoc/add-12063-i18n-keys.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// One-off, scoped i18n key insertion for issue #12063 — adds exactly the two new
+// contextCombos keys (activeProfileMasterSwitchOffWarning / ...Cta) as __MISSING__
+// placeholders to every non-English locale, WITHOUT touching any other pre-existing
+// missing-key drift (running the full `i18n:sync-ui` would also backfill unrelated
+// drift across ~1000 keys, well outside this issue's scope).
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const MESSAGES_DIR = join(process.cwd(), "src/i18n/messages");
+const EN = JSON.parse(readFileSync(join(MESSAGES_DIR, "en.json"), "utf8"));
+
+const NEW_KEYS = ["activeProfileMasterSwitchOffWarning", "activeProfileMasterSwitchOffCta"];
+const NAMESPACE = "contextCombos";
+
+const enValues = Object.fromEntries(NEW_KEYS.map((k) => [k, EN[NAMESPACE][k]]));
+
+const files = readdirSync(MESSAGES_DIR).filter((f) => f.endsWith(".json") && f !== "en.json");
+
+let changed = 0;
+for (const file of files) {
+  const path = join(MESSAGES_DIR, file);
+  const data = JSON.parse(readFileSync(path, "utf8"));
+  if (!data[NAMESPACE]) continue;
+  let touched = false;
+  for (const key of NEW_KEYS) {
+    if (!(key in data[NAMESPACE])) {
+      data[NAMESPACE][key] = `__MISSING__:${enValues[key]}`;
+      touched = true;
+    }
+  }
+  if (touched) {
+    writeFileSync(path, JSON.stringify(data, null, 2) + "\n", "utf8");
+    changed++;
+  }
+}
+
+console.log(`[add-12063-i18n-keys] updated ${changed} locale file(s)`);

--- a/src/app/(dashboard)/dashboard/context/combos/CompressionCombosPageClient.tsx
+++ b/src/app/(dashboard)/dashboard/context/combos/CompressionCombosPageClient.tsx
@@ -3,6 +3,7 @@
 // Combos screen = Compression Hub (top) + named-combos manager (below).
 //
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { STACKED_PIPELINE_ENGINE_INTENSITIES } from "@/shared/validation/compressionConfigSchemas";
 import { CompressionPipelineEditor } from "@/shared/components/compression/CompressionPipelineEditor";
@@ -185,6 +186,22 @@ function NamedCombosManager() {
         <h2 className="text-lg font-semibold text-text-main">{t("namedCombos")}</h2>
         <p className="text-sm text-text-muted">{t("namedCombosDescription")}</p>
       </div>
+
+      {/* #12063: the master "Prompt Compression" switch (Settings page) is a hard kill that
+          runs BEFORE an active profile is even considered (strategySelector.ts resolveBasePlan).
+          Surface that dependency here so a selected profile is never silently inert. */}
+      {!compressionEnabled && activeComboId && (
+        <div
+          role="alert"
+          data-testid="compression-master-switch-warning"
+          className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400"
+        >
+          {t("activeProfileMasterSwitchOffWarning")}{" "}
+          <Link href="/dashboard/context/settings" className="font-medium underline">
+            {t("activeProfileMasterSwitchOffCta")}
+          </Link>
+        </div>
+      )}
 
       <section className="rounded-lg border border-border bg-surface p-4">
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">

--- a/src/app/(dashboard)/dashboard/context/settings/CompressionPanel.tsx
+++ b/src/app/(dashboard)/dashboard/context/settings/CompressionPanel.tsx
@@ -24,7 +24,10 @@ import {
   OUTPUT_STYLE_IDS,
   outputStyleMeta,
 } from "../../../../../../open-sse/services/compression/outputStyles/catalog.ts";
-import { deriveDefaultPlan } from "../../../../../../open-sse/services/compression/deriveDefaultPlan.ts";
+import {
+  deriveEffectivePreviewPlan,
+  type NamedCombos,
+} from "../../../../../../open-sse/services/compression/deriveEffectivePreviewPlan.ts";
 import EngineGuidanceDetail from "./EngineGuidanceDetail";
 import {
   DEFAULT_CONTEXT_BUDGET,
@@ -208,6 +211,9 @@ export default function CompressionPanel() {
   const uiLang = (useLocale() || "en").split("-")[0];
   const [config, setConfig] = useState<CompressionConfig>(DEFAULT_CONFIG);
   const [mcpAccessibility, setMcpAccessibility] = useState(true);
+  // Named-combo pipelines (id -> steps), so the "Effective pipeline" preview below can match
+  // what a live request actually runs when an active profile is selected (#12063).
+  const [namedCombos, setNamedCombos] = useState<NamedCombos>({});
   // #7530 — per-engine expandable guidance (tradeoffs/lossy/cache-impact); collapsed by
   // default so the grid stays scannable.
   const [expandedGuidance, setExpandedGuidance] = useState<Record<string, boolean>>({});
@@ -246,6 +252,16 @@ export default function CompressionPanel() {
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { enabled?: boolean } | null) => {
         if (data && typeof data.enabled === "boolean") setMcpAccessibility(data.enabled);
+      })
+      .catch(() => {});
+
+    fetch("/api/context/combos")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { combos?: Array<{ id: string; pipeline: NamedCombos[string] }> } | null) => {
+        const combos = Array.isArray(data?.combos) ? data.combos : [];
+        const map: NamedCombos = {};
+        for (const combo of combos) map[combo.id] = combo.pipeline;
+        setNamedCombos(map);
       })
       .catch(() => {});
   }, []);
@@ -356,7 +372,7 @@ export default function CompressionPanel() {
     }
   };
 
-  const derived = deriveDefaultPlan(config.engines, config.enabled);
+  const derived = deriveEffectivePreviewPlan(config, namedCombos);
   const derivedText =
     derived.mode === "off"
       ? t("compressionDerivedOff")

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "حزم اللغات: {packs}",
     "dragToReorder": "اسحب لإعادة ترتيب الخطوة",
     "engine": "المحرك",
-    "intensity": "الشدة"
+    "intensity": "الشدة",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "لا يوجد تشغيل ضغط متاح.",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Dil paketləri: {packs}",
     "dragToReorder": "Addımın sırasını dəyişmək üçün sürükləyin",
     "engine": "Mühərrik",
-    "intensity": "İntensivlik"
+    "intensity": "İntensivlik",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Heç bir sıxılma icrası mövcud deyil.",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Езикови пакети: {packs}",
     "dragToReorder": "Плъзнете, за да пренаредите стъпката",
     "engine": "Двигател",
-    "intensity": "Интензивност"
+    "intensity": "Интензивност",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Няма налично изпълнение на компресиране.",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "ভাষা প্যাক: {packs}",
     "dragToReorder": "ধাপের ক্রম পরিবর্তন করতে টেনে আনুন",
     "engine": "ইঞ্জিন",
-    "intensity": "তীব্রতা"
+    "intensity": "তীব্রতা",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "কোনো কম্প্রেশন রান উপলব্ধ নেই।",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Jazykové balíčky: {packs}",
     "dragToReorder": "Přetažením změňte pořadí kroku",
     "engine": "Modul",
-    "intensity": "Intenzita"
+    "intensity": "Intenzita",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Není k dispozici žádný běh komprese.",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Sprogpakker: {packs}",
     "dragToReorder": "Træk for at omarrangere trin",
     "engine": "Motor",
-    "intensity": "Intensitet"
+    "intensity": "Intensitet",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Ingen komprimeringskørsel tilgængelig.",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Sprachpakete: {packs}",
     "dragToReorder": "Ziehen, um Schritt neu anzuordnen",
     "engine": "Engine",
-    "intensity": "Intensität"
+    "intensity": "Intensität",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Kein Komprimierungsdurchlauf verfügbar.",

--- a/src/i18n/messages/el.json
+++ b/src/i18n/messages/el.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Πακέτα γλώσσας: {packs}",
     "dragToReorder": "Σύρετε για αναδιάταξη βήματος",
     "engine": "Μηχανή",
-    "intensity": "Ένταση"
+    "intensity": "Ένταση",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Δεν υπάρχει διαθέσιμη εκτέλεση συμπίεσης.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -8657,6 +8657,8 @@
     "contextEditingNote": "Currently available for Claude (Anthropic) only. It is a delegated mode: the provider clears old tool-use blocks server-side — we do not rewrite the message. It does not affect other providers.",
     "namedCombos": "Named combos",
     "namedCombosDescription": "Save different pipelines and assign them to specific routing combos.",
+    "activeProfileMasterSwitchOffWarning": "The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "Turn it on in Settings",
     "comboNamePlaceholder": "Combo name",
     "descriptionPlaceholder": "Description",
     "nameRequired": "Enter a combo name before saving.",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Language packs: {packs}",
     "dragToReorder": "Drag to reorder step",
     "engine": "Engine",
-    "intensity": "Intensity"
+    "intensity": "Intensity",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "No compression run available.",

--- a/src/i18n/messages/et.json
+++ b/src/i18n/messages/et.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Keelepaketid: {packs}",
     "dragToReorder": "Lohistage etapi järjekorra muutmiseks",
     "engine": "Mootor",
-    "intensity": "Intensiivsus"
+    "intensity": "Intensiivsus",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Ühtegi tihenduskäivitust pole saadaval.",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "بسته‌های زبان: {packs}",
     "dragToReorder": "برای تغییر ترتیب مرحله بکشید",
     "engine": "موتور",
-    "intensity": "شدت"
+    "intensity": "شدت",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "هیچ اجرای فشرده‌سازی موجود نیست.",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Kielipaketit: {packs}",
     "dragToReorder": "Vedä järjestääksesi vaiheen uudelleen",
     "engine": "Moottori",
-    "intensity": "Voimakkuus"
+    "intensity": "Voimakkuus",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Pakkausajoa ei ole saatavilla.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Packs de langue : {packs}",
     "dragToReorder": "Faites glisser pour réorganiser l'étape",
     "engine": "Moteur",
-    "intensity": "Intensité"
+    "intensity": "Intensité",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Aucune exécution de compression disponible.",

--- a/src/i18n/messages/ga.json
+++ b/src/i18n/messages/ga.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Pacáistí teanga: {packs}",
     "dragToReorder": "Tarraing chun céim a atheagrú",
     "engine": "Inneall",
-    "intensity": "Déine"
+    "intensity": "Déine",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Níl aon rith comhbhrú ar fáil.",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "ભાષા પેક: {packs}",
     "dragToReorder": "પગલાંનો ક્રમ બદલવા માટે ખેંચો",
     "engine": "એન્જિન",
-    "intensity": "તીવ્રતા"
+    "intensity": "તીવ્રતા",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "કોઈ કમ્પ્રેશન રન ઉપલબ્ધ નથી.",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "חבילות שפה: {packs}",
     "dragToReorder": "גרור כדי לשנות את סדר השלבים",
     "engine": "מנוע",
-    "intensity": "עוצמה"
+    "intensity": "עוצמה",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "אין הרצת דחיסה זמינה.",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "भाषा पैक: {packs}",
     "dragToReorder": "चरण का क्रम बदलने के लिए खींचें",
     "engine": "इंजन",
-    "intensity": "तीव्रता"
+    "intensity": "तीव्रता",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "कोई कंप्रेशन रन उपलब्ध नहीं है।",

--- a/src/i18n/messages/hr.json
+++ b/src/i18n/messages/hr.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Jezični paketi: {packs}",
     "dragToReorder": "Povucite za promjenu redoslijeda koraka",
     "engine": "Motor",
-    "intensity": "Intenzitet"
+    "intensity": "Intenzitet",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nije dostupno nijedno pokretanje kompresije.",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Nyelvi csomagok: {packs}",
     "dragToReorder": "Húzza a lépés átrendezéséhez",
     "engine": "Motor",
-    "intensity": "Intenzitás"
+    "intensity": "Intenzitás",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nem áll rendelkezésre tömörítési futtatás.",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Paket bahasa: {packs}",
     "dragToReorder": "Seret untuk menyusun ulang langkah",
     "engine": "Mesin",
-    "intensity": "Intensitas"
+    "intensity": "Intensitas",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Tidak ada proses kompresi yang tersedia.",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Pacchetti lingua: {packs}",
     "dragToReorder": "Trascina per riordinare il passaggio",
     "engine": "Motore",
-    "intensity": "Intensità"
+    "intensity": "Intensità",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nessuna esecuzione di compressione disponibile.",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "言語パック: {packs}",
     "dragToReorder": "ドラッグしてステップを並べ替え",
     "engine": "エンジン",
-    "intensity": "強度"
+    "intensity": "強度",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "利用可能な圧縮実行はありません。",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "언어 팩: {packs}",
     "dragToReorder": "드래그하여 단계 순서 변경",
     "engine": "엔진",
-    "intensity": "강도"
+    "intensity": "강도",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "사용 가능한 압축 실행이 없습니다.",

--- a/src/i18n/messages/lt.json
+++ b/src/i18n/messages/lt.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Kalbų paketai: {packs}",
     "dragToReorder": "Vilkite, kad pakeistumėte veiksmo vietą",
     "engine": "Variklis",
-    "intensity": "Intensyvumas"
+    "intensity": "Intensyvumas",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nėra pasiekiamų glaudinimo vykdymo duomenų.",

--- a/src/i18n/messages/lv.json
+++ b/src/i18n/messages/lv.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Valodas pakas: {packs}",
     "dragToReorder": "Velciet, lai pārkārtotu soli",
     "engine": "Dzinējs",
-    "intensity": "Intensitāte"
+    "intensity": "Intensitāte",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nav pieejama saspiešanas izpilde.",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "भाषा पॅक्स: {packs}",
     "dragToReorder": "पायरीचा क्रम बदलण्यासाठी ड्रॅग करा",
     "engine": "इंजिन",
-    "intensity": "तीव्रता"
+    "intensity": "तीव्रता",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "कोणताही कॉम्प्रेशन रन उपलब्ध नाही.",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Pek bahasa: {packs}",
     "dragToReorder": "Seret untuk menyusun semula langkah",
     "engine": "Enjin",
-    "intensity": "Keamatan"
+    "intensity": "Keamatan",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Tiada larian pemampatan tersedia.",

--- a/src/i18n/messages/mt.json
+++ b/src/i18n/messages/mt.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Pakketti tal-lingwa: {packs}",
     "dragToReorder": "Iddreggja biex tibdel l-ordni tal-pass",
     "engine": "Magna",
-    "intensity": "Intensità"
+    "intensity": "Intensità",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Ebda eżekuzzjoni tal-kompressjoni mhi disponibbli.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Taalpakketten: {packs}",
     "dragToReorder": "Sleep om stap opnieuw te ordenen",
     "engine": "Engine",
-    "intensity": "Intensiteit"
+    "intensity": "Intensiteit",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Geen compressierun beschikbaar.",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Språkpakker: {packs}",
     "dragToReorder": "Dra for å endre rekkefølge på trinn",
     "engine": "Motor",
-    "intensity": "Intensitet"
+    "intensity": "Intensitet",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Ingen komprimeringskjøring tilgjengelig.",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Mga language pack: {packs}",
     "dragToReorder": "I-drag upang muling isaayos ang hakbang",
     "engine": "Engine",
-    "intensity": "Intensity"
+    "intensity": "Intensity",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Walang available na compression run.",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Pakiety językowe: {packs}",
     "dragToReorder": "Przeciągnij, aby zmienić kolejność kroku",
     "engine": "Silnik",
-    "intensity": "Intensywność"
+    "intensity": "Intensywność",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Brak dostępnego przebiegu kompresji.",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -8671,7 +8671,9 @@
     "languagePacksList": "Pacotes de idioma: {packs}",
     "dragToReorder": "Arraste para reordenar a etapa",
     "engine": "Engine",
-    "intensity": "Intensidade"
+    "intensity": "Intensidade",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nenhuma execução de compressão disponível.",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Pacotes de idioma: {packs}",
     "dragToReorder": "Arraste para reordenar o passo",
     "engine": "Motor",
-    "intensity": "Intensidade"
+    "intensity": "Intensidade",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nenhuma execução de compressão disponível.",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Pachete de limbi: {packs}",
     "dragToReorder": "Trageți pentru a reordona pasul",
     "engine": "Motor",
-    "intensity": "Intensitate"
+    "intensity": "Intensitate",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nicio rulare de compresie disponibilă.",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Языковые пакеты: {packs}",
     "dragToReorder": "Перетащите для изменения порядка шагов",
     "engine": "Движок",
-    "intensity": "Интенсивность"
+    "intensity": "Интенсивность",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Нет доступных запусков сжатия.",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Jazykové balíčky: {packs}",
     "dragToReorder": "Potiahnutím zmeníte poradie kroku",
     "engine": "Engine",
-    "intensity": "Intenzita"
+    "intensity": "Intenzita",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Nie je k dispozícii žiadny beh kompresie.",

--- a/src/i18n/messages/sl.json
+++ b/src/i18n/messages/sl.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Jezikovni paketi: {packs}",
     "dragToReorder": "Povlecite, da spremenite vrstni red koraka",
     "engine": "Mehanizem",
-    "intensity": "Intenzivnost"
+    "intensity": "Intenzivnost",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Na voljo ni nobene izvedbe stiskanja.",

--- a/src/i18n/messages/sr.json
+++ b/src/i18n/messages/sr.json
@@ -8642,7 +8642,9 @@
     "languagePacksList": "Језички пакети: {packs}",
     "dragToReorder": "Превуците да преместите корак",
     "engine": "Механизам",
-    "intensity": "Интензитет"
+    "intensity": "Интензитет",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Нема доступног извршавања компресије.",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Språkpaket: {packs}",
     "dragToReorder": "Dra för att ändra ordning på steg",
     "engine": "Motor",
-    "intensity": "Intensitet"
+    "intensity": "Intensitet",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Ingen komprimeringskörning tillgänglig.",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Vifurushi vya lugha: {packs}",
     "dragToReorder": "Buruta ili kupanga upya hatua",
     "engine": "Injini",
-    "intensity": "Ukali"
+    "intensity": "Ukali",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Hakuna uendeshaji wa mbano unaopatikana.",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "மொழிப் பொதிகள்: {packs}",
     "dragToReorder": "படியை மறுவரிசைப்படுத்த இழுக்கவும்",
     "engine": "எஞ்சின்",
-    "intensity": "தீவிரம்"
+    "intensity": "தீவிரம்",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "சுருக்க இயக்கம் எதுவும் கிடைக்கவில்லை.",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "భాషా ప్యాక్‌లు: {packs}",
     "dragToReorder": "దశను క్రమబద్ధీకరించడానికి డ్రాగ్ చేయండి",
     "engine": "ఇంజిన్",
-    "intensity": "తీవ్రత"
+    "intensity": "తీవ్రత",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "ఎటువంటి కంప్రెషన్ రన్ అందుబాటులో లేదు.",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "แพ็กภาษา: {packs}",
     "dragToReorder": "ลากเพื่อจัดลำดับขั้นตอนใหม่",
     "engine": "เอนจิน",
-    "intensity": "ความเข้ม"
+    "intensity": "ความเข้ม",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "ไม่มีการรันการบีบอัดที่พร้อมใช้งาน",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Dil paketleri: {packs}",
     "dragToReorder": "Adımı yeniden sıralamak için sürükleyin",
     "engine": "Motor",
-    "intensity": "Yoğunluk"
+    "intensity": "Yoğunluk",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Kullanılabilir sıkıştırma çalışması yok.",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "Мовні пакети: {packs}",
     "dragToReorder": "Перетягніть, щоб змінити порядок кроків",
     "engine": "Рушій",
-    "intensity": "Інтенсивність"
+    "intensity": "Інтенсивність",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Немає доступних запусків стиснення.",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "زبان کے پیک: {packs}",
     "dragToReorder": "مرحلے کو دوبارہ ترتیب دینے کے لیے گھسیٹیں",
     "engine": "انجن",
-    "intensity": "شدت"
+    "intensity": "شدت",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "کوئی کمپریشن رن دستیاب نہیں ہے۔",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -8671,7 +8671,9 @@
     "languagePacksList": "Gói ngôn ngữ: {packs}",
     "dragToReorder": "Kéo để sắp xếp lại bước",
     "engine": "Bộ máy",
-    "intensity": "Cường độ"
+    "intensity": "Cường độ",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "Chưa có lượt nén nào.",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "语言包：{packs}",
     "dragToReorder": "拖动以重新排序步骤",
     "engine": "引擎",
-    "intensity": "强度"
+    "intensity": "强度",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "没有可用的压缩运行记录。",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -8667,7 +8667,9 @@
     "languagePacksList": "語言包：{packs}",
     "dragToReorder": "拖曳以重新排序步驟",
     "engine": "引擎",
-    "intensity": "強度"
+    "intensity": "強度",
+    "activeProfileMasterSwitchOffWarning": "__MISSING__:The active profile below will not run until the master \"Prompt Compression\" switch is turned on.",
+    "activeProfileMasterSwitchOffCta": "__MISSING__:Turn it on in Settings"
   },
   "compressionStudio": {
     "noRun": "無可用的壓縮執行記錄。",

--- a/tests/unit/compression/derive-effective-preview-plan.test.ts
+++ b/tests/unit/compression/derive-effective-preview-plan.test.ts
@@ -1,0 +1,82 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_COMPRESSION_CONFIG,
+  type CompressionConfig,
+} from "@omniroute/open-sse/services/compression/types.ts";
+import { selectCompressionPlan } from "@omniroute/open-sse/services/compression/strategySelector.ts";
+import { deriveEffectivePreviewPlan } from "@omniroute/open-sse/services/compression/deriveEffectivePreviewPlan.ts";
+
+// Issue #12063: the dashboard shows an "active profile" selected (e.g. "Standard Savings",
+// pipeline rtk:standard -> caveman:full on /dashboard/context/combos), but the Settings-page
+// "Effective pipeline" preview disagreed with what a live request actually runs, because it
+// was computed as deriveDefaultPlan(config.engines, config.enabled) -- which never consults
+// config.activeComboId, unlike the real per-request resolver (resolveBasePlan).
+// deriveEffectivePreviewPlan() closes that gap for static preview surfaces.
+
+const namedCombos = {
+  "standard-savings": [
+    { engine: "rtk", intensity: "standard" },
+    { engine: "caveman", intensity: "full" },
+  ],
+};
+
+test("issue #12063: preview matches the real runtime plan when a profile is active", () => {
+  const config: CompressionConfig = {
+    ...DEFAULT_COMPRESSION_CONFIG,
+    enabled: true,
+    activeComboId: "standard-savings",
+    // No individual engine toggled on the Settings page grid.
+  };
+
+  const realRuntimePlan = selectCompressionPlan(
+    config,
+    /* comboId */ null,
+    /* estimatedTokens */ 50_000,
+    undefined,
+    undefined,
+    namedCombos,
+    /* header */ null
+  );
+  assert.equal(realRuntimePlan.mode, "stacked");
+  assert.deepEqual(realRuntimePlan.stackedPipeline, namedCombos["standard-savings"]);
+
+  const previewPlan = deriveEffectivePreviewPlan(config, namedCombos);
+  assert.equal(previewPlan.mode, realRuntimePlan.mode);
+  assert.deepEqual(previewPlan.stackedPipeline, realRuntimePlan.stackedPipeline);
+});
+
+test("master switch off => off, regardless of an active profile", () => {
+  const config: CompressionConfig = {
+    ...DEFAULT_COMPRESSION_CONFIG,
+    enabled: false,
+    activeComboId: "standard-savings",
+  };
+  assert.deepEqual(deriveEffectivePreviewPlan(config, namedCombos), {
+    mode: "off",
+    stackedPipeline: [],
+  });
+});
+
+test("activeComboId set but unresolved in combos => falls back to the engines map", () => {
+  const config: CompressionConfig = {
+    ...DEFAULT_COMPRESSION_CONFIG,
+    enabled: true,
+    activeComboId: "does-not-exist",
+    engines: { rtk: { enabled: true, level: "standard" } },
+  };
+  const preview = deriveEffectivePreviewPlan(config, namedCombos);
+  assert.equal(preview.mode, "rtk");
+});
+
+test("no active profile => matches deriveDefaultPlan(engines, enabled) exactly", () => {
+  const config: CompressionConfig = {
+    ...DEFAULT_COMPRESSION_CONFIG,
+    enabled: true,
+    activeComboId: null,
+    engines: { caveman: { enabled: true, level: "full" } },
+  };
+  const preview = deriveEffectivePreviewPlan(config, namedCombos);
+  assert.equal(preview.mode, "standard");
+  assert.deepEqual(preview.stackedPipeline, []);
+});


### PR DESCRIPTION
Closes #12063

## Root cause

The Settings-page "Effective pipeline" preview (`CompressionPanel.tsx`) was computed as
`deriveDefaultPlan(config.engines, config.enabled)`, which only looks at the master switch and
the per-engine toggle grid — it never consults `config.activeComboId`. The real per-request
resolver (`resolveBasePlan` in `open-sse/services/compression/strategySelector.ts`) gives an
active named profile precedence *over* the plain engines-derived default. So whenever an
operator picked a named profile on the Combos page but hadn't also flipped an individual engine
toggle on the Settings page, the preview showed "off" while a live request actually ran the
active profile's stacked pipeline — the reported disconnect between the UI and the
`x-omniroute-compression` response header.

Separately, the Combos page already fetches `settings.enabled` (the master switch) but never
surfaced it: a profile could show as "active" while the master switch (default `off` on a fresh
install) hard-kills all compression before `activeComboId` is even read.

## Fix

- Added `deriveEffectivePreviewPlan(config, combos)`
  (`open-sse/services/compression/deriveEffectivePreviewPlan.ts`), a pure helper for STATIC
  preview surfaces that mirrors `resolveBasePlan`'s precedence for the layers that apply
  at rest (master switch → active profile → engines-map default), skipping the
  request-scoped layers (header, routing override, auto-trigger) that need live-request
  context a static preview doesn't have.
- `CompressionPanel.tsx` now fetches the named-combo map (`/api/context/combos`) and uses
  `deriveEffectivePreviewPlan` instead of the bare `deriveDefaultPlan` call, so "Effective
  pipeline" always matches what a live request would actually run.
- `CompressionCombosPageClient.tsx` now renders a visible warning banner (new i18n keys
  `contextCombos.activeProfileMasterSwitchOffWarning` / `...Cta`) when an active profile is
  selected but the master switch is off, linking to the Settings page.
- `resolveBasePlan`/`selectCompressionPlan` (the actual request-time precedence) are
  **untouched** — this is a display/UX-only fix, confirmed by the full pre-existing
  `strategySelector`/`deriveDefaultPlan`/active-combo test suite passing unchanged (65 tests).

## Regression test

`tests/unit/compression/derive-effective-preview-plan.test.ts` — extends the plan-file's proven
RED repro into a permanent guard (master-off, active-profile-resolves, unresolved-profile
fallback, no-active-profile parity with `deriveDefaultPlan`).

The original repro (documented in the analysis plan-file, re-verified here) was RED against the
prior code:
```
✖ issue #12063: Settings-page preview must match the real runtime plan when a profile is active
  AssertionError [ERR_ASSERTION]: ... 'off' !== 'stacked'
```

GREEN after the fix:
```
node --import tsx/esm --test tests/unit/compression/derive-effective-preview-plan.test.ts
✔ issue #12063: preview matches the real runtime plan when a profile is active
✔ master switch off => off, regardless of an active profile
✔ activeComboId set but unresolved in combos => falls back to the engines map
✔ no active profile => matches deriveDefaultPlan(engines, enabled) exactly
ℹ tests 4 / pass 4 / fail 0
```

## Gates run (all green)

- `node scripts/check/check-file-size.mjs` — OK, no new frozen violations
- `node scripts/check/check-complexity.mjs` — OK (2798 violations, baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations, baseline 1437)
- `npm run typecheck:core` — exit 0
- `npm run typecheck:noimplicit:core` — exit 0
- `npm run check:dashboard-typecheck` — OK, 206 pre-existing errors all within frozen baseline
  (none in touched files)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` —
  exit 0
- `node scripts/check/check-t11-any-budget.mjs` — PASS
- `node scripts/check/check-tracked-artifacts.mjs` — OK
- `node scripts/check/check-changelog-integrity.mjs` — OK
- `npm run i18n:check-ui-coverage` — PASS, all 50 locales ≥80% (the two new i18n keys were added
  as `__MISSING__:` placeholders to all non-English locales — a scoped, ad-hoc insertion
  (`scripts/ad-hoc/add-12063-i18n-keys.mjs`) rather than the full `i18n:sync-ui`, so the diff
  touches only these 2 keys per locale and does not also backfill ~1000 unrelated pre-existing
  missing keys)
- `node --import tsx/esm --test tests/unit/compression/derive-default-plan.test.ts tests/unit/compression/derive-effective-preview-plan.test.ts` — 8/8 pass
- Full pre-existing compression-precedence suite (`strategySelector.test.ts`,
  `active-combo-dispatch.test.ts`, `active-combo-integration.test.ts`,
  `derived-pipeline-integration.test.ts`, `compression-header-dispatch.test.ts`,
  `adaptive-select-plan-wiring.test.ts`, `adaptive-chatcore-source-guard.test.ts`) — 65/65 pass
  unchanged, confirming request-time precedence was not touched
- `npx vitest run tests/unit/ui/compressionPanel.test.tsx` — 4/4 pass unchanged

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact,
tarball-smoke, agent-skills-sync
