### PR TITLE
fix(providers): honor Alibaba workspace embedding and rerank endpoints

### DIFF
--- a/changelog.d/fixes/13293-alibaba-workspace-endpoints.md
+++ b/changelog.d/fixes/13293-alibaba-workspace-endpoints.md
@@ -1,0 +1,1 @@
+- **fix(providers):** honor the selected Alibaba workspace and region endpoints for custom embedding and `qwen3-rerank` requests ([#13293](https://github.com/diegosouzapw/OmniRoute/pull/13293)) — thanks @xiaoyaner0201

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -1326,7 +1326,7 @@
   },
   "src/app/api/v1/rerank/route.ts": {
     "@typescript-eslint/no-unused-vars": {
-      "count": 3
+      "count": 2
     }
   },
   "src/app/api/v1/search/route.ts": {

--- a/open-sse/handlers/rerank.ts
+++ b/open-sse/handlers/rerank.ts
@@ -88,6 +88,18 @@ function buildAuthHeader(providerConfig, token) {
       return_documents: false,
     };
   }
+  // qwen3-rerank's /compatible-api/v1/reranks endpoint is flat like
+  // Cohere, but does not accept Cohere's return_documents request field.
+  if (providerConfig.format === "alibaba-qwen3") {
+    const compatibleBody = {
+      ...body,
+      documents: (body.documents || []).map((doc) =>
+        typeof doc === "string" ? doc : doc?.text || ""
+      ),
+    };
+    delete compatibleBody.return_documents;
+    return compatibleBody;
+  }
   // Default: Cohere-compatible format (used by Together, Fireworks, Cohere, SiliconFlow)
   return body;
 }
@@ -174,6 +186,20 @@ function buildAuthHeader(providerConfig, token) {
       },
     };
   }
+  if (providerConfig.format === "alibaba-qwen3") {
+    if (!Array.isArray(data.results)) return data;
+    const documents = Array.isArray(options.documents) ? options.documents : [];
+    const returnDocuments = options.return_documents !== false;
+    return {
+      ...data,
+      results: data.results.map((entry) => {
+        if (!returnDocuments || entry.document) return entry;
+        const doc = documents[entry.index];
+        const text = typeof doc === "string" ? doc : doc?.text || "";
+        return { ...entry, document: { text } };
+      }),
+    };
+  }
   return data;
 }
 
