### PR TITLE
fix(providers): let a dashboard OFF for private provider URLs beat the env opt-in

### DIFF
--- a/changelog.d/fixes/13323-private-provider-urls-db-off.md
+++ b/changelog.d/fixes/13323-private-provider-urls-db-off.md
@@ -1,0 +1,1 @@
+- **fix(providers):** Switching "Allow Private Provider URLs" off in the dashboard now takes effect when `OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS=true` is set in the environment ([#13323](https://github.com/diegosouzapw/OmniRoute/pull/13323))

--- a/src/shared/network/outboundUrlGuardPolicy.ts
+++ b/src/shared/network/outboundUrlGuardPolicy.ts
@@ -1,3 +1,4 @@
+import { getFeatureFlagOverride } from "@/lib/db/featureFlags";
 import { resolveFeatureFlag } from "@/shared/utils/featureFlags";
 import {
   OutboundUrlGuardError,
@@ -32,16 +33,21 @@ export function arePrivateProviderUrlsAllowed() {
   //    the dashboard ("Allow Private Provider URLs"). This is critical for the
   //    Electron build (#2575) where the server is spawned with the env value
   //    captured at boot, so subsequent UI toggles only land in the DB and the
-  //    env-first ordering would otherwise mask them.
+  //    env-first ordering would otherwise mask them. That holds for a toggle OFF
+  //    too: an override of "false" must not be re-enabled by the env opt-in below.
+  let dbValue: string | undefined;
   try {
-    const dbValue = resolveFeatureFlag(PRIVATE_PROVIDER_URLS_ENV);
-    if (isTrueValue(dbValue)) return true;
+    dbValue = getFeatureFlagOverride(PRIVATE_PROVIDER_URLS_ENV);
   } catch {
     // DB not initialized yet — fall through to env-only check.
   }
 
-  // 2) Explicit env opt-in (for headless/Docker users who set it before boot).
-  if (isTrueValue(process.env[PRIVATE_PROVIDER_URLS_ENV])) return true;
+  if (dbValue !== undefined && dbValue !== "") {
+    if (isTrueValue(dbValue)) return true;
+  } else if (isTrueValue(process.env[PRIVATE_PROVIDER_URLS_ENV])) {
+    // 2) Explicit env opt-in (for headless/Docker users who set it before boot).
+    return true;
+  }
 
   // 3) Legacy escape hatch — disabling the outbound guard implies allowing
   //    private URLs.

--- a/tests/unit/outbound-url-guard-feature-flag.test.ts
+++ b/tests/unit/outbound-url-guard-feature-flag.test.ts
@@ -78,3 +78,57 @@ test("arePrivateProviderUrlsAllowed default (no env, no DB) returns false", asyn
     });
   });
 });
+
+test("arePrivateProviderUrlsAllowed honors DB override = 'false' even when env is 'true'", async () => {
+  await withEnv("true", async () => {
+    await withDbOverride("false", async () => {
+      const { arePrivateProviderUrlsAllowed, getProviderValidationGuard } =
+        await import("../../src/shared/network/outboundUrlGuardPolicy.ts");
+      assert.equal(
+        arePrivateProviderUrlsAllowed(),
+        false,
+        "a dashboard OFF must not be re-enabled by the env opt-in"
+      );
+      assert.equal(getProviderValidationGuard(), "block-metadata");
+    });
+  });
+});
+
+test("DB override = 'false' leaves the legacy OUTBOUND_SSRF_GUARD_ENABLED=false hatch as it was", async () => {
+  const prev = process.env.OUTBOUND_SSRF_GUARD_ENABLED;
+  process.env.OUTBOUND_SSRF_GUARD_ENABLED = "false";
+  try {
+    await withEnv(undefined, async () => {
+      await withDbOverride("false", async () => {
+        const { arePrivateProviderUrlsAllowed } =
+          await import("../../src/shared/network/outboundUrlGuardPolicy.ts");
+        assert.equal(arePrivateProviderUrlsAllowed(), true);
+      });
+    });
+  } finally {
+    if (prev === undefined) delete process.env.OUTBOUND_SSRF_GUARD_ENABLED;
+    else process.env.OUTBOUND_SSRF_GUARD_ENABLED = prev;
+  }
+});
+
+test("a DB override = 'false' for local provider URLs still restores public-only", async () => {
+  const LOCAL_KEY = "OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS";
+  const prev = process.env[LOCAL_KEY];
+  delete process.env[LOCAL_KEY];
+  const { setFeatureFlagOverride, removeFeatureFlagOverride } =
+    await import("../../src/lib/db/featureFlags.ts");
+  setFeatureFlagOverride(LOCAL_KEY, "false");
+  try {
+    await withEnv(undefined, async () => {
+      await withDbOverride(undefined, async () => {
+        const { getProviderValidationGuard } =
+          await import("../../src/shared/network/outboundUrlGuardPolicy.ts");
+        assert.equal(getProviderValidationGuard(), "public-only");
+      });
+    });
+  } finally {
+    removeFeatureFlagOverride(LOCAL_KEY);
+    if (prev === undefined) delete process.env[LOCAL_KEY];
+    else process.env[LOCAL_KEY] = prev;
+  }
+});


