### PR TITLE
chore: add Windows helpers to run OmniRoute and Claude Code from a source checkout

### DIFF
--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -1,0 +1,45 @@
+# Windows helpers — run OmniRoute from a source checkout
+
+Two double-clickable `.bat` files for Windows users who cloned the repo instead of
+installing the npm package. Both resolve the repo root from their own location, so they
+work from any checkout path.
+
+| File                  | What it does                                                                       |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| `start-omniroute.bat` | `npm run dev` — dev server + dashboard on `http://localhost:20128`                 |
+| `launch-claude.bat`   | `node bin\omniroute.mjs launch` — opens Claude Code pointed at the local OmniRoute |
+
+Usage:
+
+1. `npm install` once (see the note below if you are on npm ≥ 11).
+2. Double-click `start-omniroute.bat` and wait for `dev server listening on http://0.0.0.0:20128`.
+3. Open the dashboard, connect a provider, copy an API key from **Endpoints**.
+4. Double-click `launch-claude.bat`. Extra arguments are forwarded, e.g.
+   `launch-claude.bat --profile glm52` after `node bin\omniroute.mjs setup-claude`.
+
+## npm ≥ 11 skips `better-sqlite3` on Windows
+
+`better-sqlite3` is an `optionalDependency`. npm 11 blocks install scripts of optional
+dependencies by default, so on a fresh clone `node_modules/better-sqlite3/` may simply not
+exist. The server still boots (it falls back to `node:sqlite`, which Node marks
+experimental), but `npm run dev` logs `Module not found: Can't resolve 'better-sqlite3'`
+and `[DB] Driver: node:sqlite`.
+
+Since `better-sqlite3@13` ships prebuilt binaries inside the package
+(`prebuilds/win32-x64.node`), no compiler is needed — just put the package in place:
+
+```powershell
+cd node_modules
+npm pack better-sqlite3@13.0.3
+tar -xzf better-sqlite3-13.0.3.tgz
+Remove-Item -Recurse -Force better-sqlite3 -ErrorAction SilentlyContinue
+Rename-Item package better-sqlite3
+Remove-Item better-sqlite3-13.0.3.tgz
+```
+
+Restart the server; the log should now read `[DB] Driver: better-sqlite3`.
+
+> If you do need to compile a native addon and `python` resolves to the Microsoft Store
+> build, `node-gyp` fails with `common.gypi not found` even after downloading headers — the
+> Store Python sandboxes `%LOCALAPPDATA%`. Pass `--devdir` pointing outside `AppData\Local`
+> (or install python.org Python).

--- a/contrib/windows/launch-claude.bat
+++ b/contrib/windows/launch-claude.bat
@@ -1,10 +1,33 @@
 @echo off
 rem OmniRoute — launch Claude Code pointed at the local OmniRoute server (Windows).
 rem Wraps `omniroute launch` from the source checkout so no global install is needed.
-rem Extra arguments are passed through to `omniroute launch` (e.g. --profile glm52).
-setlocal
+rem
+rem Usage:  launch-claude.bat [project-folder] [omniroute launch args...]
+rem   - From a terminal inside your project: launch-claude.bat            (opens here)
+rem   - Double-click: prompts for the project folder (Enter = current folder)
+rem Claude Code is started in the PROJECT folder, never in the OmniRoute checkout —
+rem otherwise it loads this repo's CLAUDE.md/AGENTS.md (~60k chars) into every session.
+setlocal enabledelayedexpansion
 title Claude Code via OmniRoute
-cd /d "%~dp0..\.."
-node bin\omniroute.mjs launch %*
+set "OMNIROUTE_ROOT=%~dp0..\.."
+
+if exist "%~1\" (
+  cd /d "%~1"
+  shift
+) else (
+  set "PROJ="
+  set /p "PROJ=Project folder (Enter = current: %CD%): "
+  if not "!PROJ!"=="" cd /d "!PROJ!"
+)
+
+set "ARGS="
+:collect
+if "%~1"=="" goto run
+set "ARGS=!ARGS! %1"
+shift
+goto collect
+
+:run
+node "%OMNIROUTE_ROOT%\bin\omniroute.mjs" launch!ARGS!
 endlocal
 pause

