### PR TITLE
fix(dashboard): surface combined-pipeline error in Compression Studio Run (#12061)

### DIFF
--- a/changelog.d/fixes/12061-compression-studio-run-error.md
+++ b/changelog.d/fixes/12061-compression-studio-run-error.md
@@ -1,0 +1,1 @@
+- fix(dashboard): surface a visible error when Compression Studio's combined preview run fails (#12061)

--- a/src/app/(dashboard)/dashboard/compression/studio/PlayView.tsx
+++ b/src/app/(dashboard)/dashboard/compression/studio/PlayView.tsx
@@ -109,6 +109,11 @@ export function PlayView({ text, onText, laneEngines = LANE_ENGINES }: PlayViewP
             <RiskGateBadge stats={batch?.riskGate ?? null} />
           </section>
         )}
+        {batch && !batch.combined && batch.combinedError && (
+          <section data-testid="play-combined-error" className="text-xs text-red-600">
+            {t("combinedError", { reason: batch.combinedError })}
+          </section>
+        )}
         <section>
           <header className="text-xs font-semibold">{t("eachLayer")}</header>
           <LaneList lanes={batch?.lanes ?? []} onSelect={setSelectedLane} />

--- a/src/hooks/usePreviewCompression.ts
+++ b/src/hooks/usePreviewCompression.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 import { previewToRunModel, type CompressionRunModel, type PreviewResponse } from "@/app/(dashboard)/dashboard/compression/studio/compressionFlowModel";
 export interface PreviewMessage { role: string; content: unknown; }
 export interface Lane { engine: string; run: CompressionRunModel | null; error: string | null; }
-export interface PreviewBatch { lanes: Lane[]; combined: CompressionRunModel | null; diff: PreviewResponse["diff"] | null; riskGate: PreviewResponse["riskGate"] | null; heatmap: PreviewResponse["heatmap"] | null; }
+export interface PreviewBatch { lanes: Lane[]; combined: CompressionRunModel | null; combinedError: string | null; diff: PreviewResponse["diff"] | null; riskGate: PreviewResponse["riskGate"] | null; heatmap: PreviewResponse["heatmap"] | null; }
 export interface RunPreviewArgs { messages: PreviewMessage[]; laneEngines: string[]; activeEngines: string[]; language?: string; fidelityGate?: boolean; fuzzyDedup?: boolean; riskGate?: boolean; quantumLock?: boolean; heatmap?: "ultra" | "universal"; }
 async function postPreview(payload: Record<string, unknown>): Promise<PreviewResponse> {
   const res = await fetch("/api/compression/preview", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
@@ -27,14 +27,15 @@ export async function runPreviewBatch(args: RunPreviewArgs): Promise<PreviewBatc
     })
   );
   let combined: CompressionRunModel | null = null;
+  let combinedError: string | null = null;
   let diff: PreviewResponse["diff"] | null = null;
   let riskGateStats: PreviewResponse["riskGate"] | null = null;
   let heatmapResult: PreviewResponse["heatmap"] | null = null;
   if (activeEngines.length > 0) {
     try { const res = await postPreview({ messages, pipeline: activeEngines, ...extra }); combined = previewToRunModel(res, activeEngines.join(" → ")); diff = res.diff; riskGateStats = res.riskGate ?? null; heatmapResult = res.heatmap ?? null; }
-    catch { combined = null; }
+    catch (e) { combined = null; combinedError = e instanceof Error ? e.message : "error"; }
   }
