### PR TITLE
fix(cli): let restart honor PORT like serve and dashboard

### DIFF
--- a/bin/cli/commands/restart.mjs
+++ b/bin/cli/commands/restart.mjs
@@ -6,7 +6,8 @@ export function registerRestart(program) {
   program
     .command("restart")
     .description(t("restart.description"))
-    .option("--port <port>", t("serve.port"), "20128")
+    // No Commander default: runServe() falls back to PORT, then 20128 (#7049).
+    .option("--port <port>", t("serve.port"))
     .action(async (opts) => {
       const exitCode = await runRestartCommand(opts);
       if (exitCode !== 0) process.exit(exitCode);

--- a/changelog.d/fixes/13327-cli-restart-honors-port.md
+++ b/changelog.d/fixes/13327-cli-restart-honors-port.md
@@ -1,0 +1,1 @@
+- **fix(cli):** `omniroute restart` now comes back on the port set by `PORT` (shell or `<DATA_DIR>/.env`) instead of always 20128, like `serve` and `dashboard` ([#13327](https://github.com/diegosouzapw/OmniRoute/pull/13327))

--- a/tests/unit/cli-restart-port.test.ts
+++ b/tests/unit/cli-restart-port.test.ts
@@ -1,0 +1,33 @@
+/**
+ * `omniroute restart` declared `--port` with a Commander default of "20128", so the
+ * `opts.port ?? process.env.PORT` fallback in runServe() never reached PORT: a server
+ * started on PORT=3000 (from the shell or <DATA_DIR>/.env) came back on 20128 after a
+ * restart. #7049 fixed the same default on `dashboard`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Command } from "commander";
+
+async function parseRestart(args: string[]) {
+  const { registerRestart } = await import("../../bin/cli/commands/restart.mjs");
+  const program = new Command().exitOverride();
+  registerRestart(program);
+  let parsed: Record<string, unknown> | undefined;
+  program.commands
+    .find((cmd) => cmd.name() === "restart")!
+    .action((opts: Record<string, unknown>) => {
+      parsed = opts;
+    });
+  await program.parseAsync(["restart", ...args], { from: "user" });
+  return parsed;
+}
+
+test("restart without --port leaves the port to runServe's PORT fallback", async () => {
+  const opts = await parseRestart([]);
+  assert.equal(opts?.port, undefined);
+});
+
+test("restart --port still passes the explicit port", async () => {
+  const opts = await parseRestart(["--port", "3000"]);
+  assert.equal(opts?.port, "3000");
+});


### PR DESCRIPTION
## Summary

- `omniroute restart` declares `--port` with a Commander default of `"20128"` and passes its options to `runServe()`. There, `parsePort(opts.port ?? process.env.PORT ?? "20128", 20128)` never reaches `PORT`, because `opts.port` is always set.
- The CLI loads `<DATA_DIR>/.env` into `process.env` (`bin/omniroute.mjs`). So a user with `PORT=3000` there gets port 3000 from `omniroute serve`, and port 20128 after `omniroute restart`.
- #7049 / #7252 fixed exactly this default on `dashboard`, and `serve` itself declares `--port` with no default. This PR removes it from `restart` the same way.

| `PORT` | command | before | after |
| --- | --- | --- | --- |
| 3000 | `omniroute restart` | serves on 20128 | serves on 3000 |
| 3000 | `omniroute restart --port 4000` | 4000 | 4000 |
| unset | `omniroute restart` | 20128 | 20128 |

## Related Issues

- Related to #7049 / #7252 (same Commander default on `dashboard`)

## Validation

- [x] Change type: CLI
- [x] Focused tests: `tests/unit/cli-restart-port.test.ts`, `cli-serve-stop-command.test.ts`, `cli-stop-supervisor-respawn-9455.test.ts`, `cli-dashboard-port.test.ts` (18/18 pass)
- [x] `eslint` and `prettier --check` on the changed files
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/cli-restart-port.test.ts` (new)
  - `restart` with no `--port` reaches the action with `port` undefined, so `runServe()` falls through to `PORT`. The test uses the real Commander parser.
  - Guard: `restart --port 3000` still passes `"3000"`.

With `restart.mjs` reverted, the first test fails and the guard passes.

## Coverage Notes

- `bin/cli/commands/restart.mjs`: option declaration covered through the parser.

## Reviewer Notes

- `stop` is deliberately left alone. When there is no server PID file, `runStopCommand()` falls back to freeing a port, and that still means `--port` or 20128. I tried making that fallback read `PORT` too, and dropped it. The CLI also loads `.env` from the current directory, so `PORT` there can belong to an unrelated app. With no PID file, nothing proves OmniRoute is the process on that port, and `stop` would kill the other app. So in the no-PID-file case, `restart` still frees 20128 before starting on `PORT`, the same as `stop` followed by `serve`.
