### PR TITLE
fix(quota): keep Kiro active while any _freetrial pool has quota (#13088)

### DIFF
--- a/changelog.d/fixes/1328-kiro-quota-freetrial.md
+++ b/changelog.d/fixes/1328-kiro-quota-freetrial.md
@@ -1,0 +1,1 @@
+- fix(quota): keep Kiro active while any _freetrial pool has quota (#13088)

--- a/open-sse/services/genericQuotaFetcher.ts
+++ b/open-sse/services/genericQuotaFetcher.ts
@@ -24,10 +24,8 @@ import {
   type QuotaFetcher,
   type QuotaInfo,
 } from "./quotaPreflight.ts";
-import {
-  getAntigravityQuotaFamily,
-  getQuotaFetchScope,
-} from "./antigravityQuotaFamily.ts";
+import { getAntigravityQuotaFamily, getQuotaFetchScope } from "./antigravityQuotaFamily.ts";
+import { toNumberOrNull } from "@/shared/utils/numeric";
 
 type UsageFetcher = (
   connection: Parameters<typeof getUsageForProvider>[0],
@@ -88,18 +86,11 @@ function connectionKey(provider: string, connectionId: string): string {
   return `${provider.trim()}::${connectionId.trim()}`;
 }
 
-function quotaCacheScope(
-  provider: string,
-  requestedModel?: string | null
-): string {
+function quotaCacheScope(provider: string, requestedModel?: string | null): string {
   return getQuotaFetchScope(provider, requestedModel);
 }
 
-function cacheKey(
-  provider: string,
-  connectionId: string,
-  requestedModel?: string | null
-): string {
+function cacheKey(provider: string, connectionId: string, requestedModel?: string | null): string {
   return `${connectionKey(provider, connectionId)}::${quotaCacheScope(provider, requestedModel)}`;
 }
 
@@ -125,22 +116,14 @@ function markPendingForceRefreshMiss(key: string): void {
   if (isPendingForceRefresh(key)) pendingForceRefreshMiss.set(key, Date.now());
 }
 
-function cachedQuotaIfFresh(
-  key: string,
-  forceRefresh: boolean,
-  now: number
-): QuotaInfo | null {
+function cachedQuotaIfFresh(key: string, forceRefresh: boolean, now: number): QuotaInfo | null {
   if (forceRefresh) return null;
   const cached = cache.get(key);
   if (cached && now - cached.fetchedAt < CACHE_TTL_MS) return cached.quota;
   return null;
 }
 
-function isForceRefreshMissCooling(
-  key: string,
-  forceRefresh: boolean,
-  now: number
-): boolean {
+function isForceRefreshMissCooling(key: string, forceRefresh: boolean, now: number): boolean {
   if (!forceRefresh) return false;
   const missedAt = pendingForceRefreshMiss.get(key);
   return missedAt !== undefined && now - missedAt < CACHE_TTL_MS;
@@ -150,10 +133,7 @@ function isForceRefreshMissCooling(
 function isConcurrentForceRefresh(key: string, refreshStamp: number | undefined): boolean {
   const currentStamp = pendingForceRefresh.get(key);
   if (currentStamp === refreshStamp) return false;
-  return (
-    currentStamp !== undefined &&
-    Date.now() - currentStamp <= PENDING_FORCE_REFRESH_TTL_MS
-  );
+  return currentStamp !== undefined && Date.now() - currentStamp <= PENDING_FORCE_REFRESH_TTL_MS;
 }
 
 // 5min — same as Codex. Expiry is lazy on read (`isPendingForceRefresh`);
@@ -171,14 +151,6 @@ if (typeof _cacheCleanup === "object" && "unref" in _cacheCleanup) {
   (_cacheCleanup as { unref?: () => void }).unref?.();
 }
 
-function toNumber(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = parseFloat(value);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return null;
-}
 
 /**
  * Compute percentUsed (0-1) for a single quota entry. Prefers the explicit
@@ -197,15 +169,15 @@ function percentUsedForQuota(entry: unknown): number | null {
   // otherwise one unreported model falsely exhausts the whole connection.
   if (q.fractionReported === false) return null;
 
-  const remainingPercentage = toNumber(q.remainingPercentage);
+  const remainingPercentage = toNumberOrNull(q.remainingPercentage);
   if (remainingPercentage !== null) {
     // remainingPercentage is 0-100 in the usage.ts contract.
     const used = (100 - Math.max(0, Math.min(100, remainingPercentage))) / 100;
     return used;
   }
 
-  const used = toNumber(q.used);
-  const total = toNumber(q.total);
+  const used = toNumberOrNull(q.used);
+  const total = toNumberOrNull(q.total);
   if (used !== null && total !== null && total > 0) {
     return Math.max(0, Math.min(1, used / total));
   }
@@ -239,6 +211,28 @@ type UsageToQuotaContext = {
   requestedModel?: string | null;
   provider?: string | null;
 };
+
+function aggregateGroupedQuotaValues(
+  windows: Record<string, { percentUsed: number; resetAt: string | null }>
+): { percentUsed: number; resetAt: string | null } {
+  const effectiveByBase = new Map<string, { percentUsed: number; resetAt: string | null }>();
+  for (const [key, entry] of Object.entries(windows)) {
+    const base = key.endsWith("_freetrial") ? key.slice(0, -10) : key;
+    const cur = effectiveByBase.get(base);
+    if (!cur || entry.percentUsed < cur.percentUsed) {
+      effectiveByBase.set(base, { percentUsed: entry.percentUsed, resetAt: entry.resetAt ?? null });
+    }
+  }
+  let percentUsed = 0;
+  let resetAt: string | null = null;
+  for (const eff of effectiveByBase.values()) {
+    if (eff.percentUsed > percentUsed) {
+      percentUsed = eff.percentUsed;
+      resetAt = eff.resetAt;
+    }
+  }
+  return { percentUsed, resetAt };
+}
 
 export function convertUsageToQuotaInfo(
   usage: unknown,
@@ -288,16 +282,7 @@ export function convertUsageToQuotaInfo(
   if (Object.keys(providerScopedWindows).length === 0) return null;
 
   const normalized = normalizeQuotaWindows(providerScopedWindows, context);
-  const scopedEntries = Object.values(providerScopedWindows);
-  const percentUsed = scopedEntries.reduce(
-    (worst, entry) => Math.max(worst, entry.percentUsed),
-    0
-  );
-  const resetAt =
-    scopedEntries.reduce<{ percentUsed: number; resetAt: string | null } | null>(
-      (worst, entry) => (!worst || entry.percentUsed > worst.percentUsed ? entry : worst),
-      null
-    )?.resetAt ?? null;
+  const { percentUsed, resetAt } = aggregateGroupedQuotaValues(providerScopedWindows);
 
   return {
     used: 0,
@@ -322,10 +307,7 @@ function isAntigravityProvider(provider: string | null | undefined): boolean {
   return provider === "antigravity" || provider === "agy";
 }
 
-function antigravityWeeklyWindowMatchesFamily(
-  key: string,
-  family: "gemini" | "claude"
-): boolean {
+function antigravityWeeklyWindowMatchesFamily(key: string, family: "gemini" | "claude"): boolean {
   if (!key.endsWith("_weekly")) return false;
   return family === "gemini" ? key === "gemini_weekly" : key === "claude_gpt_weekly";
 }

--- a/open-sse/services/quotaPreflight.ts
+++ b/open-sse/services/quotaPreflight.ts
@@ -205,38 +205,89 @@ function limitReachedResult(quota: QuotaInfo): PreflightQuotaResult {
   );
 }
 
+function isEntryExhausted(
+  windowName: string,
+  percentUsed: number,
+  thresholds?: PreflightQuotaThresholds
+): boolean {
+  const minRemainingPercent = resolveOrDefault(
+    thresholds?.resolveMinRemainingPercent,
+    windowName,
+    DEFAULT_MIN_REMAINING_PERCENT
+  );
+  return isRemainingAtOrBelowThreshold(remainingPercentFrom(percentUsed), minRemainingPercent);
+}
+
+function evaluateQuotaGroup(
+  entries: Array<[string, QuotaWindowInfo]>,
+  thresholds?: PreflightQuotaThresholds
+): {
+  exhausted: boolean;
+  worstPercent: number;
+  worstWindow: string | null;
+  worstResetAt: string | null;
+} {
+  let exhausted = true;
+  let worstPercent = -1;
+  let worstWindow: string | null = null;
+  let worstResetAt: string | null = null;
+  for (const [windowName, windowInfo] of entries) {
+    if (!isEntryExhausted(windowName, windowInfo.percentUsed, thresholds)) {
+      exhausted = false;
+    }
+    if (windowInfo.percentUsed > worstPercent) {
+      worstPercent = windowInfo.percentUsed;
+      worstWindow = windowName;
+      worstResetAt = windowInfo.resetAt ?? null;
+    }
+  }
+  return { exhausted, worstPercent: Math.max(0, worstPercent), worstWindow, worstResetAt };
+}
+
+function groupQuotaWindowsByBase(
+  windows: NonNullable<QuotaInfo["windows"]>
+): Map<string, Array<[string, QuotaWindowInfo]>> {
+  const groups = new Map<string, Array<[string, QuotaWindowInfo]>>();
+  for (const [windowName, windowInfo] of Object.entries(windows)) {
+    if (!Number.isFinite(windowInfo.percentUsed)) continue;
+    const base = windowName.endsWith("_freetrial") ? windowName.slice(0, -10) : windowName;
+    const list = groups.get(base);
+    if (list) list.push([windowName, windowInfo]);
+    else groups.set(base, [[windowName, windowInfo]]);
+  }
+  return groups;
+}
+
 function quotaWindowCutoffResult(
   windows: NonNullable<QuotaInfo["windows"]>,
   thresholds?: PreflightQuotaThresholds
 ): PreflightQuotaResult | null {
-  let worstUsedPercent = 0;
-  let worstWindow: string | null = null;
-  let worstResetAt: string | null = null;
+  const groups = groupQuotaWindowsByBase(windows);
+  if (groups.size === 0) return null;
 
-  for (const [windowName, windowInfo] of Object.entries(windows)) {
-    if (!Number.isFinite(windowInfo.percentUsed)) continue;
-    const minRemainingPercent = resolveOrDefault(
-      thresholds?.resolveMinRemainingPercent,
-      windowName,
-      DEFAULT_MIN_REMAINING_PERCENT
+  let worstExhaustedPercent = 0;
+  let worstExhaustedWindow: string | null = null;
+  let worstExhaustedResetAt: string | null = null;
+  let hasExhaustedGroup = false;
+
+  for (const entries of groups.values()) {
+    const { exhausted, worstPercent, worstWindow, worstResetAt } = evaluateQuotaGroup(
+      entries,
+      thresholds
     );
-    if (
-      !isRemainingAtOrBelowThreshold(
-        remainingPercentFrom(windowInfo.percentUsed),
-        minRemainingPercent
-      )
-    ) {
-      continue;
+    if (exhausted) {
+      hasExhaustedGroup = true;
+      if (worstPercent > worstExhaustedPercent || worstExhaustedWindow === null) {
+        worstExhaustedPercent = worstPercent;
+        worstExhaustedWindow = worstWindow;
+        worstExhaustedResetAt = worstResetAt;
+      }
     }
-    if (windowInfo.percentUsed <= worstUsedPercent && worstWindow !== null) continue;
-    worstUsedPercent = windowInfo.percentUsed;
-    worstWindow = windowName;
-    worstResetAt = windowInfo.resetAt ?? null;
   }
 
-  return worstWindow === null
-    ? null
-    : exhaustedResult(worstUsedPercent, worstResetAt, worstWindow);
+  return hasExhaustedGroup
+    ? exhaustedResult(worstExhaustedPercent, worstExhaustedResetAt, worstExhaustedWindow)
+    : null;
 }
 
 function quotaPercentCutoffResult(

--- a/tests/unit/generic-quota-fetcher.test.ts
+++ b/tests/unit/generic-quota-fetcher.test.ts
@@ -329,7 +329,11 @@ test("in-flight fetch must not drop a concurrent 429 force-refresh", async () =>
   assert.equal(first?.percentUsed, 0.2);
 
   const second = await fetchGenericQuota(connectionId, connection);
-  assert.equal(calls.length, 2, "concurrent 429 must not let the in-flight recache wipe force-refresh");
+  assert.equal(
+    calls.length,
+    2,
+    "concurrent 429 must not let the in-flight recache wipe force-refresh"
+  );
   assert.equal(calls[1]?.forceRefresh, true);
   assert.equal(second?.percentUsed, 0.9);
   invalidateGenericQuotaCache("agy", connectionId);
@@ -387,4 +391,29 @@ test("stamp expiry during in-flight fetch still writes the wrapper cache", async
   await fetchGenericQuota(connectionId, connection);
   assert.equal(calls.length, 2, "expired stamp during await is not a 429; cache the result");
   invalidateGenericQuotaCache("agy", connectionId);
+});
+
+test("convertUsageToQuotaInfo aggregates _freetrial and non-freetrial windows using best remaining", async () => {
+  const usage = {
+    quotas: {
+      credit: { used: 50, total: 50 },
+      credit_freetrial: { used: 0, total: 500 },
+    },
+  };
+  const result = convertUsageToQuotaInfo(usage, { provider: "kiro" });
+  // Used: min of 100% and 0% = 0%
+  assert.equal(result?.percentUsed, 0);
+  assert.equal(result?.limitReached, false);
+});
+
+test("convertUsageToQuotaInfo blocks when both base and freetrial are exhausted", async () => {
+  const usage = {
+    quotas: {
+      credit: { used: 50, total: 50 },
+      credit_freetrial: { used: 500, total: 500 },
+    },
+  };
+  const result = convertUsageToQuotaInfo(usage, { provider: "kiro" });
+  assert.equal(result?.percentUsed, 1);
+  assert.equal(result?.limitReached, true);
 });

--- a/tests/unit/quota-preflight.test.ts
+++ b/tests/unit/quota-preflight.test.ts
@@ -346,3 +346,32 @@ test("registerQuotaWindows / getQuotaWindows round-trips", () => {
   // Unknown provider returns an empty list rather than undefined.
   assert.deepEqual([...getQuotaWindows("provider-with-no-registration-anywhere")], []);
 });
+
+test("evaluateQuotaCutoff permits connection when base is exhausted but _freetrial is available", () => {
+  const quota = {
+    used: 50,
+    total: 50,
+    percentUsed: 0,
+    windows: {
+      credit: { percentUsed: 1.0, resetAt: null },
+      credit_freetrial: { percentUsed: 0.0, resetAt: null },
+    },
+  };
+  const result = evaluateQuotaCutoff(quota);
+  assert.equal(result.proceed, true);
+});
+
+test("evaluateQuotaCutoff blocks connection when both base and _freetrial are exhausted", () => {
+  const quota = {
+    used: 50,
+    total: 50,
+    percentUsed: 1.0,
+    windows: {
+      credit: { percentUsed: 1.0, resetAt: null },
+      credit_freetrial: { percentUsed: 1.0, resetAt: null },
+    },
+  };
+  const result = evaluateQuotaCutoff(quota);
+  assert.equal(result.proceed, false);
+  assert.equal(result.reason, "quota_exhausted");
+});


### PR DESCRIPTION
## Summary

- Keep Kiro OAuth accounts active and routable when base `credit` is exhausted but `credit_freetrial` still has remaining quota.
- Group quota windows by base name (treating `<resource>_freetrial` and `<resource>` as alternative pools for the same resource via best remaining percentage) in both preflight check and generic quota calculation.
- Treat independent quota dimensions (e.g. session vs weekly) conjunctively: if any group is exhausted, the connection is blocked.

## Related Issues

- Closes #13088
- Related to #1328

## Validation

- [x] Change type: routing / provider
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR

## Tests Added Or Updated

- `tests/unit/quota-preflight.test.ts` - test alternative `_freetrial` pools vs independent windows in `evaluateQuotaCutoff`
- `tests/unit/generic-quota-fetcher.test.ts` - test `convertUsageToQuotaInfo` aggregation with `_freetrial` pools

## Coverage Notes

- Changes in `open-sse/services/quotaPreflight.ts` and `open-sse/services/genericQuotaFetcher.ts` are covered by unit tests in `tests/unit/quota-preflight.test.ts` and `tests/unit/generic-quota-fetcher.test.ts`.

## Reviewer Notes

- No breaking changes or migrations.
- Alternative quota pools evaluation is scoped strictly to resource pairs sharing base name (with `_freetrial` suffix).

⚠️ base-red inherited: #12732