-  return { lanes, combined, diff, riskGate: riskGateStats, heatmap: heatmapResult };
+  return { lanes, combined, combinedError, diff, riskGate: riskGateStats, heatmap: heatmapResult };
 }
 export function usePreviewCompression() {
   const [batch, setBatch] = useState<PreviewBatch | null>(null);

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -8696,6 +8696,7 @@
     "run": "تشغيل",
     "laneRejected": "تم الرفض: {reason}",
     "error": "خطأ",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "التدفق المدمج",
     "eachLayer": "كل طبقة على حدة",
     "diff": "الفرق",

--- a/src/i18n/messages/az.json
+++ b/src/i18n/messages/az.json
@@ -8696,6 +8696,7 @@
     "run": "İcra et",
     "laneRejected": "rədd edildi: {reason}",
     "error": "xəta",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombinə edilmiş axın",
     "eachLayer": "Hər qat ayrıca",
     "diff": "Fərq",

--- a/src/i18n/messages/bg.json
+++ b/src/i18n/messages/bg.json
@@ -8696,6 +8696,7 @@
     "run": "Стартиране",
     "laneRejected": "отхвърлено: {reason}",
     "error": "грешка",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Комбиниран поток",
     "eachLayer": "Всеки слой поотделно",
     "diff": "Разлика",

--- a/src/i18n/messages/bn.json
+++ b/src/i18n/messages/bn.json
@@ -8696,6 +8696,7 @@
     "run": "রান করুন",
     "laneRejected": "প্রত্যাখ্যাত: {reason}",
     "error": "ত্রুটি",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "সম্মিলিত ফ্লো",
     "eachLayer": "প্রতিটি লেয়ার আলাদাভাবে",
     "diff": "পার্থক্য",

--- a/src/i18n/messages/cs.json
+++ b/src/i18n/messages/cs.json
@@ -8696,6 +8696,7 @@
     "run": "Spustit",
     "laneRejected": "zamítnuto: {reason}",
     "error": "chyba",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombinovaný tok",
     "eachLayer": "Každá vrstva zvlášť",
     "diff": "Rozdíl",

--- a/src/i18n/messages/da.json
+++ b/src/i18n/messages/da.json
@@ -8696,6 +8696,7 @@
     "run": "Kør",
     "laneRejected": "afvist: {reason}",
     "error": "fejl",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombineret flow",
     "eachLayer": "Hvert lag separat",
     "diff": "Forskel",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -8696,6 +8696,7 @@
     "run": "Ausführen",
     "laneRejected": "abgelehnt: {reason}",
     "error": "Fehler",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombinierter Ablauf",
     "eachLayer": "Jede Ebene einzeln",
     "diff": "Differenz",

--- a/src/i18n/messages/el.json
+++ b/src/i18n/messages/el.json
@@ -8671,6 +8671,7 @@
     "run": "Εκτέλεση",
     "laneRejected": "απορρίφθηκε: {reason}",
     "error": "σφάλμα",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Συνδυασμένη ροή",
     "eachLayer": "Κάθε επίπεδο ξεχωριστά",
     "diff": "Διαφορά",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -8699,6 +8699,7 @@
     "run": "Run",
     "laneRejected": "rejected: {reason}",
     "error": "error",
+    "combinedError": "Combined pipeline preview failed: {reason}",
     "combinedFlow": "Combined flow",
     "eachLayer": "Each layer separately",
     "diff": "Difference",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -8696,6 +8696,7 @@
     "run": "Run",
     "laneRejected": "rejected: {reason}",
     "error": "error",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Combined flow",
     "eachLayer": "Each layer separately",
     "diff": "Difference",

--- a/src/i18n/messages/et.json
+++ b/src/i18n/messages/et.json
@@ -8671,6 +8671,7 @@
     "run": "Käivita",
     "laneRejected": "tagasi lükatud: {reason}",
     "error": "viga",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombineeritud voog",
     "eachLayer": "Iga kiht eraldi",
     "diff": "Erinevus",

--- a/src/i18n/messages/fa.json
+++ b/src/i18n/messages/fa.json
@@ -8696,6 +8696,7 @@
     "run": "اجرا",
     "laneRejected": "رد شد: {reason}",
     "error": "خطا",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "جریان ترکیبی",
     "eachLayer": "هر لایه به‌صورت جداگانه",
     "diff": "تفاوت",

--- a/src/i18n/messages/fi.json
+++ b/src/i18n/messages/fi.json
@@ -8696,6 +8696,7 @@
     "run": "Suorita",
     "laneRejected": "hylätty: {reason}",
     "error": "virhe",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Yhdistetty vuo",
     "eachLayer": "Jokainen kerros erikseen",
     "diff": "Ero",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -8696,6 +8696,7 @@
     "run": "Exécuter",
     "laneRejected": "rejeté : {reason}",
     "error": "erreur",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Flux combiné",
     "eachLayer": "Chaque couche séparément",
     "diff": "Différence",

--- a/src/i18n/messages/ga.json
+++ b/src/i18n/messages/ga.json
@@ -8671,6 +8671,7 @@
     "run": "Rith",
     "laneRejected": "diútaíodh: {reason}",
     "error": "earráid",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Sruth comhcheangailte",
     "eachLayer": "Gach sraith ina n-aonar",
     "diff": "Difríocht",

--- a/src/i18n/messages/gu.json
+++ b/src/i18n/messages/gu.json
@@ -8696,6 +8696,7 @@
     "run": "ચલાવો",
     "laneRejected": "નકારવામાં આવ્યું: {reason}",
     "error": "ભૂલ",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "સંયુક્ત પ્રવાહ",
     "eachLayer": "દરેક સ્તર અલગથી",
     "diff": "તફાવત",

--- a/src/i18n/messages/he.json
+++ b/src/i18n/messages/he.json
@@ -8696,6 +8696,7 @@
     "run": "הרץ",
     "laneRejected": "נדחה: {reason}",
     "error": "שגיאה",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "זרימה משולבת",
     "eachLayer": "כל שכבה בנפרד",
     "diff": "הבדל",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -8696,6 +8696,7 @@
     "run": "चलाएं",
     "laneRejected": "अस्वीकृत: {reason}",
     "error": "त्रुटि",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "संयुक्त प्रवाह",
     "eachLayer": "प्रत्येक परत अलग से",
     "diff": "अंतर",

--- a/src/i18n/messages/hr.json
+++ b/src/i18n/messages/hr.json
@@ -8671,6 +8671,7 @@
     "run": "Pokreni",
     "laneRejected": "odbijeno: {reason}",
     "error": "pogreška",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombinirani tok",
     "eachLayer": "Svaki sloj zasebno",
     "diff": "Razlika",

--- a/src/i18n/messages/hu.json
+++ b/src/i18n/messages/hu.json
@@ -8696,6 +8696,7 @@
     "run": "Futtatás",
     "laneRejected": "elutasítva: {reason}",
     "error": "hiba",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Összevont folyamat",
     "eachLayer": "Minden réteg külön-külön",
     "diff": "Különbség",

--- a/src/i18n/messages/id.json
+++ b/src/i18n/messages/id.json
@@ -8696,6 +8696,7 @@
     "run": "Jalankan",
     "laneRejected": "ditolak: {reason}",
     "error": "kesalahan",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Alur gabungan",
     "eachLayer": "Setiap lapisan secara terpisah",
     "diff": "Perbedaan",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -8696,6 +8696,7 @@
     "run": "Esegui",
     "laneRejected": "rifiutato: {reason}",
     "error": "errore",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Flusso combinato",
     "eachLayer": "Ogni livello separatamente",
     "diff": "Differenza",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -8696,6 +8696,7 @@
     "run": "実行",
     "laneRejected": "拒否されました: {reason}",
     "error": "エラー",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "結合フロー",
     "eachLayer": "各レイヤー個別",
     "diff": "差分",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -8696,6 +8696,7 @@
     "run": "실행",
     "laneRejected": "거부됨: {reason}",
     "error": "오류",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "결합된 흐름",
     "eachLayer": "각 레이어 개별",
     "diff": "차이",

--- a/src/i18n/messages/lt.json
+++ b/src/i18n/messages/lt.json
@@ -8671,6 +8671,7 @@
     "run": "Vykdyti",
     "laneRejected": "atmesta: {reason}",
     "error": "klaida",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Jungtinė eiga",
     "eachLayer": "Kiekvienas sluoksnis atskirai",
     "diff": "Skirtumas",

--- a/src/i18n/messages/lv.json
+++ b/src/i18n/messages/lv.json
@@ -8671,6 +8671,7 @@
     "run": "Izpildīt",
     "laneRejected": "noraidīts: {reason}",
     "error": "kļūda",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Apvienotā plūsma",
     "eachLayer": "Katrs slānis atsevišķi",
     "diff": "Atšķirība",

--- a/src/i18n/messages/mr.json
+++ b/src/i18n/messages/mr.json
@@ -8696,6 +8696,7 @@
     "run": "चालवा",
     "laneRejected": "नाकारले: {reason}",
     "error": "त्रुटी",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "एकत्रित फ्लो",
     "eachLayer": "प्रत्येक लेयर स्वतंत्रपणे",
     "diff": "फरक",

--- a/src/i18n/messages/ms.json
+++ b/src/i18n/messages/ms.json
@@ -8696,6 +8696,7 @@
     "run": "Jalankan",
     "laneRejected": "ditolak: {reason}",
     "error": "ralat",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Aliran gabungan",
     "eachLayer": "Setiap lapisan secara berasingan",
     "diff": "Perbezaan",

--- a/src/i18n/messages/mt.json
+++ b/src/i18n/messages/mt.json
@@ -8671,6 +8671,7 @@
     "run": "Ħaddem",
     "laneRejected": "irrifjutat: {reason}",
     "error": "żball",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Fluss ikkombinat",
     "eachLayer": "Kull saff separatament",
     "diff": "Differenza",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -8696,6 +8696,7 @@
     "run": "Uitvoeren",
     "laneRejected": "afgewezen: {reason}",
     "error": "fout",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Gecombineerde flow",
     "eachLayer": "Elke laag afzonderlijk",
     "diff": "Verschil",

--- a/src/i18n/messages/no.json
+++ b/src/i18n/messages/no.json
@@ -8696,6 +8696,7 @@
     "run": "Kjør",
     "laneRejected": "avvist: {reason}",
     "error": "feil",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombinert flyt",
     "eachLayer": "Hvert lag separat",
     "diff": "Differanse",

--- a/src/i18n/messages/phi.json
+++ b/src/i18n/messages/phi.json
@@ -8696,6 +8696,7 @@
     "run": "Patakbuhin",
     "laneRejected": "tinanggihan: {reason}",
     "error": "error",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Pinagsamang flow",
     "eachLayer": "Bawat layer nang hiwalay",
     "diff": "Pagkakaiba",

--- a/src/i18n/messages/pl.json
+++ b/src/i18n/messages/pl.json
@@ -8696,6 +8696,7 @@
     "run": "Uruchom",
     "laneRejected": "odrzucono: {reason}",
     "error": "błąd",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Połączony przepływ",
     "eachLayer": "Każda warstwa osobno",
     "diff": "Różnica",

--- a/src/i18n/messages/pt-BR.json
+++ b/src/i18n/messages/pt-BR.json
@@ -8700,6 +8700,7 @@
     "run": "Executar",
     "laneRejected": "rejeitado: {reason}",
     "error": "erro",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Fluxo combinado",
     "eachLayer": "Cada camada separadamente",
     "diff": "Diferença",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -8696,6 +8696,7 @@
     "run": "Executar",
     "laneRejected": "rejeitado: {reason}",
     "error": "erro",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Fluxo combinado",
     "eachLayer": "Cada camada separadamente",
     "diff": "Diferença",

--- a/src/i18n/messages/ro.json
+++ b/src/i18n/messages/ro.json
@@ -8696,6 +8696,7 @@
     "run": "Rulează",
     "laneRejected": "respins: {reason}",
     "error": "eroare",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Flux combinat",
     "eachLayer": "Fiecare strat separat",
     "diff": "Diferență",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -8696,6 +8696,7 @@
     "run": "Запустить",
     "laneRejected": "отклонено: {reason}",
     "error": "ошибка",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Комбинированный поток",
     "eachLayer": "Каждый слой отдельно",
     "diff": "Разница",

--- a/src/i18n/messages/sk.json
+++ b/src/i18n/messages/sk.json
@@ -8696,6 +8696,7 @@
     "run": "Spustiť",
     "laneRejected": "odmietnuté: {reason}",
     "error": "chyba",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombinovaný tok",
     "eachLayer": "Každá vrstva samostatne",
     "diff": "Rozdiel",

--- a/src/i18n/messages/sl.json
+++ b/src/i18n/messages/sl.json
@@ -8671,6 +8671,7 @@
     "run": "Zaženi",
     "laneRejected": "zavrnjeno: {reason}",
     "error": "napaka",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Združeni tok",
     "eachLayer": "Vsaka plast posebej",
     "diff": "Razlika",

--- a/src/i18n/messages/sr.json
+++ b/src/i18n/messages/sr.json
@@ -8671,6 +8671,7 @@
     "run": "Покрени",
     "laneRejected": "одбијено: {reason}",
     "error": "грешка",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Комбиновани ток",
     "eachLayer": "Сваки слој посебно",
     "diff": "Разлика",

--- a/src/i18n/messages/sv.json
+++ b/src/i18n/messages/sv.json
@@ -8696,6 +8696,7 @@
     "run": "Kör",
     "laneRejected": "avvisad: {reason}",
     "error": "fel",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Kombinerat flöde",
     "eachLayer": "Varje lager separat",
     "diff": "Skillnad",

--- a/src/i18n/messages/sw.json
+++ b/src/i18n/messages/sw.json
@@ -8696,6 +8696,7 @@
     "run": "Endesha",
     "laneRejected": "imekataliwa: {reason}",
     "error": "hitilafu",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Mtiririko uliounganishwa",
     "eachLayer": "Kila safu kando",
     "diff": "Tofauti",

--- a/src/i18n/messages/ta.json
+++ b/src/i18n/messages/ta.json
@@ -8696,6 +8696,7 @@
     "run": "இயக்கு",
     "laneRejected": "நிராகரிக்கப்பட்டது: {reason}",
     "error": "பிழை",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "ஒருங்கிணைந்த ஓட்டம்",
     "eachLayer": "ஒவ்வொரு அடுக்கையும் தனித்தனியாக",
     "diff": "வேறுபாடு",

--- a/src/i18n/messages/te.json
+++ b/src/i18n/messages/te.json
@@ -8696,6 +8696,7 @@
     "run": "రన్ చేయండి",
     "laneRejected": "తిరస్కరించబడింది: {reason}",
     "error": "లోపం",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "కంబైన్డ్ ఫ్లో",
     "eachLayer": "ప్రతి లేయర్ విడివిడిగా",
     "diff": "వ్యత్యాసం",

--- a/src/i18n/messages/th.json
+++ b/src/i18n/messages/th.json
@@ -8696,6 +8696,7 @@
     "run": "รัน",
     "laneRejected": "ถูกปฏิเสธ: {reason}",
     "error": "ข้อผิดพลาด",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "โฟลว์รวม",
     "eachLayer": "แต่ละเลเยอร์แยกกัน",
     "diff": "ความต่าง",

--- a/src/i18n/messages/tr.json
+++ b/src/i18n/messages/tr.json
@@ -8696,6 +8696,7 @@
     "run": "Çalıştır",
     "laneRejected": "reddedildi: {reason}",
     "error": "hata",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Birleşik akış",
     "eachLayer": "Her katman ayrı ayrı",
     "diff": "Fark",

--- a/src/i18n/messages/uk-UA.json
+++ b/src/i18n/messages/uk-UA.json
@@ -8696,6 +8696,7 @@
     "run": "Запустити",
     "laneRejected": "відхилено: {reason}",
     "error": "помилка",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Комбінований потік",
     "eachLayer": "Кожен шар окремо",
     "diff": "Різниця",

--- a/src/i18n/messages/ur.json
+++ b/src/i18n/messages/ur.json
@@ -8696,6 +8696,7 @@
     "run": "چلائیں",
     "laneRejected": "مسترد شدہ: {reason}",
     "error": "خرابی",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "مشترکہ بہاؤ",
     "eachLayer": "ہر تہہ الگ سے",
     "diff": "فرق",

--- a/src/i18n/messages/vi.json
+++ b/src/i18n/messages/vi.json
@@ -8700,6 +8700,7 @@
     "run": "Chạy",
     "laneRejected": "bị từ chối: {reason}",
     "error": "lỗi",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "Luồng kết hợp",
     "eachLayer": "Từng lớp riêng biệt",
     "diff": "Khác biệt",

--- a/src/i18n/messages/zh-CN.json
+++ b/src/i18n/messages/zh-CN.json
@@ -8696,6 +8696,7 @@
     "run": "运行",
     "laneRejected": "已拒绝: {reason}",
     "error": "错误",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "组合流程",
     "eachLayer": "单独各层",
     "diff": "差异",

--- a/src/i18n/messages/zh-TW.json
+++ b/src/i18n/messages/zh-TW.json
@@ -8696,6 +8696,7 @@
     "run": "執行",
     "laneRejected": "已拒絕：{reason}",
     "error": "錯誤",
+    "combinedError": "__MISSING__:Combined pipeline preview failed: {reason}",
     "combinedFlow": "組合流程",
     "eachLayer": "各圖層分開",
     "diff": "差異",

--- a/tests/unit/ui/playViewCombinedError.test.tsx
+++ b/tests/unit/ui/playViewCombinedError.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+// Regression for #12061: when the COMBINED-pipeline preview request fails
+// (while per-lane requests succeed), PlayView must surface a visible error
+// instead of silently rendering nothing for the combined result section.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  (globalThis as any).ResizeObserver ||= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // Per-lane requests (body.engineId set) succeed; the combined pipeline
+  // request (body.pipeline set) fails -- e.g. an auth/backend error on the
+  // combined-stack call specifically.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_u: string, init: any) => {
+      const body = JSON.parse(init.body);
+      if (body.pipeline) {
+        return { ok: false, status: 500, json: async () => ({ error: "internal error" }) } as any;
+      }
+      const engine = body.engineId ?? "combo";
+      return {
+        ok: true,
+        json: async () => ({
+          original: "o",
+          compressed: "c",
+          originalTokens: 10,
+          compressedTokens: 6,
+          savingsPct: 40,
+          mode: "stacked",
+          durationMs: 1,
+          engineBreakdown: [
+            { engine, originalTokens: 10, compressedTokens: 6, savingsPercent: 40, techniquesUsed: [] },
+          ],
+          diff: [],
+          preservedBlocks: [],
+          ruleRemovals: [],
+          validation: { valid: true, errors: [], warnings: [], fallbackApplied: false },
+        }),
+      } as any;
+    })
+  );
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("PlayView combined-pipeline run failure (#12061)", () => {
+  it("shows a visible error for the combined result instead of nothing", async () => {
+    const { PlayView } = await import(
+      "@/app/(dashboard)/dashboard/compression/studio/PlayView"
+    );
+    await act(async () => {
+      root.render(
+        <PlayView text="TEST INPUT" onText={() => {}} laneEngines={["rtk", "caveman"]} />
+      );
+    });
+    const runBtn = container.querySelector('[data-testid="play-run"]') as HTMLButtonElement;
+    expect(runBtn).toBeTruthy();
+    await act(async () => {
+      runBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Per-lane previews succeeded -- lanes should show savings, not "error".
+    const laneRows = Array.from(container.querySelectorAll('[data-testid="play-lane"]'));
+    expect(laneRows.length).toBe(2);
+    for (const row of laneRows) {
+      expect(row.textContent ?? "").not.toMatch(/error/i);
+    }
+
+    // The combined section (success branch) never renders since the
+    // combined request failed.
+    const combinedSection = container.querySelector('[data-testid="play-combined"]');
+    expect(combinedSection).toBeNull();
+
+    const hasErrorTestId = !!container.querySelector(
+      '[data-testid="play-run-error"], [data-testid="play-combined-error"], [data-testid="play-error"]'
+    );
+    const text = container.textContent ?? "";
+    const hasHumanReadableError = /error|failed|falhou|erro/i.test(text);
+
+    expect(hasErrorTestId || hasHumanReadableError).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #12061

## Root cause

Compression Studio's Play tab runs a combined-pipeline preview request in parallel with
per-lane preview requests. `runPreviewBatch()` (`src/hooks/usePreviewCompression.ts`)
wrapped the combined-pipeline `POST /api/compression/preview` call in
`try { ... } catch { combined = null; }`, discarding the caught error entirely. `PlayView`
only rendered the combined-result section when `batch?.combined` was truthy
(`src/app/(dashboard)/dashboard/compression/studio/PlayView.tsx:102`), so a failed combined
request rendered nothing — no error, no placeholder — indistinguishable from an idle state.
Per-lane failures did show a terse "⚠ error", but the primary combined section stayed
completely silent on failure, matching the reported "Run returns no result" behavior.

## Fix

- `src/hooks/usePreviewCompression.ts`: `PreviewBatch` gained a `combinedError: string | null`
  field; the combined-pipeline `catch` now captures the error message instead of dropping it.
- `src/app/(dashboard)/dashboard/compression/studio/PlayView.tsx`: added a
  `data-testid="play-combined-error"` fallback section, rendered only after a run has
  completed (`batch` non-null) with no combined result and a captured error — never on the
  initial/idle state.
- `src/i18n/messages/en.json`: added `compressionStudio.combinedError` ("Combined pipeline
  preview failed: {reason}"). Propagated to the other 49 locales via
  `node scripts/i18n/sync-ui-keys.mjs` (English source only; other locales carry the tracked
  `__MISSING__:` placeholder per the project's i18n convention — no hand-translation).

Scope: this only addresses the silent-failure defect on the combined-result section, per the
issue's own final scoping comment. The separately reported "input gets cleared" symptom does
not reproduce in code (the `text` state lives in the parent `page.tsx` and nothing in
`PlayView.tsx`/`PlaygroundInput` touches it) and is out of scope here.

## Regression test

`tests/unit/ui/playViewCombinedError.test.tsx` — mocks per-lane preview calls as succeeding
while the combined-pipeline call returns a 500, renders `PlayView`, clicks Run, and asserts a
visible error is shown for the combined section instead of nothing.

RED (before fix):
```
AssertionError: expected false to be true
 ❯ tests/unit/ui/playViewCombinedError.test.tsx:102:53
```

GREEN (after fix):
```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

## Gates run

- `node scripts/check/check-file-size.mjs` — no violations on touched files
- `node scripts/check/check-complexity.mjs` — OK (2798 violations, baseline 3218)
- `node scripts/check/check-cognitive-complexity.mjs` — OK (1265 violations, baseline 1437)
- `npm run typecheck:core` — clean
- `npm run check:dashboard-typecheck` — OK, 206 pre-existing errors, all within frozen baseline (no new regressions)
- `npx eslint --suppressions-location config/quality/eslint-suppressions.json <changed files>` — clean
- `npx vitest run --config vitest.config.ts tests/unit/ui/playViewCombinedError.test.tsx` — 1 passed
- Existing tests of the touched area — `tests/unit/ui/usePreviewCompression.test.tsx`,
  `tests/unit/ui/fidelityGateToggle.test.tsx`, `tests/unit/ui/fuzzyDedupToggle.test.tsx` — all
  still pass (3 files, 5 tests)
- `node scripts/i18n/check-ui-keys-coverage.mjs` — PASS, all 50 locales ≥ 80% coverage
- `node scripts/check/check-changelog-integrity.mjs` — OK

Note: `tests/unit/ui/playView.test.tsx` is pre-existing-excluded from the vitest UI config
under issue #8618 (unrelated to this change) and was left untouched.

⚠️ base-red inherited: #12732 — unit #12058, integration codex-cache, package-artifact, tarball-smoke, agent-skills-sync