### PR DESCRIPTION
## Summary

- `arePrivateProviderUrlsAllowed()` opens with "DB override takes precedence — it represents an explicit user toggle in the dashboard", but it only acts on an override of `"true"`. An override of `"false"` falls through to the `process.env` check.
- So with `OMNIROUTE_ALLOW_PRIVATE_PROVIDER_URLS=true` in the environment (the opt-in `.env.example` describes), switching "Allow Private Provider URLs" OFF in the dashboard has no effect:
  - The provider validation and outbound guards stay at `"none"`, which means no checks at all.
  - The Feature Flags page shows the flag as off, with source `db`.
- #2595 (for #2575) added the DB read to make the toggle work without a restart, and covered only the OFF→ON direction. The existing tests cover three of the four env/DB combinations and skip this one.
- Fix: read the stored override directly and treat any stored value as final for this flag. The sibling `areLocalProviderUrlsAllowed()` in the same file already does this (`if (dbValue !== undefined && dbValue !== "") return isTrueValue(dbValue);`).

| env | DB override | before | after |
| --- | --- | --- | --- |
| `true` | none | allowed | allowed |
| unset | `true` | allowed | allowed |
| `false` | `true` | allowed | allowed |
| unset | `false` | blocked | blocked |
| `true` | `false` | **allowed** | blocked (`getProviderValidationGuard()` → `block-metadata`) |

## Related Issues

- Related to #2575 / #2595 (the OFF→ON half of the same toggle)

## Validation

- [x] Change type: provider
- [x] Focused tests: every unit test that imports `outboundUrlGuardPolicy` (feature-flag, local-flag, provider validation SSRF guard, provider models LAN guard, remote image fetch, webhook metadata / private opt-in, production build module integrity) plus `cc-compatible-provider.test.ts`: 63/63 pass
- [x] `eslint` and `prettier --check` on the changed files
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/outbound-url-guard-feature-flag.test.ts`
  - DB override `"false"` with env `"true"` → not allowed, and the validation guard falls back to `block-metadata`.
  - Guard: DB override `"false"` does not change the legacy `OUTBOUND_SSRF_GUARD_ENABLED=false` hatch.
  - Guard: a DB override `"false"` for the sibling `OMNIROUTE_ALLOW_LOCAL_PROVIDER_URLS` still yields `public-only`. The existing local-flag tests only set that flag through `process.env`, so a DB-side regression there went unseen (its `resolveFeatureFlag()` call sits inside a `try/catch` that would swallow a failure).

With the source change reverted, the first test fails and the guards and the four existing tests pass.

## Coverage Notes

- `src/shared/network/outboundUrlGuardPolicy.ts`: all four branches of the new override/env block are exercised by the seven tests in that file.

## Reviewer Notes

- The legacy `OUTBOUND_SSRF_GUARD_ENABLED=false` hatch is intentionally left as it was. It is a different key, and whether a dashboard OFF for this flag should also override a globally disabled guard is a separate decision. Relatedly, the "SSRF Guard" flag (`OUTBOUND_SSRF_GUARD_ENABLED`) is only ever read from `process.env` here, so its own dashboard toggle does nothing. That one fails closed, so I left it out of this PR.
- The module now also imports `getFeatureFlagOverride` from `@/lib/db/featureFlags`. `@/shared/utils/featureFlags` already imported it, so the dependency graph is the same, and #7682's CLI split is unaffected.
