### PR TITLE
fix(translator): keep tool_choice "none" instead of turning it into "auto"

### DIFF
--- a/changelog.d/fixes/13333-tool-choice-none-claude.md
+++ b/changelog.d/fixes/13333-tool-choice-none-claude.md
@@ -1,0 +1,1 @@
+- **fix(translator):** `tool_choice: "none"` is now sent to Claude-format providers as `{ type: "none" }` (and back to OpenAI as `"none"`) instead of `auto`, so the model can no longer call tools the client switched off ([#13333](https://github.com/diegosouzapw/OmniRoute/pull/13333))

--- a/open-sse/translator/request/claude-to-openai.ts
+++ b/open-sse/translator/request/claude-to-openai.ts
@@ -541,6 +541,8 @@ function convertToolChoice(choice, hasServerWebSearch = false) {
   switch (choice.type) {
     case "auto":
       return "auto";
+    case "none":
+      return "none";
     case TOOL_CHOICE_ANY:
       return "required";
     case "tool":

--- a/open-sse/translator/request/openai-to-claude.ts
+++ b/open-sse/translator/request/openai-to-claude.ts
@@ -728,8 +728,10 @@ function convertOpenAIToolChoice(choice) {
     if (choice.type === "function" && choice.function?.name) {
       return { type: "tool", name: choice.function.name };
     }
-    // Map OpenAI string types to Claude equivalents
-    if (choice.type === "auto" || choice.type === "none") return { type: "auto" };
+    // Map OpenAI string types to Claude equivalents. Claude has its own "none"; mapping it
+    // to "auto" let the model call tools the client had switched off.
+    if (choice.type === "auto") return { type: "auto" };
+    if (choice.type === "none") return { type: "none" };
     if (choice.type === "required" || choice.type === "any")
       return { type: CLAUDE_TOOL_CHOICE_REQUIRED };
     // If type is "tool" already (Claude-native), pass through
@@ -737,7 +739,8 @@ function convertOpenAIToolChoice(choice) {
     // Fallback: unknown object type — default to auto to avoid 400 errors
     return { type: "auto" };
   }
-  if (choice === "auto" || choice === "none") return { type: "auto" };
+  if (choice === "auto") return { type: "auto" };
+  if (choice === "none") return { type: "none" };
   if (choice === "required") return { type: CLAUDE_TOOL_CHOICE_REQUIRED };
   if (typeof choice === "object" && choice.function) {
     return { type: "tool", name: choice.function.name };

--- a/tests/unit/translator-claude-to-openai.test.ts
+++ b/tests/unit/translator-claude-to-openai.test.ts
@@ -475,3 +475,14 @@ test("Claude -> OpenAI handles redacted thinking, empty arrays and unknown block
   });
   assert.equal(result.messages.length, 2);
 });
+
+test("Claude -> OpenAI keeps tool_choice none instead of widening it to auto", () => {
+  const body = (toolChoice: unknown) => ({
+    messages: [{ role: "user", content: [{ type: "text", text: "Just answer in text" }] }],
+    tools: [{ name: "weather", description: "Weather", input_schema: { type: "object" } }],
+    tool_choice: toolChoice,
+  });
+
+  assert.equal(claudeToOpenAIRequest("gpt-4o", body({ type: "none" }), false).tool_choice, "none");
+  assert.equal(claudeToOpenAIRequest("gpt-4o", body({ type: "auto" }), false).tool_choice, "auto");
+});

--- a/tests/unit/translator-openai-to-claude.test.ts
+++ b/tests/unit/translator-openai-to-claude.test.ts
@@ -721,3 +721,29 @@ test("OpenAI -> Claude treats developer role as system (fix for Responses API â†
   const userMessages = result.messages.filter((m) => m.role === "user");
   assert.equal(userMessages.length, 1, "expected exactly one user message");
 });
+
+// tool_choice "none" was mapped to Claude {type:"auto"}, so a request that listed tools
+// but switched tool use off still let the model call them.
+test("OpenAI -> Claude keeps tool_choice none as Claude none", () => {
+  const body = (toolChoice: unknown) => ({
+    messages: [{ role: "user", content: "Just answer in text" }],
+    tools: [
+      {
+        type: "function",
+        function: { name: "get_weather", parameters: { type: "object", properties: {} } },
+      },
+    ],
+    tool_choice: toolChoice,
+  });
+
+  assert.deepEqual(openaiToClaudeRequest("claude-4-sonnet", body("none"), false).tool_choice, {
+    type: "none",
+  });
+  assert.deepEqual(
+    openaiToClaudeRequest("claude-4-sonnet", body({ type: "none" }), false).tool_choice,
+    { type: "none" }
+  );
+  assert.deepEqual(openaiToClaudeRequest("claude-4-sonnet", body("auto"), false).tool_choice, {
+    type: "auto",
+  });
+});


### PR DESCRIPTION
## Summary

- `convertOpenAIToolChoice()` in `open-sse/translator/request/openai-to-claude.ts` maps both `"none"` and `{ type: "none" }` to Claude `{ type: "auto" }`.
- A request that lists tools but switches tool use off, for example the Vercel AI SDK's `toolChoice: 'none'` or any OpenAI client sending `tool_choice: "none"`, therefore reaches a Claude-format provider with tool use enabled. The model can then call tools the client explicitly disabled, and the client receives `tool_calls` it did not ask for.
- Claude has its own `{ type: "none" }`. The upstream error quoted in #1072 lists the accepted tags: *"expected tags: 'auto', 'any', 'tool', 'none'"*.
- The reverse direction had the same gap. `convertToolChoice()` in `claude-to-openai.ts` has no `none` case and falls through to `"auto"`.
- `openai-to-gemini.ts` says its converter "Mirrors convertOpenAIToolChoice in openai-to-claude.ts", and it already maps `"none"` to Gemini `NONE` (pinned by `gemini-tool-choice.test.ts`). The Clova, Cursor and Copilot paths honor `"none"` too.

| input | before | after |
| --- | --- | --- |
| OpenAI `"none"` → Claude | `{ type: "auto" }` | `{ type: "none" }` |
| OpenAI `{ type: "none" }` → Claude | `{ type: "auto" }` | `{ type: "none" }` |
| Claude `{ type: "none" }` → OpenAI | `"auto"` | `"none"` |
| `"auto"`, `"required"`, named function / tool | unchanged | unchanged |

## Related Issues

- Related to #1072 (the Anthropic error listing the accepted `tool_choice` tags)

## Validation

- [x] Change type: provider (translator)
- [x] Focused tests: `translator-openai-to-claude.test.ts`, `translator-claude-to-openai.test.ts` (36/36); every unit test that mentions `tool_choice: "none"` plus the Claude thinking/tool_choice guard tests (116/116); all 61 translator test files (794/794)
- [x] `prettier --check` on the changed lines; `eslint` reports only the 3 errors these files already have on the base branch
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/translator-openai-to-claude.test.ts`: `"none"` and `{ type: "none" }` map to Claude `{ type: "none" }`; guard: `"auto"` still maps to `{ type: "auto" }`.
- `tests/unit/translator-claude-to-openai.test.ts`: Claude `{ type: "none" }` maps to `"none"`; guard: `{ type: "auto" }` still maps to `"auto"`.

With the source changes reverted, both new tests fail on their `none` assertions.

## Coverage Notes

- Both changed branches are exercised by the new tests.

## Reviewer Notes

- Extended thinking accepts `tool_choice` `auto` or `none`. The thinking guard in `executors/base.ts` only reacts to forced choices (`any` / `tool`), so it is unaffected.
- `services/claudeCodeCompatible.ts` has its own `buildClaudeCodeCompatibleToolChoice()`. It drops `"none"` (returns `null`, so no `tool_choice` is sent) for the CC-compatible third-party path. I left it alone: that path targets upstreams whose accepted values I could not verify.
