### PR TITLE
fix(cli): read commander's negated --no-* flags as opts.<name> === false

### DIFF
--- a/bin/cli/commands/chat.mjs
+++ b/bin/cli/commands/chat.mjs
@@ -79,7 +79,8 @@ export async function runChatCommand(promptArg, opts, cmd) {
   const data = await response.json();
   const text = extractText(data, opts.responsesApi);
 
-  if (!opts.noHistory) {
+  // Commander stores `--no-history` as `history === false`, never as `noHistory`.
+  if (opts.history !== false && opts.noHistory !== true) {
     appendHistory({ prompt, model: opts.model, latencyMs, usage: data.usage, response: text });
   }
 

--- a/bin/cli/commands/contexts.mjs
+++ b/bin/cli/commands/contexts.mjs
@@ -248,7 +248,9 @@ export function registerContexts(program) {
     .option("--no-secrets", "Omit API keys from export")
     .action(async (opts, cmd) => {
       const cfg = loadContexts();
-      const out = opts.noSecrets ? redactContextSecrets(cfg) : JSON.parse(JSON.stringify(cfg));
+      // Commander stores `--no-secrets` as `secrets === false`, never as `noSecrets`.
+      const redact = opts.secrets === false || opts.noSecrets === true;
+      const out = redact ? redactContextSecrets(cfg) : JSON.parse(JSON.stringify(cfg));
       const json = JSON.stringify(out, null, 2);
       if (opts.out) {
         const { writeFileSync } = await import("node:fs");

--- a/bin/cli/commands/serve.mjs
+++ b/bin/cli/commands/serve.mjs
@@ -276,7 +276,8 @@ export async function runServe(opts = {}) {
     return runDaemon(serverJs, env, memoryLimit, dashboardPort, apiPort);
   }
 
-  if (opts.noRecovery) {
+  // Commander stores `--no-recovery` as `recovery === false`, never as `noRecovery`.
+  if (opts.recovery === false || opts.noRecovery === true) {
     return runWithoutRecovery(
       serverJs,
       env,

--- a/changelog.d/fixes/13322-cli-negated-flags.md
+++ b/changelog.d/fixes/13322-cli-negated-flags.md
@@ -1,0 +1,1 @@
+- **fix(cli):** `contexts export --no-secrets` now leaves the access tokens and API keys out, and `chat --no-history` and `serve --no-recovery` take effect; all three flags were accepted and ignored ([#13322](https://github.com/diegosouzapw/OmniRoute/pull/13322))

--- a/tests/unit/cli-negated-flags.test.ts
+++ b/tests/unit/cli-negated-flags.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Commander stores a negated option such as `--no-history` as `history === false`; it never
+ * sets `noHistory`. `chat --no-history`, `contexts export --no-secrets` and
+ * `serve --no-recovery` read the `noX` name, so each flag was accepted and did nothing:
+ * the prompt was still written to cli-history.jsonl, and the export still carried the
+ * access tokens and API keys. These tests drive the real Commander parser instead of
+ * hand-building an options object Commander never produces.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+
+const FAKE_RESPONSE = {
+  id: "chatcmpl-abc",
+  model: "claude-sonnet-4-6",
+  choices: [{ message: { role: "assistant", content: "Hello!" } }],
+  usage: { prompt_tokens: 5, completion_tokens: 10, total_tokens: 15 },
+};
+
+async function withDataDir(prefix: string, fn: (dir: string) => Promise<void>) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  const prevDataDir = process.env.DATA_DIR;
+  const prevKeychain = process.env.OMNIROUTE_KEYCHAIN_DISABLED;
+  process.env.DATA_DIR = dir;
+  process.env.OMNIROUTE_KEYCHAIN_DISABLED = "1";
+  try {
+    await fn(dir);
+  } finally {
+    if (prevDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = prevDataDir;
+    if (prevKeychain === undefined) delete process.env.OMNIROUTE_KEYCHAIN_DISABLED;
+    else process.env.OMNIROUTE_KEYCHAIN_DISABLED = prevKeychain;
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  }
+}
+
+async function quietly(fn: () => Promise<unknown>) {
+  const out = process.stdout.write.bind(process.stdout);
+  const err = process.stderr.write.bind(process.stderr);
+  process.stdout.write = () => true;
+  process.stderr.write = () => true;
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = out;
+    process.stderr.write = err;
+  }
+}
+
+async function runChat(args: string[]) {
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = (() =>
+    Promise.resolve(
+      new Response(JSON.stringify(FAKE_RESPONSE), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    )) as typeof fetch;
+  try {
+    const { registerChat } = await import("../../bin/cli/commands/chat.mjs");
+    const program = new Command().exitOverride();
+    registerChat(program);
+    await quietly(() => program.parseAsync(["chat", ...args], { from: "user" }));
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+}
+
+test("chat --no-history does not write cli-history.jsonl", async () => {
+  await withDataDir("chat-no-history-", async (dir) => {
+    await runChat(["secret prompt", "--no-history"]);
+    assert.equal(existsSync(join(dir, "cli-history.jsonl")), false);
+  });
+});
+
+test("chat without --no-history still records the exchange", async () => {
+  await withDataDir("chat-history-", async (dir) => {
+    await runChat(["keep this"]);
+    const line = JSON.parse(readFileSync(join(dir, "cli-history.jsonl"), "utf8").trim());
+    assert.equal(line.prompt, "keep this");
+  });
+});
+
+async function exportContexts(dir: string, args: string[]) {
+  const { saveContexts } = await import("../../bin/cli/contexts.mjs");
+  saveContexts({
+    currentContext: "remote",
+    contexts: {
+      remote: {
+        baseUrl: "https://omniroute.example",
+        accessToken: "oma_SECRET_TOKEN",
+        apiKey: "sk-SECRET-KEY",
+      },
+    },
+  });
+  const { registerContexts } = await import("../../bin/cli/commands/contexts.mjs");
+  const program = new Command().exitOverride();
+  registerContexts(program);
+  const outFile = join(dir, "export.json");
+  await quietly(() =>
+    program.parseAsync(["contexts", "export", "--out", outFile, ...args], { from: "user" })
+  );
+  return readFileSync(outFile, "utf8");
+}
+
+test("contexts export --no-secrets leaves the token and API key out", async () => {
+  await withDataDir("ctx-no-secrets-", async (dir) => {
+    const json = await exportContexts(dir, ["--no-secrets"]);
+    assert.doesNotMatch(json, /oma_SECRET_TOKEN|sk-SECRET-KEY/);
+    assert.equal(JSON.parse(json).contexts.remote.baseUrl, "https://omniroute.example");
+  });
+});
+
+test("contexts export without --no-secrets keeps the full config", async () => {
+  await withDataDir("ctx-secrets-", async (dir) => {
+    const json = await exportContexts(dir, []);
+    assert.match(json, /sk-SECRET-KEY/);
+  });
+});
+
+test("serve --no-recovery reaches runServe as recovery === false", async () => {
+  const { registerServe } = await import("../../bin/cli/commands/serve.mjs");
+  const program = new Command().exitOverride();
+  registerServe(program);
+  let parsed: Record<string, unknown> | undefined;
+  program.commands
+    .find((cmd) => cmd.name() === "serve")!
+    .action((opts: Record<string, unknown>) => {
+      parsed = opts;
+    });
+
+  await program.parseAsync(["serve", "--no-recovery"], { from: "user" });
+
+  assert.equal(parsed?.recovery, false);
+  assert.equal(parsed?.noRecovery, undefined);
+
+  const fs = await import("node:fs");
+  const path = await import("node:path");
+  const source = fs.readFileSync(
+    path.resolve(import.meta.dirname, "../../bin/cli/commands/serve.mjs"),
+    "utf-8"
+  );
+  assert.match(source, /if \(opts\.recovery === false[^)]*\) \{\s*return runWithoutRecovery\(/);
+});


### PR DESCRIPTION
## Summary

Commander stores a negated option such as `--no-history` as `history === false`. It never sets `noHistory`. Three commands read the `noX` name, so each flag is accepted without error and does nothing:

| command | reads | what actually happens |
| --- | --- | --- |
| `omniroute contexts export --no-secrets` | `opts.noSecrets` | the export still contains every context's `accessToken` and `apiKey`; `redactContextSecrets()` is never reached |
| `omniroute chat --no-history` | `opts.noHistory` | the prompt and response are still appended to `cli-history.jsonl`, which the help text promises not to do |
| `omniroute serve --no-recovery` | `opts.noRecovery` | the auto-restart supervisor still runs (documented in `docs/guides/USER_GUIDE.md` as the debugging mode) |

The export case matters most. The credentials stay in `config.json` in plain text whenever the keychain is unavailable (headless Linux, keytar missing) and in legacy `profiles` entries. So a user who adds `--no-secrets` before sharing an export, precisely because of that, gets the keys in the file.

The same code base already handles this correctly elsewhere. `resolveProviderCredential()` says so in a comment ("Commander represents the negated `--no-credential` option as `credential === false`"), `validateTrayOptions()` checks `opts.noRecovery || opts.recovery === false`, and `runServe()` reads `opts.open === false` a few lines above the broken check. The fix reads the key Commander sets and keeps accepting the `noX` form, the same way those two helpers do.

These went unnoticed because the chat tests hand-build `{ noHistory: true }`, an options object Commander never produces. `redactContextSecrets()` has its own test, but nothing ran it through the command.

## Related Issues

- None found. Searched for `no-secrets`, `no-history`, `no-recovery`, `noSecrets`, `noHistory`, `noRecovery`, `cli-history`, `redactContextSecrets` and `contexts export`.

## Validation

- [x] Change type: CLI
- [x] Focused tests: `tests/unit/cli-negated-flags.test.ts`, `tests/unit/cli-chat.test.ts`, `tests/unit/cli-contexts.test.ts`, `tests/unit/cli-serve-port.test.ts` (31/31 pass)
- [x] `eslint` and `prettier --check` on the changed files
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/cli-negated-flags.test.ts` (new). The tests drive the real Commander parser:
  - `chat "…" --no-history` (with `fetch` stubbed) leaves no `cli-history.jsonl`.
  - Guard: `chat` without the flag still records the exchange.
  - `contexts export --no-secrets --out <file>` writes no token or API key and keeps the rest of the context.
  - Guard: `contexts export` without the flag still writes the full config.
  - `serve --no-recovery` reaches the action as `recovery === false`, and the recovery branch in `runServe()` checks that key. The source assertion follows `cli-serve-port.test.ts`, since `runServe()` spawns the server.

With the three source changes reverted, the three flag tests fail, and the two guards and every existing test still pass.

## Coverage Notes

- `bin/cli/commands/chat.mjs` and `contexts.mjs`: the changed lines are executed end to end by the new tests.
- `bin/cli/commands/serve.mjs`: the parse shape is executed; the branch itself is asserted structurally.

## Reviewer Notes

- Nothing changes when a flag is absent.
- Open PRs #12485 and #12484 edit `serve.mjs`, around lines 230–320 and 446–490. This change is the single `if` at line 279, so the hunks do not overlap.
