### PR TITLE
fix(translator): skip replayed web_search_call metadata

### DIFF
--- a/changelog.d/fixes/responses-web-search-call-replay.md
+++ b/changelog.d/fixes/responses-web-search-call-replay.md
@@ -1,0 +1,1 @@
+Responses-to-Chat fallback now skips replayed `web_search_call` metadata while preserving the paired function result, preventing deterministic HTTP 400 failures on follow-up turns routed to Chat Completions providers.

--- a/open-sse/translator/request/openai-responses.ts
+++ b/open-sse/translator/request/openai-responses.ts
@@ -468,14 +468,16 @@ export function openaiResponsesToOpenAIRequest(
       continue;
     }
 
-    // Skip tool_search_call items. These are Responses-API-only metadata items
-    // emitted by Codex's dynamic tool-search optimization: they record that the
-    // model queried a subset of available tools, but carry no content that Chat
-    // Completions can represent. Throwing here would break every multi-turn
-    // conversation where Codex previously used tool_search (the whole session
-    // would carry tool_search_call items forward in `input`). Skipping matches
-    // the reasoning-item policy: display-only metadata, no chat side-effect.
-    if (itemType === "tool_search_call" || itemType === "tool_search_result") {
+    // Skip Responses-only search metadata. tool_search_call/tool_search_result
+    // are Codex's dynamic tool-discovery items; web_search_call is emitted by
+    // OmniRoute's web-search fallback alongside function_call_output, which
+    // already carries the result for Chat Completions. Replayed metadata has no
+    // lossless Chat representation and must not fail a follow-up turn.
+    if (
+      itemType === "tool_search_call" ||
+      itemType === "tool_search_result" ||
+      itemType === "web_search_call"
+    ) {
       continue;
     }
 

--- a/tests/unit/responses-chat-translation-gaps.test.ts
+++ b/tests/unit/responses-chat-translation-gaps.test.ts
@@ -125,7 +125,6 @@ test("Responses -> Chat rejects input item types without a lossless Chat equival
     { type: "item_reference", id: "item_123" },
     { type: "computer_call_output", call_id: "call_1", output: {} },
     { type: "mcp_call", name: "remote", arguments: "{}" },
-    { type: "web_search_call", id: "search_1" },
     { unexpected: true },
   ]) {
     assert.throws(

--- a/tests/unit/responses-tool-search-call-skip.test.ts
+++ b/tests/unit/responses-tool-search-call-skip.test.ts
@@ -58,6 +58,51 @@ test("tool_search_result input item is silently skipped", () => {
   assert.equal(messages[0].role, "user");
 });
 
+test("web_search_call replay is skipped while its function result is preserved", () => {
+  const body = {
+    model: "test-model",
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "Find docs" }] },
+      {
+        type: "function_call",
+        call_id: "call_search",
+        name: "omniroute_web_search",
+        arguments: '{"query":"OmniRoute docs"}',
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_search",
+        output: '{"success":true,"results":[{"url":"https://example.com","title":"Example"}]}',
+      },
+      {
+        type: "web_search_call",
+        id: "ws_call_search",
+        status: "completed",
+        action: {
+          type: "web_search",
+          query: "OmniRoute docs",
+          sources: [{ title: "Example", url: "https://example.com", caption: "Result" }],
+        },
+      },
+    ],
+    stream: false,
+  };
+  let result;
+  assert.doesNotThrow(() => {
+    result = translateRequest("openai-responses", "openai", "test-model", body, false);
+  }, "web_search_call replay must not throw");
+  const messages = (
+    result as { messages?: Array<{ role?: string; tool_calls?: unknown; content?: unknown }> }
+  ).messages;
+  assert.ok(Array.isArray(messages));
+  assert.equal(messages.length, 3, "web_search_call metadata must not create a duplicate message");
+  assert.deepEqual(
+    messages.map((message) => message.role),
+    ["user", "assistant", "tool"]
+  );
+  assert.equal(messages[2].content, body.input[2].output);
+});
+
 test("multiple tool_search_call items interspersed with messages are skipped in order", () => {
   const body = {
     model: "test-model",


### PR DESCRIPTION
## Summary

- skip replayed `web_search_call` metadata during Responses-to-Chat translation
- preserve the paired `function_call_output` search result
- add regression coverage for a real OmniRoute web-search fallback replay

## Problem

PR #12031 made OmniRoute's Responses web-search fallback emit a native `web_search_call` item alongside the existing `function_call` / `function_call_output` round trip.

Responses clients retain output items in conversation history and replay them in the next request's `input`. If that follow-up turn routes to a Chat Completions provider, the translator currently rejects the item before provider dispatch:

```text
Unsupported Responses API feature: input item type 'web_search_call' cannot be represented in Chat Completions
```

This makes every subsequent turn fail deterministically until history is cleared.

## Fix

Treat `web_search_call` like the adjacent `tool_search_call` / `tool_search_result` Responses-only metadata items and skip it during Chat conversion. The paired `function_call_output` already contains the executed search result and remains translated into a Chat tool message, so the fix avoids both data loss and duplicated source text.

## Validation

- `node --import tsx/esm --test tests/unit/responses-tool-search-call-skip.test.ts tests/unit/responses-chat-translation-gaps.test.ts` — 18/18 pass on upstream `release/v3.8.51` HEAD
- `npm run typecheck:core` — pass
- ESLint on changed files — pass
- production replay payload verified against an Azox deployment: old deterministic `web_search_call cannot be represented` HTTP 400 is gone

## Related

- introduced by the output shape added in #12031 / #12030
- follows the translator policy already used for `tool_search_call` replay metadata
