### PR TITLE
fix(guardrails): resolve prefixed combo names in Vision Bridge

### DIFF
--- a/src/lib/guardrails/visionBridge.ts
+++ b/src/lib/guardrails/visionBridge.ts
@@ -56,8 +56,14 @@ export async function getComboVisionBridgeDecision(
     const { getComboByName } = await import("@/lib/db/combos");
     const { resolveComboForModel } = await import("@/lib/db/modelComboMappings");
 
-    // 1. Try to find combo by exact name match
+    // 1. Try to find combo by exact name match. The normal Combo resolver also
+    // accepts `combo/<name>` for combos stored under their bare name; keep the
+    // Vision Bridge capability check on the same lookup path.
     let combo = await getComboByName(model);
+
+    if (!combo && model.startsWith("combo/")) {
+      combo = await getComboByName(model.slice("combo/".length));
+    }
 
     // 2. If no exact match, try model-combo mapping
     if (!combo) {

--- a/tests/unit/guardrails/visionBridge-combo-reroute.test.ts
+++ b/tests/unit/guardrails/visionBridge-combo-reroute.test.ts
@@ -144,6 +144,11 @@ test("decision: combo with all vision-capable targets returns 'skip'", async () 
   assert.equal(await getComboVisionBridgeDecision("vision-combo"), "skip");
 });
 
+test("decision: explicit combo/ prefix resolves the stored bare combo name", async () => {
+  await createCombo("prefixed-vision-combo", [{ provider: "openai", model: VISION_MODEL }]);
+  assert.equal(await getComboVisionBridgeDecision("combo/prefixed-vision-combo"), "skip");
+});
+
 test("decision: mixed combo (some vision, some not) returns 'process'", async () => {
   await createCombo("mixed-combo", [
     { provider: "openai", model: VISION_MODEL },


### PR DESCRIPTION
## Summary

- Resolve `combo/<name>` identifiers before the Vision Bridge combo capability lookup.
- Keep prefixed combo models on the same lookup path as the standard combo resolver.
- Add regression coverage for a vision-capable combo addressed with the `combo/` prefix.

## Root cause

The normal combo resolver accepts both bare combo names and `combo/<name>`. Vision Bridge previously performed only the exact lookup, so a prefixed combo could be classified as `not-combo` and take the wrong vision-routing path.

## Testing

- 47 related Vision Bridge tests passed.
- Targeted ESLint passed.
- `git diff --check` passed.