### PR TITLE
fix(admission): measure request bodies with the active cost budget

### DIFF
--- a/open-sse/services/admission/requestFeatures.ts
+++ b/open-sse/services/admission/requestFeatures.ts
@@ -4,11 +4,13 @@
  */
 
 import { estimateSizeFast } from "../../utils/estimateSize.ts";
-import type { AdmissionCostFeatures } from "./types.ts";
+import { resolveCostConfig } from "./cost.ts";
+import type { AdmissionCostConfig, AdmissionCostFeatures } from "./types.ts";
 
 export type AdmissionFeatureExtractionContext = {
   /** When set, wins over any body/wrapped stream field. */
   streaming?: boolean;
+  cost?: Partial<AdmissionCostConfig>;
 };
 
 /**
@@ -159,7 +161,8 @@ export function extractAdmissionCostFeatures(
   body: unknown,
   context?: AdmissionFeatureExtractionContext
 ): AdmissionCostFeatures {
-  const bodyBytes = estimateSizeFast(body);
+  const cost = resolveCostConfig(context?.cost);
+  const bodyBytes = estimateSizeFast(body, cost.bodyBytesPerUnit * cost.maxRequestCost);
   const layers = featureLayers(body);
   const draft: FeatureDraft = {
     messageCount: 0,

--- a/open-sse/services/admission/runtime.ts
+++ b/open-sse/services/admission/runtime.ts
@@ -5,6 +5,7 @@
 
 import { AdaptiveAdmissionController } from "./controller.ts";
 import { validateConfig } from "./config.ts";
+import { resolveCostConfig } from "./cost.ts";
 import { extractAdmissionCostFeatures } from "./requestFeatures.ts";
 import {
   type AdaptiveAdmissionConfig,
@@ -323,6 +324,7 @@ function classifyHttpOutcome(status: number, signal?: AbortSignal): AdmissionRel
 
 class AdaptiveAdmissionRuntimeImpl implements AdaptiveAdmissionRuntime {
   private readonly controller: AdaptiveAdmissionController;
+  private readonly costConfig: ReturnType<typeof resolveCostConfig>;
   private readonly checkResourcePressure: () => ResourcePressureGuardResult | null;
   private readonly getResourcePressureObservation: () => ResourcePressureObservation;
   private readonly onPressureObserved?: (pressure: AdmissionPressure) => void;
@@ -338,6 +340,7 @@ class AdaptiveAdmissionRuntimeImpl implements AdaptiveAdmissionRuntime {
 
   constructor(options: AdaptiveAdmissionRuntimeOptions, config: AdaptiveAdmissionConfig) {
     this.controller = new AdaptiveAdmissionController(config, options.clock);
+    this.costConfig = resolveCostConfig(config.cost);
     this.checkResourcePressure = options.checkResourcePressure ?? checkResourcePressureGuard;
     this.getResourcePressureObservation =
       options.getResourcePressureObservation ?? getResourcePressureObservation;
@@ -372,7 +375,10 @@ class AdaptiveAdmissionRuntimeImpl implements AdaptiveAdmissionRuntime {
 
     const features = extractAdmissionCostFeatures(
       input.body,
-      input.streaming === undefined ? undefined : { streaming: input.streaming }
+      {
+        streaming: input.streaming,
+        cost: this.costConfig,
+      }
     );
     let result: AdmissionAcquireResult;
     try {

--- a/tests/unit/adaptive-admission-features.test.ts
+++ b/tests/unit/adaptive-admission-features.test.ts
@@ -37,6 +37,25 @@ describe("bounded request feature extraction", () => {
     }
   });
 
+  it("measures admission bodies beyond the default size-estimator limit", () => {
+    const body = {
+      messages: Array.from({ length: 200 }, () => ({ role: "user", content: "x".repeat(10_000) })),
+    };
+    const features = extractAdmissionCostFeatures(body);
+
+    assert.ok((features.bodyBytes ?? 0) > 1_000_000);
+    assert.ok((features.estimatedInputTokens ?? 0) > 250_000);
+  });
+
+  it("uses the active admission cost budget when measuring bodies", () => {
+    const body = { payload: "x".repeat(17_000_000) };
+    const features = extractAdmissionCostFeatures(body, {
+      cost: { bodyBytesPerUnit: 1_000_000, maxRequestCost: 20 },
+    });
+
+    assert.ok((features.bodyBytes ?? 0) > 16_384_000);
+  });
+
   it("extracts production-realistic Chat, Responses, Gemini, and Antigravity shapes", () => {
     // OpenAI Chat Completions — stream omitted defaults false (higher non-stream class).
     const chat = extractAdmissionCostFeatures({
@@ -146,7 +165,7 @@ describe("bounded request feature extraction", () => {
   it("bounds tool scans and never touches entries beyond the budget (conservative count)", () => {
     // Huge leading string makes estimateSizeFast byte-exit before walking tools,
     // so only countTools can touch the tools proxy — proving its scan bound alone.
-    const sizePad = "x".repeat(300_000);
+    const sizePad = "x".repeat(17_000_000);
 
     let accesses = 0;
     const tools = new Proxy([] as unknown[], {


### PR DESCRIPTION
## Summary

Admission cost feature extraction stopped at the size estimator's default 256 KiB limit, flattening body and token estimates for larger requests. The extractor now derives its measurement limit from the active admission cost budget, including runtime overrides.

## Related Issues

- Closes #13164

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR:

- [x] Change type: provider / routing / UI / i18n / CLI / DB / build-deploy / other
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- `tests/unit/adaptive-admission-features.test.ts`

## Coverage Notes

- The changed `open-sse/` admission runtime and feature extraction are covered by the updated admission feature tests and the focused admission, cost, and estimator suite.
- No coverage report was run locally.

## Reviewer Notes

- Maintainers familiar with recent changes: Diego Rodrigues de Sa e Souza, Dizzle, and Markus Hartung.
- The patch preserves the estimator's node budget and semantic-cache default while applying the active admission cost profile.
- No migration or feature flag is involved; a changelog fragment is not present in this candidate.

Focused validation run locally: `node --import tsx/esm --test tests/unit/adaptive-admission-features.test.ts tests/unit/adaptive-admission-cost.test.ts tests/unit/estimateSizeFast.test.ts`, `npm run typecheck:core`, and ESLint on the changed files.
