### PR TITLE
fix(translator): pair id-less Gemini tool results with their call

### DIFF
--- a/changelog.d/fixes/13334-gemini-tool-result-without-id.md
+++ b/changelog.d/fixes/13334-gemini-tool-result-without-id.md
@@ -1,0 +1,1 @@
+- **fix(translator):** Gemini tool results sent without an `id` (the usual case, since OmniRoute's own Gemini responses never emit one) now reach the model instead of being replaced by an empty result, on the Gemini, Antigravity and `/v1beta` request paths ([#13334](https://github.com/diegosouzapw/OmniRoute/pull/13334))

--- a/open-sse/translator/helpers/geminiToolCallIds.ts
+++ b/open-sse/translator/helpers/geminiToolCallIds.ts
@@ -1,0 +1,61 @@
+/**
+ * Pairs Gemini `functionResponse` parts with the `functionCall` they answer.
+ *
+ * Gemini carries an `id` on either part only when the client set one, and OmniRoute's own
+ * Gemini-format responses never emit it, so multi-turn tool loops through the Gemini
+ * endpoints usually arrive without ids. A call without an id is given a generated one;
+ * falling back to the function *name* for the matching response then points the tool
+ * message at a call id that does not exist, and the tool-call normalization downstream
+ * (fixMissingToolResponses / stripOrphanedToolResults) replaces the real output with an
+ * empty result. Responses without an id therefore take the oldest still-open call id with
+ * the same function name, in order, since one function can be called several times.
+ *
+ * Pairing is scoped to one round of calls. Once a non-model content (the user's reply, the
+ * tool responses) has come in, the next content that makes calls starts a new round, so a call
+ * left unanswered earlier in the history cannot take the response meant for a later call to
+ * the same function. The model's own thought or text contents between two call contents do
+ * not end the round.
+ */
+export function createGeminiToolCallIdPairing(newId: () => string) {
+  const openCalls = new Map<string, Array<{ id: string; generated: boolean }>>();
+  let roundEnded = false;
+
+  return {
+    /** Call once per Gemini `content`, before its parts. */
+    beginContent(content: { role?: unknown; parts?: unknown }): void {
+      const madeCalls =
+        Array.isArray(content?.parts) &&
+        content.parts.some((part) => Boolean((part as { functionCall?: unknown })?.functionCall));
+      if (madeCalls && roundEnded) openCalls.clear();
+      if (madeCalls) roundEnded = false;
+      else if (content?.role !== "model") roundEnded = true;
+    },
+
+    /** Id for a `functionCall` part: its own id, or a generated one. */
+    callId(call: { id?: unknown; name?: unknown }): string {
+      const generated = !(typeof call.id === "string" && call.id);
+      const id = generated ? newId() : (call.id as string);
+      const name = typeof call.name === "string" ? call.name : "";
+      const open = openCalls.get(name) ?? [];
+      open.push({ id, generated });
+      openCalls.set(name, open);
+      return id;
+    },
+
+    /** `tool_call_id` for a `functionResponse` part. */
+    responseId(response: { id?: unknown; name?: unknown }): string {
+      const name = typeof response.name === "string" ? response.name : "";
+      const open = openCalls.get(name) ?? [];
+      if (typeof response.id === "string" && response.id) {
+        const index = open.findIndex((call) => call.id === response.id);
+        if (index !== -1) open.splice(index, 1);
+        return response.id;
+      }
+      // An id the client chose is answered by a response carrying that id, so an id-less
+      // response takes the oldest call whose id was generated here.
+      const index = open.findIndex((call) => call.generated);
+      if (index === -1) return open.shift()?.id ?? name;
+      return open.splice(index, 1)[0].id;
+    },
+  };
+}

--- a/open-sse/translator/request/antigravity-to-openai.ts
+++ b/open-sse/translator/request/antigravity-to-openai.ts
@@ -1,6 +1,7 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
+import { createGeminiToolCallIdPairing } from "../helpers/geminiToolCallIds.ts";
 import { fixToolPairs } from "../../services/contextManager.ts";
 import { normalizeEffort } from "@/shared/reasoning/effortStandardization";
 
@@ -80,8 +81,12 @@ export function antigravityToOpenAIRequest(model, body, stream) {
 
   // Convert contents to messages
   if (req.contents && Array.isArray(req.contents)) {
+    const toolCallIds = createGeminiToolCallIdPairing(
+      () => `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+    );
     for (const content of req.contents) {
-      const converted = convertContent(content);
+      toolCallIds.beginContent(content);
+      const converted = convertContent(content, toolCallIds);
       if (converted) {
         if (Array.isArray(converted)) {
           result.messages.push(...converted);
@@ -243,7 +248,7 @@ function preserveRequired(obj: unknown): void {
 
 // Convert Antigravity content to OpenAI message
 // Handles: text, thought, thoughtSignature, functionCall, functionResponse, inlineData
-function convertContent(content) {
+function convertContent(content, toolCallIds) {
   const role =
     content.role === "model" ? "assistant" : content.role === "user" ? "user" : content.role;
 
@@ -290,7 +295,7 @@ function convertContent(content) {
     // Function call
     if (part.functionCall) {
       toolCalls.push({
-        id: part.functionCall.id || `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        id: toolCallIds.callId(part.functionCall),
         type: "function",
         function: {
           name: part.functionCall.name,
@@ -306,7 +311,7 @@ function convertContent(content) {
         resp && typeof resp === "object" && "result" in resp ? resp.result : (resp ?? {});
       toolResults.push({
         role: "tool",
-        tool_call_id: part.functionResponse.id || part.functionResponse.name,
+        tool_call_id: toolCallIds.responseId(part.functionResponse),
         content: JSON.stringify(resultPayload),
       });
     }

--- a/open-sse/translator/request/gemini-to-openai.ts
+++ b/open-sse/translator/request/gemini-to-openai.ts
@@ -1,6 +1,9 @@
 import { register } from "../registry.ts";
 import { FORMATS } from "../formats.ts";
 import { adjustMaxTokens } from "../helpers/maxTokensHelper.ts";
+import { createGeminiToolCallIdPairing } from "../helpers/geminiToolCallIds.ts";
+
+const newCallId = () => `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 
 // Convert Gemini request to OpenAI format
 export function geminiToOpenAIRequest(model, body, stream) {
@@ -46,8 +49,10 @@ export function geminiToOpenAIRequest(model, body, stream) {
 
   // Convert contents to messages
   if (body.contents && Array.isArray(body.contents)) {
+    const toolCallIds = createGeminiToolCallIdPairing(newCallId);
     for (const content of splitCoLocatedFunctionResponses(body.contents)) {
-      const converted = convertGeminiContentWithReasoning(content);
+      toolCallIds.beginContent(content);
+      const converted = convertGeminiContentWithReasoning(content, toolCallIds);
       if (converted) {
         result.messages.push(converted);
       }
@@ -109,7 +114,7 @@ function splitCoLocatedFunctionResponses(contents) {
   return out;
 }
 
-function convertGeminiContent(content) {
+function convertGeminiContent(content, toolCallIds) {
   const role = content.role === "user" ? "user" : "assistant";
 
   if (!content.parts || !Array.isArray(content.parts)) {
@@ -137,7 +142,7 @@ function convertGeminiContent(content) {
 
     if (part.functionCall) {
       toolCalls.push({
-        id: part.functionCall.id || `call_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        id: toolCallIds.callId(part.functionCall),
         type: "function",
         function: {
           name: part.functionCall.name,
@@ -152,7 +157,7 @@ function convertGeminiContent(content) {
         resp && typeof resp === "object" && "result" in resp ? resp.result : (resp ?? {});
       return {
         role: "tool",
-        tool_call_id: part.functionResponse.id || part.functionResponse.name,
+        tool_call_id: toolCallIds.responseId(part.functionResponse),
         content: JSON.stringify(resultPayload),
       };
     }
@@ -189,9 +194,9 @@ function convertGeminiContent(content) {
 // prevents Reasoning Replay Cache (docs/routing/REASONING_REPLAY.md) from ever seeing
 // it as `reasoning_content`. Split thought parts out first and re-attach the joined
 // text as `reasoning_content` on the resulting message instead.
-function convertGeminiContentWithReasoning(content) {
+function convertGeminiContentWithReasoning(content, toolCallIds) {
   if (!content || !Array.isArray(content.parts)) {
-    return convertGeminiContent(content);
+    return convertGeminiContent(content, toolCallIds);
   }
 
   let reasoningContent = "";
@@ -205,10 +210,10 @@ function convertGeminiContentWithReasoning(content) {
   }
 
   if (!reasoningContent) {
-    return convertGeminiContent(content);
+    return convertGeminiContent(content, toolCallIds);
   }
 
-  const converted = convertGeminiContent({ ...content, parts: visibleParts });
+  const converted = convertGeminiContent({ ...content, parts: visibleParts }, toolCallIds);
 
   if (converted && converted.role !== "tool") {
     return { ...converted, reasoning_content: reasoningContent };

--- a/src/app/api/v1beta/models/[...path]/convertGeminiToInternal.ts
+++ b/src/app/api/v1beta/models/[...path]/convertGeminiToInternal.ts
@@ -15,6 +15,8 @@
  * `open-sse/translator/request/gemini-to-openai.ts`.
  */
 
+import { createGeminiToolCallIdPairing } from "@omniroute/open-sse/translator/helpers/geminiToolCallIds.ts";
+
 interface GeminiFunctionCall {
   name?: string;
   args?: Record<string, unknown>;
@@ -98,23 +100,29 @@ function newToolCallId(): string {
  * an assistant message carrying `tool_calls`; otherwise a plain text message.
  * Returns `null` when the content has nothing to contribute.
  */
-function convertContent(content: GeminiContent): InternalMessage | null {
+function convertContent(
+  content: GeminiContent,
+  toolCallIds: ReturnType<typeof createGeminiToolCallIdPairing>
+): InternalMessage | InternalMessage[] | null {
   const parts = content.parts;
   if (!parts || !Array.isArray(parts)) return null;
 
-  // A functionResponse turn maps to a `tool` role message.
+  // A functionResponse turn maps to `tool` role messages, one per response: Gemini answers
+  // parallel calls with several functionResponse parts in a single content.
+  const toolMessages: InternalMessage[] = [];
   for (const part of parts) {
     if (part.functionResponse) {
       const fr = part.functionResponse;
       const payload =
         fr.response && "result" in fr.response ? fr.response.result : fr.response ?? {};
-      return {
+      toolMessages.push({
         role: "tool",
-        tool_call_id: fr.id || fr.name || "",
+        tool_call_id: toolCallIds.responseId(fr),
         content: JSON.stringify(payload ?? {}),
-      };
+      });
     }
   }
+  if (toolMessages.length > 0) return toolMessages;
 
   const textSegments: string[] = [];
   const toolCalls: InternalMessage["tool_calls"] = [];
@@ -125,7 +133,7 @@ function convertContent(content: GeminiContent): InternalMessage | null {
     }
     if (part.functionCall) {
       toolCalls.push({
-        id: part.functionCall.id || newToolCallId(),
+        id: toolCallIds.callId(part.functionCall),
         type: "function",
         function: {
           name: part.functionCall.name || "",
@@ -173,9 +181,12 @@ export function convertGeminiToInternal(
 
   // Convert contents to messages (text + tool calls + tool responses)
   if (geminiBody.contents) {
+    const toolCallIds = createGeminiToolCallIdPairing(newToolCallId);
     for (const content of geminiBody.contents) {
-      const converted = convertContent(content);
-      if (converted) messages.push(converted);
+      toolCallIds.beginContent(content);
+      const converted = convertContent(content, toolCallIds);
+      if (Array.isArray(converted)) messages.push(...converted);
+      else if (converted) messages.push(converted);
     }
   }
 

--- a/tests/unit/gemini-tool-result-without-id.test.ts
+++ b/tests/unit/gemini-tool-result-without-id.test.ts
@@ -1,0 +1,227 @@
+// Gemini carries an `id` on functionCall / functionResponse parts only when the client sets
+// one, and OmniRoute's own Gemini-format responses never emit it. A call without an id got a
+// generated one while its response fell back to the function *name* as tool_call_id, so the
+// two never matched: the tool-call normalization in translateRequest then inserted an empty
+// result for the call and dropped the real output as an orphan. #11365 fixed the half where
+// the client does send ids. The three Gemini-shaped converters now pair an id-less response
+// with the oldest open call of the same name within the current round of calls.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { geminiToOpenAIRequest } =
+  await import("../../open-sse/translator/request/gemini-to-openai.ts");
+const { antigravityToOpenAIRequest } =
+  await import("../../open-sse/translator/request/antigravity-to-openai.ts");
+const { convertGeminiToInternal } =
+  await import("../../src/app/api/v1beta/models/[...path]/convertGeminiToInternal.ts");
+const { translateRequest } = await import("../../open-sse/translator/index.ts");
+const { FORMATS } = await import("../../open-sse/translator/formats.ts");
+
+type Message = {
+  role: string;
+  content?: unknown;
+  tool_call_id?: string;
+  tool_calls?: Array<{ id: string; function: { name: string; arguments: string } }>;
+};
+
+const call = (name: string, args: Record<string, unknown>) => ({ functionCall: { name, args } });
+const reply = (name: string, result: unknown) => ({
+  functionResponse: { name, response: { result } },
+});
+
+const singleCall = [
+  { role: "user", parts: [{ text: "Weather in Tokyo?" }] },
+  { role: "model", parts: [call("get_weather", { city: "Tokyo" })] },
+  { role: "user", parts: [reply("get_weather", "22C sunny")] },
+];
+
+// The same function called twice in one turn; Gemini answers in call order.
+const repeatedCall = [
+  { role: "user", parts: [{ text: "Tokyo and Paris?" }] },
+  {
+    role: "model",
+    parts: [call("get_weather", { city: "Tokyo" }), call("get_weather", { city: "Paris" })],
+  },
+  { role: "user", parts: [reply("get_weather", "22C sunny"), reply("get_weather", "14C rain")] },
+];
+
+function pairs(messages: Message[]) {
+  const callIds = messages.flatMap((m) => m.tool_calls?.map((c) => c.id) ?? []);
+  const results = messages
+    .filter((m) => m.role === "tool")
+    .map((m) => ({ id: m.tool_call_id, content: m.content }));
+  return { callIds, results };
+}
+
+const converters: Array<[string, (contents: unknown[]) => Message[]]> = [
+  [
+    "gemini-to-openai",
+    (contents) => geminiToOpenAIRequest("gpt-4o", { contents }, false).messages as Message[],
+  ],
+  [
+    "antigravity-to-openai",
+    (contents) =>
+      antigravityToOpenAIRequest("gpt-4o", { request: { contents } }, false).messages as Message[],
+  ],
+  [
+    "/v1beta convertGeminiToInternal",
+    (contents) =>
+      convertGeminiToInternal({ contents }, "openai/gpt-4o", false).messages as Message[],
+  ],
+];
+
+// gemini-cli's usual shape: two parallel reads answered in one content, then a later read.
+const parallelThenLater = [
+  { role: "user", parts: [{ text: "Compare a and b, then read c" }] },
+  { role: "model", parts: [call("read_file", { path: "a" }), call("read_file", { path: "b" })] },
+  { role: "user", parts: [reply("read_file", "A-content"), reply("read_file", "B-content")] },
+  { role: "model", parts: [call("read_file", { path: "c" })] },
+  { role: "user", parts: [reply("read_file", "C-content")] },
+];
+
+// One model turn split by a thought-only content between its two calls.
+const splitModelTurn = [
+  { role: "user", parts: [{ text: "Read a and b" }] },
+  { role: "model", parts: [call("read_file", { path: "a" })] },
+  { role: "model", parts: [{ text: "Also b.", thought: true }] },
+  { role: "model", parts: [call("read_file", { path: "b" })] },
+  { role: "user", parts: [reply("read_file", "A-content"), reply("read_file", "B-content")] },
+];
+
+// A call the client never answered must not take a later call's response.
+const unansweredThenRetried = [
+  { role: "model", parts: [call("get_weather", { city: "Tokyo" })] },
+  { role: "user", parts: [{ text: "Never mind, try Paris" }] },
+  { role: "model", parts: [call("get_weather", { city: "Paris" })] },
+  { role: "user", parts: [reply("get_weather", "14C rain")] },
+];
+
+for (const [label, convert] of converters) {
+  test(`${label}: an id-less functionResponse answers the generated call id`, () => {
+    const { callIds, results } = pairs(convert(structuredClone(singleCall)));
+    assert.equal(callIds.length, 1);
+    assert.deepEqual(results, [{ id: callIds[0], content: '"22C sunny"' }]);
+  });
+}
+
+for (const [label, convert] of converters) {
+  test(`${label}: repeated calls to one function are answered in order`, () => {
+    const { callIds, results } = pairs(convert(structuredClone(repeatedCall)));
+    assert.equal(callIds.length, 2);
+    assert.deepEqual(results, [
+      { id: callIds[0], content: '"22C sunny"' },
+      { id: callIds[1], content: '"14C rain"' },
+    ]);
+  });
+
+  test(`${label}: parallel calls, then a later call to the same function`, () => {
+    const { callIds, results } = pairs(convert(structuredClone(parallelThenLater)));
+    assert.equal(callIds.length, 3);
+    assert.deepEqual(results, [
+      { id: callIds[0], content: '"A-content"' },
+      { id: callIds[1], content: '"B-content"' },
+      { id: callIds[2], content: '"C-content"' },
+    ]);
+  });
+
+  test(`${label}: a thought between two calls of one turn does not split the round`, () => {
+    const messages = convert(structuredClone(splitModelTurn));
+    const idFor = (path: string) =>
+      messages
+        .flatMap((m) => m.tool_calls ?? [])
+        .find((c) => JSON.parse(c.function.arguments).path === path)?.id;
+    assert.deepEqual(pairs(messages).results, [
+      { id: idFor("a"), content: '"A-content"' },
+      { id: idFor("b"), content: '"B-content"' },
+    ]);
+  });
+
+  test(`${label}: an unanswered call does not take a later call's response`, () => {
+    const messages = convert(structuredClone(unansweredThenRetried));
+    // antigravity's fixToolPairs drops the unanswered call; the others keep it.
+    const parisCall = messages
+      .flatMap((m) => m.tool_calls ?? [])
+      .find((c) => JSON.parse(c.function.arguments).city === "Paris");
+    assert.ok(parisCall);
+    assert.deepEqual(pairs(messages).results, [{ id: parisCall.id, content: '"14C rain"' }]);
+  });
+}
+
+test("the tool output survives translateRequest's tool-call normalization", () => {
+  const body = {
+    contents: structuredClone(singleCall),
+    tools: [{ functionDeclarations: [{ name: "get_weather", parameters: { type: "object" } }] }],
+  };
+  const viaTranslator = translateRequest(FORMATS.GEMINI, FORMATS.OPENAI, "gpt-4o", body, false);
+  const viaV1beta = translateRequest(
+    FORMATS.OPENAI,
+    FORMATS.OPENAI,
+    "gpt-4o",
+    convertGeminiToInternal(structuredClone(body), "openai/gpt-4o", false),
+    false
+  );
+  for (const out of [viaTranslator, viaV1beta]) {
+    const { callIds, results } = pairs(out.messages as Message[]);
+    assert.deepEqual(results, [{ id: callIds[0], content: '"22C sunny"' }]);
+  }
+});
+
+test("an id-less response does not take a call whose id the client chose", () => {
+  const messages = geminiToOpenAIRequest(
+    "gpt-4o",
+    {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            { functionCall: { id: "call_x", name: "get_weather", args: { city: "Tokyo" } } },
+            call("get_weather", { city: "Paris" }),
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            reply("get_weather", "14C rain"),
+            {
+              functionResponse: { id: "call_x", name: "get_weather", response: { result: "22C" } },
+            },
+          ],
+        },
+      ],
+    },
+    false
+  ).messages as Message[];
+  const { callIds, results } = pairs(messages);
+  assert.equal(callIds[0], "call_x");
+  assert.deepEqual(results, [
+    { id: callIds[1], content: '"14C rain"' },
+    { id: "call_x", content: '"22C"' },
+  ]);
+});
+
+test("a response with an id keeps it, and an id-less one takes the remaining call", () => {
+  const messages = geminiToOpenAIRequest(
+    "gpt-4o",
+    {
+      contents: [
+        {
+          role: "model",
+          parts: [{ functionCall: { id: "call_a", name: "get_weather", args: {} } }],
+        },
+        { role: "model", parts: [call("get_weather", { city: "Paris" })] },
+        {
+          role: "user",
+          parts: [{ functionResponse: { id: "call_a", name: "get_weather", response: {} } }],
+        },
+        { role: "user", parts: [reply("get_weather", "14C rain")] },
+      ],
+    },
+    false
+  ).messages as Message[];
+  const { callIds, results } = pairs(messages);
+  assert.equal(callIds[0], "call_a");
+  assert.deepEqual(
+    results.map((r) => r.id),
+    ["call_a", callIds[1]]
+  );
+});

--- a/tests/unit/v1beta-gemini-tool-calling-6222.test.ts
+++ b/tests/unit/v1beta-gemini-tool-calling-6222.test.ts
@@ -117,7 +117,10 @@ test("request: functionResponse part → tool role message", () => {
 
   const toolMsg = out.messages.find((m) => m.role === "tool");
   assert.ok(toolMsg, "tool message should exist");
-  assert.equal(toolMsg.tool_call_id, "get_weather");
+  // Neither part carries an id, so the response must answer the call's generated id —
+  // the function name matches no call and the result would be dropped downstream.
+  const assistantMsg = out.messages.find((m) => m.role === "assistant");
+  assert.equal(toolMsg.tool_call_id, assistantMsg.tool_calls[0].id);
   assert.deepEqual(JSON.parse(toolMsg.content), { tempC: 18 });
 });
 


### PR DESCRIPTION
## Summary

- Gemini puts an `id` on `functionCall` / `functionResponse` parts only when the client sets one. OmniRoute's own Gemini-format responses never emit it: `openai-to-antigravity.ts` keeps `accum.id` but writes only `{ name, args }`, and so do the Gemini SSE writers. Every multi-turn tool loop through OmniRoute's Gemini endpoints therefore comes back without ids.
- The three Gemini-shaped converters give such a call a generated id (`call_<ts>_<rand>`), but set the matching response's `tool_call_id` to the function **name**. The two never match:
  - `open-sse/translator/request/gemini-to-openai.ts`
  - `open-sse/translator/request/antigravity-to-openai.ts`
  - `src/app/api/v1beta/models/[...path]/convertGeminiToInternal.ts` (the `/v1beta/models/{m}:generateContent` route)
- For the Gemini translator and `/v1beta`, `translateRequest()` then runs `ensureToolCallIds` → `fixMissingToolResponses` → `stripOrphanedToolResults`. That inserts an empty result for the call and drops the real output as an orphan. The model sees `""` instead of the tool's answer.
- For Antigravity, `fixToolPairs` drops both the call and its result, so the whole exchange disappears from the history.
- #11365 fixed the half where the client does send ids. This PR fixes the id-less half.

Measured with the real modules. The call is `get_weather` with no id; the response has no id and result `"22C sunny"`:

| path | before | after |
| --- | --- | --- |
| Gemini → OpenAI via `translateRequest` | `{ role: "tool", tool_call_id: "call_…", content: "" }` | `content: "\"22C sunny\""` |
| `/v1beta` `convertGeminiToInternal` (raw) | `tool_call_id: "get_weather"` (matches no call) | `tool_call_id: "call_…"` (the call's id) |
| `/v1beta` then `translateRequest` | `content: ""` | `content: "\"22C sunny\""` |

- Fix: a small shared helper, `open-sse/translator/helpers/geminiToolCallIds.ts`. It records every call id per function name and gives an id-less response the oldest still-open call with the same name whose id was generated here. Repeated calls to one function are therefore answered in order, the way Gemini returns them. A response that carries an id keeps it and closes that call. An id the client chose is left for the response that names it. If no call is open for the name, the old name fallback remains.
- Pairing is scoped to one round of calls. Once a non-model content (the user's reply, the tool responses) has come in, the next content that makes calls starts a new round, so a call the client never answered cannot take the response meant for a later call to the same function. The model's own thought or text contents between two call contents do not end the round.
- `/v1beta` also returned only the **first** `functionResponse` of a content, which is how Gemini answers parallel calls. It now emits one tool message per response, as the Antigravity converter already does. Otherwise, with gemini-cli's usual pattern (parallel `read_file(a)`, `read_file(b)`, then a later `read_file(c)`), `b`'s response was lost.

## Related Issues

- Follow-up to #11365 (functionCall id preserved when the client sends it)

## Validation

- [x] Change type: provider (translator / `/v1beta` route)
- [x] Focused tests: the new test file plus `v1beta-gemini-tool-calling-6222`, `translator-gemini-to-openai`, `gemini-to-openai-function-response`, `translator-antigravity-to-openai`, `translator-antigravity-signature-bypass` (51/51)
- [x] Wide run: all translator, antigravity, v1beta and gemini unit test files (204 files, 1549/1550). The one failure, `antigravity-missing-project-chat.test.ts`, fails identically on a clean `release/v3.8.51` on Windows.
- [x] `tsc` on the changed files (temp tsconfig extending the root one): clean; `eslint` clean; `prettier --check` on the changed lines
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/gemini-tool-result-without-id.test.ts` (new)
  - For each of the three converters:
    - an id-less response answers the generated call id and keeps its content;
    - two calls to the same function in one turn are answered in order;
    - parallel calls followed by a later call to the same function (the gemini-cli pattern) all pair correctly;
    - a thought-only model content between two calls of one turn does not split the round;
    - a call the client never answered does not take a later call's response.
  - The tool output survives `translateRequest`'s normalization, both through the Gemini translator and through `/v1beta`.
  - Mixed ids, in both orders: a response with an id keeps it, and an id-less one takes the call whose id was generated, not the one the client named.
- `tests/unit/v1beta-gemini-tool-calling-6222.test.ts`: the "functionResponse part → tool role message" case asserted `tool_call_id === "get_weather"` for this exact id-less input. It never compared that against the call's id, which is the bug. It now asserts that the tool message answers the assistant's call id.

With the three converters reverted, 19 of the 51 tests in these files fail: all 18 new cases plus the updated assertion. The rest pass either way.

## Coverage Notes

- `geminiToolCallIds.ts` is exercised through all three converters, including the with-id, without-id, repeated-name and mixed cases.

## Reviewer Notes

- Generated id formats are unchanged in each converter (`/v1beta` still uses its `newToolCallId()`).
- `/v1beta` still drops non-`functionResponse` parts that share a content with a `functionResponse`, as before. `gemini-to-openai.ts` keeps them via `splitCoLocatedFunctionResponses()`. I left that out to keep this PR to the pairing.
