### PR TITLE
fix(resilience): parse RFC 3339 and fractional-second rate-limit resets

### DIFF
--- a/changelog.d/fixes/13321-rate-limit-reset-rfc3339.md
+++ b/changelog.d/fixes/13321-rate-limit-reset-rfc3339.md
@@ -1,0 +1,1 @@
+- **fix(resilience):** Rate-limit reset headers in RFC 3339 form (Anthropic) and with fractional seconds (`2m59.56s`) are parsed correctly, instead of an Anthropic reset seconds away throttling the connection for about 34 minutes ([#13321](https://github.com/diegosouzapw/OmniRoute/pull/13321))

--- a/open-sse/services/rateLimitManager/headers.ts
+++ b/open-sse/services/rateLimitManager/headers.ts
@@ -29,34 +29,40 @@ export const ANTHROPIC_HEADERS = {
 
 /**
  * Parse a reset time string into milliseconds.
- * Formats: "1s", "1m", "1h", "1ms", "60", ISO date, Unix timestamp
+ * Formats: "1s", "1m", "1h", "1ms", "2m59.56s", "60", ISO date, Unix timestamp
  */
 export function parseResetTime(value) {
-  if (!value) return null;
+  const text = value?.trim();
+  if (!text) return null;
 
-  // Duration strings: "1s", "500ms", "1m30s"
-  const durationMatch = value.match(/^(?:(\d+)h)?(?:(\d+)m(?!s))?(?:(\d+)s)?(?:(\d+)ms)?$/);
+  // Duration strings: "1s", "500ms", "1m30s", "2m59.56s"
+  const durationMatch = text.match(
+    /^(?:(\d+)h)?(?:(\d+)m(?!s))?(?:(\d+(?:\.\d+)?)s)?(?:(\d+(?:\.\d+)?)ms)?$/
+  );
   if (durationMatch) {
     const [, h, m, s, ms] = durationMatch;
-    return (
-      (parseInt(h || 0) * 3600 + parseInt(m || 0) * 60 + parseInt(s || 0)) * 1000 +
-      parseInt(ms || 0)
+    return Math.round(
+      (parseInt(h || 0) * 3600 + parseInt(m || 0) * 60 + parseFloat(s || 0)) * 1000 +
+        parseFloat(ms || 0)
     );
   }
 
-  // Pure number: assume seconds
-  const num = parseFloat(value);
-  if (!isNaN(num) && num > 0) {
-    // If it looks like a Unix timestamp (> year 2025)
-    if (num > 1700000000) {
-      return Math.max(0, num * 1000 - Date.now());
+  // Pure number: assume seconds. Test the whole string — parseFloat alone also reads
+  // the leading year of an ISO date ("2026-09-11T06:27:29Z" → 2026).
+  if (/^\d+(?:\.\d+)?$/.test(text)) {
+    const num = parseFloat(text);
+    if (num > 0) {
+      // If it looks like a Unix timestamp (> year 2025)
+      if (num > 1700000000) {
+        return Math.max(0, num * 1000 - Date.now());
+      }
+      return num * 1000;
     }
-    return num * 1000;
   }
 
-  // ISO date string
+  // ISO date string (Anthropic's anthropic-ratelimit-*-reset headers are RFC 3339)
   try {
-    const date = new Date(value);
+    const date = new Date(text);
     if (!isNaN(date.getTime())) {
       return Math.max(0, date.getTime() - Date.now());
     }

--- a/tests/unit/ratelimitmanager-headers-split.test.ts
+++ b/tests/unit/ratelimitmanager-headers-split.test.ts
@@ -44,6 +44,31 @@ test("rateLimitManager/headers — parseResetTime: bare number → seconds*1000"
   assert.equal(parseResetTime("5"), 5_000);
 });
 
+// anthropic-ratelimit-*-reset carries an RFC 3339 timestamp. parseFloat read its
+// leading year, so a reset 30s away came back as 2026 * 1000 ms (~34 minutes).
+test("rateLimitManager/headers — parseResetTime: RFC 3339 timestamp → ms until then", () => {
+  const inThirtySeconds = new Date(Date.now() + 30_000);
+  for (const value of [
+    inThirtySeconds.toISOString(),
+    inThirtySeconds.toISOString().replace(/\.\d{3}Z$/, "Z"),
+  ]) {
+    const ms = parseResetTime(value);
+    assert.ok(ms > 28_000 && ms <= 30_000, `${value} → ${ms}`);
+  }
+  assert.equal(parseResetTime(new Date(Date.now() - 5_000).toISOString()), 0);
+});
+
+test("rateLimitManager/headers — parseResetTime: fractional seconds in a duration", () => {
+  assert.equal(parseResetTime("2m59.56s"), 179_560);
+  assert.equal(parseResetTime("1h2m3.5s"), 3_723_500);
+  assert.equal(parseResetTime("7.66s"), 7_660);
+});
+
+test("rateLimitManager/headers — parseResetTime: Unix timestamp → ms until then", () => {
+  const ms = parseResetTime(String(Math.floor(Date.now() / 1000) + 60));
+  assert.ok(ms > 58_000 && ms <= 60_000, String(ms));
+});
+
 test("rateLimitManager/headers — toPlainHeaders normalizes to a string record", () => {
   const out = toPlainHeaders({ "X-RateLimit-Remaining": "10", "Content-Type": "application/json" });
   assert.equal(typeof out, "object");


### PR DESCRIPTION
## Summary

- `parseResetTime()` runs `parseFloat()` before its ISO-date branch, and `parseFloat("2026-09-11T06:27:29Z")` is `2026`. That is greater than 0 and below the Unix-timestamp threshold, so the function returns `2026 * 1000` ms. For any date that starts with a digit, the ISO branch its own doc comment lists is never reached.
- Anthropic's `anthropic-ratelimit-requests-reset` / `-input-tokens-reset` headers are RFC 3339 timestamps (`ANTHROPIC_HEADERS` maps them to this function). When `remaining` falls under 10% of `limit`, `updateFromHeaders()` sets the limiter's `reservoirRefreshInterval` to this value. So a connection with a real reset seconds away refills its reservoir every ~34 minutes instead, and requests queued behind the drained reservoir wait for that or run out their queue-wait budget (`maxWaitMs`).
- Fix: take the bare-number branch only when the whole string is a number, so a date goes to `new Date()`. `services/usage/quota.ts` does the same (`/^\d+$/` numeric, everything else through `Date`).
- The duration regex had no fractional part, so Groq's documented `2m59.56s` also fell through to `parseFloat()` and came back as 2000 ms. It now accepts fractional seconds (and milliseconds). This is needed for the main fix anyway: `"7.66s"` was only right by accident, through `parseFloat()`, and the stricter numeric check would otherwise have turned it into `null`.

Measured on `release/v3.8.51` (the new tests, source reverted):

| input | before | after |
| --- | --- | --- |
| RFC 3339, 30 s ahead | `2026000` (~34 min) | ~30000 |
| `2m59.56s` | `2000` | `179560` |
| `1h2m3.5s` | `1000` | `3723500` |
| `7.66s`, `30s`, `500ms`, `1m30s`, `5`, Unix epoch | unchanged | unchanged |

## Related Issues

- Related to #5736 (the extraction of this parser into `rateLimitManager/headers.ts`)

## Validation

- [x] Change type: routing (resilience)
- [x] Focused tests: `tests/unit/ratelimitmanager-headers-split.test.ts`, `tests/unit/rate-limit-manager.test.ts` (29/29 pass)
- [x] `eslint` and `prettier --check` on the changed files
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/ratelimitmanager-headers-split.test.ts`
  - An RFC 3339 reset 30 s ahead, with and without milliseconds, returns ~30000; a reset in the past returns 0.
  - Fractional-second durations: `2m59.56s`, `1h2m3.5s`, `7.66s`.
  - Guard: a Unix timestamp 60 s ahead still returns ~60000.

With the source change reverted, the first two fail (`2026000`, `2000`) and the guard passes.

## Coverage Notes

- `open-sse/services/rateLimitManager/headers.ts`: every branch of `parseResetTime()` is exercised by the existing and new cases.

## Reviewer Notes

- Callers: `rateLimitManager.ts` for `retry-after` on a 429 (an HTTP-date there already failed `parseFloat()` and reached `Date`, so it behaves the same) and for the reset header on a normal response.
- Inputs no provider sends change too. `".5"`, `"1e3"`, `"+60"` and `"30 seconds"` used to be read by `parseFloat()` and now return `null`, so the caller uses its 60 s default. `"1.5ms"` was 1500 (read as seconds) and is now 2.
- Whitespace around the value is now trimmed before parsing. Before, `" 30s"` only worked because `parseFloat()` skips leading spaces.
