### PR TITLE
fix(api): stop DISABLE_SQLITE_AUTO_BACKUP from turning off Redis rate limiting

### DIFF
--- a/changelog.d/fixes/13329-rate-limiter-backup-flag.md
+++ b/changelog.d/fixes/13329-rate-limiter-backup-flag.md
@@ -1,0 +1,1 @@
+- **fix(api):** Setting `DISABLE_SQLITE_AUTO_BACKUP=true` no longer makes the API-key rate limiter and auth cache skip Redis, which let every replica enforce the full per-key limit on its own ([#13329](https://github.com/diegosouzapw/OmniRoute/pull/13329))

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -272,11 +272,7 @@ function isConfiguredEnvApiKey(key: string): boolean {
 }
 
 function isRedisAuthCacheEnabled(): boolean {
-  return (
-    process.env.OMNIROUTE_DISABLE_REDIS_AUTH_CACHE !== "1" &&
-    process.env.NODE_ENV !== "test" &&
-    process.env.DISABLE_SQLITE_AUTO_BACKUP !== "true"
-  );
+  return process.env.OMNIROUTE_DISABLE_REDIS_AUTH_CACHE !== "1" && process.env.NODE_ENV !== "test";
 }
 
 async function deleteRedisAuthCacheEntry(keyHash: unknown): Promise<void> {

--- a/src/shared/utils/rateLimiter.ts
+++ b/src/shared/utils/rateLimiter.ts
@@ -230,10 +230,9 @@ export async function checkRateLimit(
   if (!rules || rules.length === 0) return { allowed: true };
 
   // ── In-memory mock for unit tests ──
-  const isTestMode =
-    explicitTestMode ||
-    process.env.NODE_ENV === "test" ||
-    process.env.DISABLE_SQLITE_AUTO_BACKUP === "true";
+  // Not DISABLE_SQLITE_AUTO_BACKUP: that is a production setting (backups managed
+  // externally), and treating it as test mode skipped Redis on every replica.
+  const isTestMode = explicitTestMode || process.env.NODE_ENV === "test";
 
   if (isTestMode) {
     return checkInMemoryRateLimit(TEST_MEMORY_STORE, keyId, rules);

--- a/tests/unit/rate-limiter-backup-flag-not-test-mode.test.ts
+++ b/tests/unit/rate-limiter-backup-flag-not-test-mode.test.ts
@@ -1,0 +1,71 @@
+/**
+ * DISABLE_SQLITE_AUTO_BACKUP is a production setting (.env.example: "Set true only when
+ * those backups are managed externally"), but checkRateLimit() and the Redis auth cache
+ * also read it as "running under tests". A deployment with REDIS_URL and externally
+ * managed backups therefore rate-limited every key in process memory, so each replica
+ * enforced the full per-key limit on its own.
+ *
+ * The REDIS_URL below points at a closed port. Taking the Redis path shows up as the
+ * limiter's fail-open { allowed: true }; the in-memory test store would reject the
+ * second request against a limit of 1.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ENV_KEYS = ["REDIS_URL", "NODE_ENV", "DISABLE_SQLITE_AUTO_BACKUP"] as const;
+
+async function twoRequestsAgainstLimitOne(env: Partial<Record<(typeof ENV_KEYS)[number], string>>) {
+  const saved = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) {
+    if (env[key] === undefined) delete process.env[key];
+    else process.env[key] = env[key];
+  }
+  const originalConsoleError = console.error;
+  console.error = () => {};
+  const modulePath = path.join(process.cwd(), "src/shared/utils/rateLimiter.ts");
+  const rateLimiter = await import(`${pathToFileURL(modulePath).href}?case=${Math.random()}`);
+  try {
+    const rules = [{ limit: 1, window: 60 }];
+    return [
+      await rateLimiter.checkRateLimit("key-1", rules),
+      await rateLimiter.checkRateLimit("key-1", rules),
+    ];
+  } finally {
+    if (rateLimiter.isRedisConfigured()) {
+      (await rateLimiter.getRedisClient()).disconnect();
+    }
+    console.error = originalConsoleError;
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  }
+}
+
+test("DISABLE_SQLITE_AUTO_BACKUP=true does not move a Redis deployment to the in-memory store", async () => {
+  const results = await twoRequestsAgainstLimitOne({
+    REDIS_URL: "redis://127.0.0.1:1",
+    NODE_ENV: "production",
+    DISABLE_SQLITE_AUTO_BACKUP: "true",
+  });
+  assert.deepEqual(results, [{ allowed: true }, { allowed: true }]);
+});
+
+test("NODE_ENV=test still keeps the limiter in memory even with REDIS_URL set", async () => {
+  const results = await twoRequestsAgainstLimitOne({
+    REDIS_URL: "redis://127.0.0.1:1",
+    NODE_ENV: "test",
+  });
+  assert.deepEqual(results, [{ allowed: true }, { allowed: false, failedWindow: 60 }]);
+});
+
+test("the Redis auth cache is not switched off by DISABLE_SQLITE_AUTO_BACKUP", () => {
+  const source = fs.readFileSync(path.join(process.cwd(), "src/lib/db/apiKeys.ts"), "utf8");
+  const gate = source.match(/function isRedisAuthCacheEnabled\(\)[^{]*\{([\s\S]*?)\n\}/);
+  assert.ok(gate, "isRedisAuthCacheEnabled() not found");
+  assert.doesNotMatch(gate[1], /DISABLE_SQLITE_AUTO_BACKUP/);
+  assert.match(gate[1], /NODE_ENV !== "test"/);
+});


### PR DESCRIPTION
## Summary

- `checkRateLimit()` (`src/shared/utils/rateLimiter.ts`) decides whether it is running under tests like this:

  ```ts
  const isTestMode =
    explicitTestMode ||
    process.env.NODE_ENV === "test" ||
    process.env.DISABLE_SQLITE_AUTO_BACKUP === "true";
  ```

  `isRedisAuthCacheEnabled()` (`src/lib/db/apiKeys.ts`) uses the same backup clause.
- `DISABLE_SQLITE_AUTO_BACKUP` is a production setting. `.env.example`: *"Used by: src/lib/db/backup.ts. Set true only when those backups are managed externally."* It is the flag the unit-test scripts happen to set, which is presumably how it ended up being used as a proxy for "tests".
- A deployment that manages its SQLite backups externally and runs several replicas behind `REDIS_URL` therefore gets:
  - every per-key rate limit enforced in process memory (`TEST_MEMORY_STORE`), so each replica allows the full limit: N replicas → N× the configured requests per window;
  - the Redis auth cache switched off, so key validation is never shared across replicas.

  Nothing logs this. `REDIS_URL` is set and the rate limiter looks configured.
- Fix: drop the backup clause from both checks. `NODE_ENV === "test"` and the explicit `setRateLimiterTestMode()` switch stay, so tests that opt in explicitly are unaffected.

Measured with the real module, `NODE_ENV=production`, `REDIS_URL` pointing at a closed port, two requests against a limit of 1:

| `DISABLE_SQLITE_AUTO_BACKUP` | before | after |
| --- | --- | --- |
| `true` | in-memory: allowed, **rejected** (Redis never contacted) | Redis path (fail-open here, because the port is closed): allowed, allowed |
| unset | Redis path | Redis path |

## Related Issues

- None found. Searched for `DISABLE_SQLITE_AUTO_BACKUP`, `rate limiter test mode`, `rate limiter redis bypass`, `redis auth cache disabled` and `isAutomatedTestProcess`.

## Validation

- [x] Change type: routing / API
- [x] Focused tests: every unit test file that reaches `checkRateLimit`, `setRateLimiterTestMode`, `enforceApiKeyPolicy` or the auth cache (14 files, 132 tests). The results are identical before and after the change, including 2 failures that are already there on a clean `release/v3.8.51` on Windows (the hard-lease inventory tests). The new test file passes 3/3.
- [x] `prettier --check` on the changed files; `eslint` reports only the 3 `no-unused-vars` errors that `src/lib/db/apiKeys.ts` already has on the base branch
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/rate-limiter-backup-flag-not-test-mode.test.ts` (new)
  - With `DISABLE_SQLITE_AUTO_BACKUP=true`, `NODE_ENV=production` and a `REDIS_URL`, the limiter takes the Redis path (observable as its fail-open result against a closed port) instead of the in-memory store.
  - Guard: `NODE_ENV=test` with a `REDIS_URL` still stays in memory.
  - `isRedisAuthCacheEnabled()` no longer reads the backup flag and still honors `NODE_ENV=test`. This is a source check, since the function is not exported.

With the source changes reverted, the first and third tests fail and the guard passes. The file runs in about 2 s; the Redis client is disconnected in `finally`.

## Coverage Notes

- `src/shared/utils/rateLimiter.ts`: both branches of the test-mode check are exercised by the new tests.
- `src/lib/db/apiKeys.ts`: one-line gate change, asserted structurally.

## Reviewer Notes

- `npm run test:unit` sets `DISABLE_SQLITE_AUTO_BACKUP=true` without `NODE_ENV=test`. Under the runner, tests that reach the limiter without `setRateLimiterTestMode(true)` now use `FALLBACK_MEMORY_STORE` instead of `TEST_MEMORY_STORE`. Both go through the same `checkInMemoryRateLimit()`, and no CI workflow sets `REDIS_URL`, so no test reaches Redis. The auth-cache paths are all behind `isRedisConfigured()` as well.
- One side effect: before, the backup flag also kept a local `npm run test:unit` off a `REDIS_URL` exported in the developer's shell. Test files that do not call `setRateLimiterTestMode(true)` would now use that Redis. CI sets no `REDIS_URL`, and the tests that do set one (`circuitBreakerFactory*.test.ts`) also set `NODE_ENV=test`.
- I did not switch to `isAutomatedTestProcess()`, which would also cover that local case: `rate-limiter-fallback.test.ts` deliberately sets `NODE_ENV=production` to cover the fallback store. Under the runner `isAutomatedTestProcess()` is always true, so that test would silently stop covering the fallback.
