### PR TITLE
chore(deps): pin joi to ^18.2.8 via overrides (#13085)

### DIFF
--- a/package.json
+++ b/package.json
@@ -469,6 +469,7 @@
   },
   "overrides": {
     "browserslist": "^4.28.8",
+    "joi": "^18.2.8",
     "onnxruntime-node": "1.24.3",
     "eslint-plugin-react-hooks": "7.1.1",
     "fast-xml-parser": "^5.10.1",


### PR DESCRIPTION
## Summary

Fixes #13085

Adds `joi: ^18.2.8` to the `overrides` block in `package.json`, bumping the transitive dep from 18.2.3 to 18.2.8 to close the upstream security advisories.

## Why overrides (not a direct dep)

`joi` is a transitive dependency in this repo — it appears in `package-lock.json` (resolved through sub-deps) but no file in `src/`, `open-sse/`, or `bin/` imports it directly. Adding a direct `dependencies` entry would be wrong (it would imply the package is used directly here, generating noise in dep-check tooling and the published-tarball surface).

Per the overrides-pin pattern established by Diego in #12592 (browserslist), #13148 (hono), and #13117 (csv-parse), transitive bumps ship as `overrides` entries rather than direct dependencies. `npm install` resolves the override chain and pulls `joi@18.2.8` for every sub-dep that requests `joi`.

## Diff

```diff
   "overrides": {
     "browserslist": "^4.28.8",
+    "joi": "^18.2.8",
     "onnxruntime-node": "1.24.3",
     ...
   }
```

Inserted alphabetically after `browserslist`. No other sort changes — every other key retains its original order to keep the diff minimal and reviewable.

## Verification

- `npm view joi@18.2.8` returns successfully — the version exists on the registry
- `overrides` is the documented npm mechanism for pinning transitive deps without changing direct deps
- Single-line addition, no schema/permission impact

Fixes #13085
