### PR TITLE
fix(sse): keep a round-robin target's concurrency limit through a cooldown

### DIFF
--- a/changelog.d/fixes/13320-semaphore-cooldown-keeps-limit.md
+++ b/changelog.d/fixes/13320-semaphore-cooldown-keeps-limit.md
@@ -1,0 +1,1 @@
+- **fix(sse):** A transient error on a round-robin combo target no longer resets its concurrency limit to 3, so a target capped at 1 is not sent three queued requests at once when its cooldown ends ([#13320](https://github.com/diegosouzapw/OmniRoute/pull/13320))

--- a/open-sse/services/rateLimitSemaphore.ts
+++ b/open-sse/services/rateLimitSemaphore.ts
@@ -186,7 +186,10 @@ export function acquire(
  * @param {number} cooldownMs - How long to block (milliseconds)
  */
 export function markRateLimited(modelStr: string, cooldownMs: number): void {
-  const gate = getGate(modelStr);
+  // Keep the limit the gate was acquired with. getGate() writes its argument into
+  // gate.max, so the bare default here would reset a configured limit to 3 and the
+  // post-cooldown drain would release that many queued requests at once.
+  const gate = getGate(modelStr, gates.get(modelStr)?.max);
   gate.rateLimitedUntil = Date.now() + cooldownMs;
 
   // Schedule drain after cooldown expires

--- a/tests/unit/rate-limit-semaphore-cooldown-limit.test.ts
+++ b/tests/unit/rate-limit-semaphore-cooldown-limit.test.ts
@@ -1,0 +1,68 @@
+/**
+ * markRateLimited() used to call getGate() without a limit, and getGate() writes its
+ * argument into gate.max — so a round-robin target configured for 1 concurrent request
+ * was reset to the default of 3 by its first transient error, and the drain after the
+ * cooldown released three queued requests at a target that had just returned 429.
+ */
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  acquire,
+  getStats,
+  markRateLimited,
+  resetAll,
+} from "../../open-sse/services/rateLimitSemaphore.ts";
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+afterEach(() => {
+  resetAll();
+});
+
+describe("rateLimitSemaphore cooldown keeps the configured limit", () => {
+  it("drains a limit-1 gate one request at a time after the cooldown", async () => {
+    const model = "combo:rr:glm/glm-4.6";
+    const opts = { maxConcurrency: 1, timeoutMs: 1000 };
+
+    const releaseFirst = await acquire(model, opts);
+    const queued = [
+      acquire(model, opts).catch(() => null),
+      acquire(model, opts).catch(() => null),
+      acquire(model, opts).catch(() => null),
+    ];
+    await wait(5);
+
+    markRateLimited(model, 20);
+    assert.equal(getStats()[model].max, 1);
+
+    releaseFirst();
+    await wait(120);
+
+    const stats = getStats()[model];
+    assert.equal(stats.max, 1);
+    assert.equal(stats.running, 1);
+    assert.equal(stats.queued, 2);
+
+    resetAll();
+    await Promise.all(queued);
+  });
+
+  it("keeps a limit above the default", async () => {
+    const model = "combo:rr:openai/gpt-5";
+
+    const release = await acquire(model, { maxConcurrency: 8 });
+    markRateLimited(model, 20);
+
+    assert.equal(getStats()[model].max, 8);
+    release();
+  });
+
+  it("still gives an untracked model the default limit", () => {
+    const model = "combo:rr:untracked/model";
+
+    markRateLimited(model, 20);
+
+    assert.equal(getStats()[model].max, 3);
+  });
+});


### PR DESCRIPTION
## Summary

- A transient error (429/5xx) on a round-robin combo target resets that target's concurrency limit to 3. `markRateLimited()` calls `getGate(modelStr)` with no limit, and `getGate()` writes its argument into `gate.max` ("Update max if config changed"), so the default of 3 replaces whatever the gate was acquired with.
- The limit comes from the connection's `maxConcurrent` or the combo's `concurrencyPerModel` (`resolveTargetConcurrency`). #4965 added the per-connection cap for accounts such as GLM and MiniMax Starter that allow about one concurrent call and answer 429 above that. So the bug fires exactly when the cap matters: right after the upstream returned 429, the drain at the end of the cooldown releases up to three queued requests at a target capped at 1.
- A limit above 3 is cut to 3 until the next `acquire()` puts it back, so requests queue behind a limit nobody configured.
- Fix: pass the gate's current limit. `accountSemaphore.markBlocked()` already does the same thing (`ensureGate(key, gates.get(key)?.maxConcurrency ?? 1)`). An untracked key still gets the default.

Measured with the real module: hold every slot, queue three requests, `markRateLimited(key, 20)`, release one slot, wait out the cooldown.

| limit | | `max` after `markRateLimited` | after the cooldown |
| --- | --- | --- | --- |
| 1 | before | 3 | running 3, queued 0 |
| 1 | after | 1 | running 1, queued 2 |
| 8 | before | 3 | running 7, queued 3 (stuck behind max 3) |
| 8 | after | 8 | running 8, queued 2 |

## Related Issues

- Related to #4965 (per-connection `maxConcurrent` in round-robin)

## Validation

- [x] Change type: routing
- [x] Focused tests: `tests/unit/rate-limit-semaphore-cooldown-limit.test.ts`, `tests/unit/rateLimitSemaphore.test.ts`, `tests/unit/services-branch-hardening.test.ts` (14/14 pass)
- [x] `eslint` and `prettier --check` on the changed files
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/rate-limit-semaphore-cooldown-limit.test.ts` (new)
  - A limit-1 gate keeps `max` 1 through `markRateLimited()` and drains one request at a time after the cooldown.
  - A limit of 8 survives `markRateLimited()`.
  - Guard: `markRateLimited()` on an untracked key still creates a gate with the default limit of 3.

With the source change reverted, the first two tests fail and the guard still passes.

## Coverage Notes

- `open-sse/services/rateLimitSemaphore.ts`: the changed line is covered by the new tests and by the existing `markRateLimited` case in `services-branch-hardening.test.ts`.

## Reviewer Notes

- One caller: `roundRobinCombo.ts` (`semaphore.markRateLimited(semaphoreKey, cooldownMs)` on a transient error with `cooldownMs > 0`). With the default limit of 3 nothing changes, which is probably why this went unnoticed.