@@ -188,6 +214,8 @@ function buildAuthHeader(providerConfig, token) {
  * @param {boolean} [options.return_documents] - Whether to include document text in results
  * @param {Object} options.credentials - Provider credentials { apiKey, accessToken }
  * @param {string} [options.connectionId] - Connection ID for per-connection proxy resolution
+ * @param {Object} [options.resolvedProvider] - Runtime provider config for dynamic endpoints
+ * @param {string} [options.resolvedModel] - Model ID after removing a dynamic provider prefix
  * @returns {Response}
  */
 /** @returns {Promise<unknown>} */
@@ -202,6 +230,7 @@ export async function handleRerank({
   apiKeyId = null,
   apiKeyName = null,
   resolvedProvider = null,
+  resolvedModel = null,
 }) {
   const startTime = Date.now();
   if (!model) return errorResponse(400, "model is required");
@@ -210,9 +239,9 @@ export async function handleRerank({
     return errorResponse(400, "documents must be a non-empty array");
   }
 
-  const { provider: providerId, model: modelId } = parseRerankModel(model);
-  const providerConfig =
-    resolvedProvider || (providerId ? getRerankProvider(providerId) : null);
+  const { provider: providerId, model: parsedModelId } = parseRerankModel(model);
+  const modelId = resolvedModel ?? parsedModelId;
+  const providerConfig = resolvedProvider || (providerId ? getRerankProvider(providerId) : null);
 
   if (!providerConfig) {
     const availableProviders = Object.keys(RERANK_PROVIDERS).join(", ");
@@ -301,7 +330,9 @@ export async function handleRerank({
     });
 
     const searchUnits = Number(result?.meta?.billed_units?.search_units) || 0;
-    const costUsd = await calculateModalCost("rerank", effectiveProviderId, modelId, { searchUnits });
+    const costUsd = await calculateModalCost("rerank", effectiveProviderId, modelId, {
+      searchUnits,
+    });
 
     saveCallLog({
       method: "POST",

--- a/open-sse/handlers/rerank.ts
+++ b/open-sse/handlers/rerank.ts
@@ -104,6 +104,21 @@ function buildAuthHeader(providerConfig, token) {
   return body;
 }
 
+function transformAlibabaQwen3Response(data, options: RerankResponseOptions) {
+  if (!Array.isArray(data.results)) return data;
+  const documents = Array.isArray(options.documents) ? options.documents : [];
+  const returnDocuments = options.return_documents !== false;
+  return {
+    ...data,
+    results: data.results.map((entry) => {
+      if (!returnDocuments || entry.document) return entry;
+      const doc = documents[entry.index];
+      const text = typeof doc === "string" ? doc : doc?.text || "";
+      return { ...entry, document: { text } };
+    }),
+  };
+}
+
 /**
  * Transform response from provider-specific formats back to Cohere format
  */
@@ -187,18 +202,7 @@ function buildAuthHeader(providerConfig, token) {
     };
   }
   if (providerConfig.format === "alibaba-qwen3") {
-    if (!Array.isArray(data.results)) return data;
-    const documents = Array.isArray(options.documents) ? options.documents : [];
-    const returnDocuments = options.return_documents !== false;
-    return {
-      ...data,
-      results: data.results.map((entry) => {
-        if (!returnDocuments || entry.document) return entry;
-        const doc = documents[entry.index];
-        const text = typeof doc === "string" ? doc : doc?.text || "";
-        return { ...entry, document: { text } };
-      }),
-    };
+    return transformAlibabaQwen3Response(data, options);
   }
   return data;
 }

--- a/src/app/api/v1/rerank/route.ts
+++ b/src/app/api/v1/rerank/route.ts
@@ -20,6 +20,7 @@ import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { generateRequestId } from "@/shared/utils/requestId";
 import { CORS_HEADERS } from "@omniroute/open-sse/utils/cors.ts";
 import { deriveRerankProviderForChatProvider } from "@omniroute/open-sse/config/rerankRegistry.ts";
+import { resolveAlibabaQwen3RerankUrl } from "@/shared/constants/alibabaProviderRegions";
 
 /**
  * Handle CORS preflight
@@ -107,6 +108,9 @@ async function postHandler(request, context) {
 
   // Try cloud registry first
   const { provider, model: modelId } = parseRerankModel(body.model);
+  const prefixSeparator = body.model.indexOf("/");
+  const resolvedModelId =
+    provider || prefixSeparator < 0 ? modelId : body.model.slice(prefixSeparator + 1);
 
   // Generic fallback: a configured OpenAI-compatible chat provider with no
   // curated rerank entry (groq, mistral, ...) still exposes a Cohere-compatible
@@ -129,7 +133,12 @@ async function postHandler(request, context) {
   if (provider || derivedProvider) {
     // Cloud provider matched (or a generic Cohere-compatible endpoint was derived)
     const effectiveProviderId = provider || derivedProvider!.id;
-    const credentials = await getProviderCredentialsWithQuotaPreflight(effectiveProviderId);
+    const credentials = await getProviderCredentialsWithQuotaPreflight(
+      effectiveProviderId,
+      null,
+      null,
+      resolvedModelId
+    );
     if (!credentials) {
       return errorResponse(
         HTTP_STATUS.BAD_REQUEST,
@@ -140,6 +149,39 @@ async function postHandler(request, context) {
       return rateLimitedProviderResponse(effectiveProviderId, credentials);
     }
 
+    let runtimeProvider = derivedProvider as
+      | (NonNullable<ReturnType<typeof deriveRerankProviderForChatProvider>> & {
+          format?: string;
+        })
+      | null;
+    if (
+      (effectiveProviderId === "alibaba" || effectiveProviderId === "alibaba-cn") &&
+      resolvedModelId === "qwen3-rerank"
+    ) {
+      const providerSpecificData = (
+        credentials as { providerSpecificData?: Record<string, unknown> | null }
+      ).providerSpecificData;
+      const baseUrl = resolveAlibabaQwen3RerankUrl(
+        effectiveProviderId,
+        providerSpecificData,
+        derivedProvider?.baseUrl || ""
+      );
+      if (!baseUrl) {
+        return errorResponse(
+          HTTP_STATUS.BAD_REQUEST,
+          `No rerank endpoint configured for provider: ${effectiveProviderId}`
+        );
+      }
+      runtimeProvider = {
+        id: effectiveProviderId,
+        baseUrl,
+        authType: "apikey",
+        authHeader: "bearer",
+        models: [],
+        format: "alibaba-qwen3",
+      };
+    }
+
     const response = await handleRerank({
       model: body.model,
       query: body.query,
@@ -147,7 +189,8 @@ async function postHandler(request, context) {
       top_n: body.top_n,
       return_documents: body.return_documents,
       credentials,
-      resolvedProvider: derivedProvider || null,
+      resolvedProvider: runtimeProvider,
+      resolvedModel: resolvedModelId,
       connectionId: (credentials as { connectionId?: string } | null)?.connectionId || null,
       apiKeyId: policy.apiKeyInfo?.id || null,
       apiKeyName: policy.apiKeyInfo?.name || null,

--- a/src/lib/embeddings/service.ts
+++ b/src/lib/embeddings/service.ts
@@ -33,6 +33,7 @@ import { calculateCost } from "@/lib/usage/costCalculator";
 import { attachOmniRouteMetaHeaders } from "@/domain/omnirouteResponseMeta";
 import { generateRequestId } from "@/shared/utils/requestId";
 import { resolveLocalSyncedEndpointRoute } from "@/lib/providerModels/syncedEndpointRouting";
+import { resolveAlibabaProviderEmbeddingUrl } from "@/shared/constants/alibabaProviderRegions";
 
 type ValidatedEmbeddingBody = Record<string, unknown> & { model: string };
 type ProviderCredentialsResult = Awaited<ReturnType<typeof getProviderCredentials>>;
@@ -344,6 +345,24 @@ export async function createEmbeddingResponse(
     ) {
       credentials = localCredentials;
     }
+  }
+
+  // Alibaba's embedding endpoint is connection-scoped: workspace and region
+  // live in providerSpecificData, so the static chat registry cannot select it.
+  if (
+    credentials &&
+    !options.resolvedProvider &&
+    (provider === "alibaba" || provider === "alibaba-cn")
+  ) {
+    const providerSpecificData = (
+      credentials as { providerSpecificData?: Record<string, unknown> | null }
+    ).providerSpecificData;
+    const connectionBaseUrl = resolveAlibabaProviderEmbeddingUrl(
+      provider,
+      providerSpecificData,
+      providerConfig.baseUrl
+    );
+    if (connectionBaseUrl) providerConfig = { ...providerConfig, baseUrl: connectionBaseUrl };
   }
 
   // #474: when the request used a bare model name (no "/" — e.g. an alias that

--- a/src/shared/constants/alibabaProviderRegions.ts
+++ b/src/shared/constants/alibabaProviderRegions.ts
@@ -189,6 +189,65 @@ export function resolveAlibabaProviderBaseUrl(
   return ALIBABA_PROVIDER_ENDPOINTS[family][region];
 }
 
+function resolveAlibabaCompatibleApiRoot(
+  providerId: string,
+  providerSpecificData: unknown,
+  fallback: string,
+  apiFamily: "compatible-mode" | "compatible-api"
+): string {
+  const resolved = stripTrailingSlashes(
+    resolveAlibabaProviderBaseUrl(providerId, providerSpecificData, fallback).trim()
+  ).replace(/\/(?:chat\/completions|embeddings|reranks?|models)$/i, "");
+  if (!resolved) return "";
+
+  const compatibleRoot = resolved.replace(/\/compatible-(?:mode|api)\/v1$/i, `/${apiFamily}/v1`);
+  if (compatibleRoot !== resolved) return compatibleRoot;
+
+  try {
+    const url = new URL(resolved);
+    const isAlibabaCloudRoot =
+      (url.pathname === "" || url.pathname === "/") &&
+      (url.hostname === "dashscope.aliyuncs.com" ||
+        url.hostname === "dashscope-intl.aliyuncs.com" ||
+        url.hostname.endsWith(".maas.aliyuncs.com"));
+    if (isAlibabaCloudRoot) return `${stripTrailingSlashes(resolved)}/${apiFamily}/v1`;
+  } catch {
+    // Keep operator-supplied proxy paths unchanged; validation owns URL rejection.
+  }
+
+  return resolved;
+}
+
+/** Resolve the selected Alibaba connection's OpenAI-compatible embedding endpoint. */
+export function resolveAlibabaProviderEmbeddingUrl(
+  providerId: string,
+  providerSpecificData?: unknown,
+  fallback = ""
+): string {
+  const root = resolveAlibabaCompatibleApiRoot(
+    providerId,
+    providerSpecificData,
+    fallback,
+    "compatible-mode"
+  );
+  return root ? `${root}/embeddings` : "";
+}
+
+/** Resolve qwen3-rerank's flat compatible endpoint for the selected connection. */
+export function resolveAlibabaQwen3RerankUrl(
+  providerId: string,
+  providerSpecificData?: unknown,
+  fallback = ""
+): string {
+  const root = resolveAlibabaCompatibleApiRoot(
+    providerId,
+    providerSpecificData,
+    fallback,
+    "compatible-api"
+  );
+  return root ? `${root}/reranks` : "";
+}
+
 export function resolveAlibabaProviderModelsUrl(
   providerId: string,
   providerSpecificData?: unknown,

--- a/tests/unit/alibaba-embedding-rerank-endpoints-13030.test.ts
+++ b/tests/unit/alibaba-embedding-rerank-endpoints-13030.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-issue-13030-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.API_KEY_SECRET = "issue-13030-test-secret";
+process.env.REQUIRE_API_KEY = "false";
+
+const WORKSPACE_BASE = "https://workspace-test.cn-beijing.maas.aliyuncs.com/compatible-mode/v1";
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const { createEmbeddingResponse } = await import("../../src/lib/embeddings/service.ts");
+const { POST: postRerank } = await import("../../src/app/api/v1/rerank/route.ts");
+
+function resetStorage(): void {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("#13030 Alibaba embedding and rerank use the selected workspace connection", async () => {
+  resetStorage();
+  await providersDb.createProviderConnection({
+    provider: "alibaba",
+    authType: "apikey",
+    apiKey: "sk-workspace-test",
+    isActive: true,
+    testStatus: "active",
+    providerSpecificData: {
+      region: "china-beijing",
+      baseUrl: WORKSPACE_BASE,
+    },
+  });
+
+  const calls: Array<{ url: string; body: Record<string, unknown>; authorization: string | null }> =
+    [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input, init) => {
+    const headers = new Headers(init?.headers);
+    calls.push({
+      url: String(input),
+      body: JSON.parse(String(init?.body || "{}")) as Record<string, unknown>,
+      authorization: headers.get("authorization"),
+    });
+
+    if (String(input).endsWith("/embeddings")) {
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ object: "embedding", embedding: [0.1, 0.2], index: 0 }],
+          model: "qwen3.7-text-embedding",
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        object: "list",
+        results: [{ index: 0, relevance_score: 0.95 }],
+        model: "qwen3-rerank",
+        id: "rerank-test",
+        usage: { total_tokens: 3 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }) as typeof globalThis.fetch;
+
+  try {
+    const embeddingResponse = await createEmbeddingResponse({
+      model: "alibaba/qwen3.7-text-embedding",
+      input: "hello",
+      dimensions: 1024,
+    });
+    assert.equal(embeddingResponse.status, 200);
+
+    const rerankResponse = await postRerank(
+      new Request("http://localhost/v1/rerank", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "alibaba/qwen3-rerank",
+          query: "hello",
+          documents: [{ text: "hello world" }, "unrelated"],
+          top_n: 1,
+        }),
+      })
+    );
+    assert.equal(rerankResponse.status, 200);
+    const rerankBody = (await rerankResponse.json()) as {
+      results: Array<{ document?: { text?: string } }>;
+    };
+    assert.equal(rerankBody.results[0].document?.text, "hello world");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(
+    calls.map((call) => call.url),
+    [
+      `${WORKSPACE_BASE}/embeddings`,
+      "https://workspace-test.cn-beijing.maas.aliyuncs.com/compatible-api/v1/reranks",
+    ]
+  );
+  assert.equal(calls[0].body.model, "qwen3.7-text-embedding");
+  assert.equal(calls[1].body.model, "qwen3-rerank");
+  assert.deepEqual(calls[1].body.documents, ["hello world", "unrelated"]);
+  assert.equal("return_documents" in calls[1].body, false);
+  assert.deepEqual(
+    calls.map((call) => call.authorization),
+    ["Bearer sk-workspace-test", "Bearer sk-workspace-test"]
+  );
+});

--- a/tests/unit/alibaba-provider-regions.test.ts
+++ b/tests/unit/alibaba-provider-regions.test.ts
@@ -12,8 +12,10 @@ import {
   isAlibabaRegionalProvider,
   normalizeAlibabaProviderRegion,
   resolveAlibabaProviderBaseUrl,
+  resolveAlibabaProviderEmbeddingUrl,
   resolveAlibabaProviderMediaBaseUrl,
   resolveAlibabaProviderModelsUrl,
+  resolveAlibabaQwen3RerankUrl,
 } from "../../src/shared/constants/alibabaProviderRegions.ts";
 import { APIKEY_PROVIDERS } from "../../src/shared/constants/providers.ts";
 
@@ -75,6 +77,37 @@ test("regional resolver normalizes old region names and preserves genuine custom
     }),
     "https://token-plan.example.internal/compatible-mode/v1",
     "an operator-supplied endpoint must remain authoritative"
+  );
+});
+
+test("#13030 Alibaba specialty endpoints follow the selected workspace connection", () => {
+  const workspace = {
+    region: "china-beijing",
+    baseUrl: "https://workspace-test.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+  };
+  assert.equal(
+    resolveAlibabaProviderEmbeddingUrl("alibaba", workspace),
+    "https://workspace-test.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/embeddings"
+  );
+  assert.equal(
+    resolveAlibabaQwen3RerankUrl("alibaba", workspace),
+    "https://workspace-test.cn-beijing.maas.aliyuncs.com/compatible-api/v1/reranks"
+  );
+  assert.equal(
+    resolveAlibabaQwen3RerankUrl("alibaba-cn"),
+    "https://dashscope.aliyuncs.com/compatible-api/v1/reranks"
+  );
+  assert.equal(
+    resolveAlibabaProviderEmbeddingUrl("alibaba", {
+      baseUrl: "https://workspace-test.ap-southeast-1.maas.aliyuncs.com",
+    }),
+    "https://workspace-test.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/embeddings"
+  );
+  assert.equal(
+    resolveAlibabaQwen3RerankUrl("alibaba", {
+      baseUrl: "https://workspace-test.ap-southeast-1.maas.aliyuncs.com/compatible-api/v1/reranks",
+    }),
+    "https://workspace-test.ap-southeast-1.maas.aliyuncs.com/compatible-api/v1/reranks"
   );
 });
 
@@ -332,6 +365,8 @@ test("trailing-slash normalization is linear on pathological slash runs (ReDoS g
   resolveAlibabaProviderModelsUrl("alibaba", pathological);
   resolveAlibabaProviderMediaBaseUrl("alibaba", pathological);
   resolveAlibabaProviderBaseUrl("alibaba", pathological);
+  resolveAlibabaProviderEmbeddingUrl("alibaba", pathological);
+  resolveAlibabaQwen3RerankUrl("alibaba", pathological);
   const elapsed = performance.now() - started;
 
   assert.ok(


### PR DESCRIPTION
## Summary

- Resolve Alibaba embedding and `qwen3-rerank` URLs only after credential selection, so the selected connection's workspace, region, and custom base URL are authoritative.
- Normalize embedding requests to `/compatible-mode/v1/embeddings` and `qwen3-rerank` requests to `/compatible-api/v1/reranks`.
- Preserve the unprefixed model ID for generic rerank fallbacks and adapt `qwen3-rerank`'s flat request/top-level response shape without forwarding unsupported `return_documents`.

## Related Issues

- Closes #13030

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider
- [x] Focused tests and category gates from the golden path
- [ ] `npm run lint` — inherited base-red tracked by #12732: the clean base and this branch both report the same three `no-explicit-any` errors in `tests/unit/volcengine-plan-binding-upsert.test.ts`; changed-file ESLint passes
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

Commands run:

- `node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test tests/unit/alibaba-embedding-rerank-endpoints-13030.test.ts tests/unit/alibaba-provider-regions.test.ts tests/unit/embedding-generic-provider-fallback.test.ts tests/unit/rerank-generic-provider-fallback.test.ts tests/unit/rerank-providers-5332.test.ts tests/unit/rerank-object-documents-response-path.test.ts` — 38 passed, 0 failed
- `npm run typecheck:core` — passed
- `npm run build:contributor` — passed
- `npm run check:provider-consistency` — passed
- `npm run check:provider-assets` — passed
- `npm run check:cycles` — passed
- `npm run check:tracked-artifacts` — passed
- `npm run check:any-budget:t11` — passed
- Changed-file Prettier and ESLint — passed
- `npm run test:scoped:staged` — unavailable on macOS's stock Bash 3.2 because the script requires `mapfile`; the focused runtime and sibling suites above were run directly

## Tests Added Or Updated

- `tests/unit/alibaba-embedding-rerank-endpoints-13030.test.ts`
- `tests/unit/alibaba-provider-regions.test.ts`

## Coverage Notes

- The new runtime regression test persists an Alibaba connection with a workspace base URL, calls both the embedding service and the public rerank route, captures the mocked upstream requests, and verifies URL, model ID, request shape, response normalization, and credential alignment.
- The regional resolver suite covers explicit workspace roots, China defaults, host-only workspace URLs, already-normalized rerank URLs, and the existing linear-time trailing-slash guard.

## Reviewer Notes

- The special rerank adapter is intentionally limited to `qwen3-rerank`. Alibaba's newer `qwen3.7-text-rerank`, `qwen3-vl-rerank`, and `gte-rerank-v2` use the separate native `/api/v1/services/rerank/text-rerank/text-rerank` contract and remain outside this issue's scope.
- No migrations or feature flags are added.
- The branch is based on `release/v3.8.51@fd27ff08c7c864edeca19b37bac65a340033c1a8`.
- ⚠️ Base-red inherited: #12732.