--- a/contrib/windows/launch-claude.bat
+++ b/contrib/windows/launch-claude.bat
@@ -1,0 +1,10 @@
+@echo off
+rem OmniRoute — launch Claude Code pointed at the local OmniRoute server (Windows).
+rem Wraps `omniroute launch` from the source checkout so no global install is needed.
+rem Extra arguments are passed through to `omniroute launch` (e.g. --profile glm52).
+setlocal
+title Claude Code via OmniRoute
+cd /d "%~dp0..\.."
+node bin\omniroute.mjs launch %*
+endlocal
+pause

--- a/contrib/windows/start-omniroute.bat
+++ b/contrib/windows/start-omniroute.bat
@@ -1,0 +1,11 @@
+@echo off
+rem OmniRoute — start the dev server from a source checkout (Windows).
+rem Double-click, or run from any directory. Resolves the repo root from this file's location.
+setlocal
+title OmniRoute Server
+cd /d "%~dp0..\.."
+echo Starting OmniRoute on http://localhost:20128 ...
+echo (Leave this window open. Close it to stop the server.)
+call npm run dev
+endlocal
+pause


### PR DESCRIPTION
## Summary

- Adds `contrib/windows/` with two double-clickable helpers for Windows users who run OmniRoute from a **source checkout** instead of the npm package:
  - `start-omniroute.bat` → `npm run dev` (resolves the repo root from its own path, works from any checkout location)
  - `launch-claude.bat` → `node bin\omniroute.mjs launch`, forwarding extra args (e.g. `--profile glm52`)
- `contrib/windows/README.md` documents a fresh-clone gotcha on Windows with **npm ≥ 11**: the optional `better-sqlite3` dependency is silently skipped (npm 11 blocks install scripts of optional deps), the server falls back to `node:sqlite` and `npm run dev` logs `Module not found: Can't resolve 'better-sqlite3'` + `[DB] Driver: node:sqlite`. Because `better-sqlite3@13` ships `prebuilds/win32-x64.node` inside the package, extracting `npm pack better-sqlite3@13.0.3` into `node_modules/` fixes it with no compiler. Also notes that the Microsoft Store Python breaks `node-gyp` (`common.gypi not found`) because it sandboxes `%LOCALAPPDATA%`.

## Related Issues

- None — observed while onboarding on Windows 11.

## Validation

- [x] Change type: other (contrib scripts + docs, no production code)
- [x] Focused tests and category gates: pre-commit hooks ran green (`lint-staged`, `check-docs-sync`, `check:any-budget:t11`, `check:tracked-artifacts`)
- [x] `npm run lint` — not applicable to `.bat`/`.md`; Prettier ran via lint-staged
- [x] Branch cut from current `release/v3.8.51` tip (`af49d49`)
- [x] No production-code changes → no test required

## Tests Added Or Updated

- None. No production code changed (`src/`, `open-sse/`, `electron/`, `bin/` untouched).

## Coverage Notes

- Not applicable — no code under coverage touched.

## Reviewer Notes

- Manually verified on Windows 11 Pro, Node 24.14.0, npm 11.6.1: fresh clone → `npm install` → `better-sqlite3` absent → README steps → restart → `[DB] Driver: better-sqlite3`, dashboard reachable at `http://localhost:20128`, `node bin\omniroute.mjs launch --help` works.
- Files live under `contrib/` (next to `contrib/podman`, `contrib/vps`) to respect the repo-root hygiene rule in `AGENTS.md`.
- If you prefer the npm-11 note to live in `docs/guides/TROUBLESHOOTING.md` instead of the contrib README, happy to move it.
