### PR TITLE
fix(translator): send a Claude tool_result image to Gemini as inlineData

### DIFF
--- a/changelog.d/fixes/13335-claude-tool-result-image-gemini.md
+++ b/changelog.d/fixes/13335-claude-tool-result-image-gemini.md
@@ -1,0 +1,1 @@
+- **fix(translator):** An image returned inside a Claude `tool_result` (Read on a PNG, an MCP screenshot) is now sent to Gemini as an image part instead of base64 text ([#13335](https://github.com/diegosouzapw/OmniRoute/pull/13335))

--- a/open-sse/translator/request/claude-to-gemini.ts
+++ b/open-sse/translator/request/claude-to-gemini.ts
@@ -136,6 +136,10 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
     const omittedToolCallIds = new Set<string>();
     for (const msg of body.messages) {
       const parts = [];
+      // Images returned inside tool_result blocks go right after the last tool response,
+      // ahead of any text that follows it, as on the Claude -> OpenAI -> Gemini path.
+      const toolResultImageParts = [];
+      let afterLastToolResult = -1;
 
       if (Array.isArray(msg.content)) {
         for (const block of msg.content) {
@@ -180,9 +184,24 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
             case "tool_result": {
               let content = block.content;
               if (Array.isArray(content)) {
-                content = content
-                  .map((c) => (c.type === "text" ? c.text : JSON.stringify(c)))
-                  .join("\n");
+                // A base64 image (the Read tool on a PNG, an MCP screenshot) becomes an
+                // inlineData part, as claude-to-openai.ts lifts it into an image turn
+                // (#5100); JSON.stringify would hand Gemini the base64 as text.
+                const textParts = [];
+                let hasImage = false;
+                for (const c of content) {
+                  if (c.type === "image" && c.source?.type === "base64") {
+                    toolResultImageParts.push({
+                      inlineData: { mimeType: c.source.media_type, data: c.source.data },
+                    });
+                    hasImage = true;
+                  } else {
+                    textParts.push(c.type === "text" ? c.text : JSON.stringify(c));
+                  }
+                }
+                content =
+                  textParts.join("\n") ||
+                  (hasImage ? "[tool returned an image; see attached]" : "");
               }
               const toolUseId = block.tool_use_id;
               const name = toolUseNames[toolUseId] || "unknown";
@@ -194,6 +213,7 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
                 parts.push({
                   text: buildHistoricalToolResultContext(name, content),
                 });
+                afterLastToolResult = parts.length;
                 break;
               }
 
@@ -204,6 +224,7 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
                   response: { result: content },
                 },
               });
+              afterLastToolResult = parts.length;
               break;
             }
 
@@ -222,6 +243,9 @@ export function claudeToGeminiRequest(model, body, stream, credentials = null) {
         }
       } else if (typeof msg.content === "string" && msg.content) {
         parts.push({ text: msg.content });
+      }
+      if (toolResultImageParts.length > 0) {
+        parts.splice(afterLastToolResult, 0, ...toolResultImageParts);
       }
 
       if (parts.length > 0) {

--- a/tests/unit/claude-to-gemini-tool-result-image.test.ts
+++ b/tests/unit/claude-to-gemini-tool-result-image.test.ts
@@ -1,0 +1,85 @@
+// A base64 image inside a Claude tool_result (the Read tool on a PNG, an MCP screenshot)
+// was JSON.stringify'd into the functionResponse, handing Gemini the base64 as text.
+// claude-to-openai.ts lifts it out (#5100); the direct Claude -> Gemini path now sends it
+// as an inlineData part right after the tool responses and ahead of any text that follows,
+// which is where the Claude -> OpenAI -> Gemini path puts it.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { claudeToGeminiRequest } =
+  await import("../../open-sse/translator/request/claude-to-gemini.ts");
+const { buildGeminiThoughtSignatureKey, storeGeminiThoughtSignature } =
+  await import("../../open-sse/services/geminiThoughtSignatureStore.ts");
+
+type Part = Record<string, unknown>;
+
+const PNG = { inlineData: { mimeType: "image/png", data: "iVBORw0K" } };
+
+function convert(ns: string, userContent: unknown[], { signed = true } = {}) {
+  if (signed) {
+    storeGeminiThoughtSignature(buildGeminiThoughtSignatureKey(ns, "tu_img"), "SIG_IMG");
+  }
+  const result = claudeToGeminiRequest(
+    "gemini-2.5-pro",
+    {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tu_img", name: "read_file", input: { path: "a.png" } },
+          ],
+        },
+        { role: "user", content: userContent },
+      ],
+    },
+    false,
+    { _signatureNamespace: ns }
+  );
+  return result.contents.flatMap((c) => c.parts as Part[]);
+}
+
+const imageResult = (text?: string) => ({
+  type: "tool_result",
+  tool_use_id: "tu_img",
+  content: [
+    ...(text ? [{ type: "text", text }] : []),
+    { type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0K" } },
+  ],
+});
+
+test("a tool_result image becomes inlineData, not base64 text", () => {
+  const parts = convert("tool-image-signed", [imageResult("a.png (1x1)")]);
+
+  assert.deepEqual(parts.slice(-2), [
+    {
+      functionResponse: { id: "tu_img", name: "read_file", response: { result: "a.png (1x1)" } },
+    },
+    PNG,
+  ]);
+});
+
+test("the image goes before text that follows the tool_result", () => {
+  const parts = convert("tool-image-trailing-text", [
+    imageResult(),
+    { type: "text", text: "<system-reminder>keep going</system-reminder>" },
+  ]);
+
+  assert.deepEqual(parts.slice(-3), [
+    {
+      functionResponse: {
+        id: "tu_img",
+        name: "read_file",
+        response: { result: "[tool returned an image; see attached]" },
+      },
+    },
+    PNG,
+    { text: "<system-reminder>keep going</system-reminder>" },
+  ]);
+});
+
+test("signature-less history keeps the image out of the context text", () => {
+  const parts = convert("tool-image-unsigned", [imageResult("a.png (1x1)")], { signed: false });
+
+  assert.ok(!JSON.stringify(parts.filter((p) => p.text)).includes("iVBORw0K"));
+  assert.deepEqual(parts.at(-1), PNG);
+});


### PR DESCRIPTION
## Summary

- `claudeToGeminiRequest()` flattens an array `tool_result` with `c.type === "text" ? c.text : JSON.stringify(c)`. A base64 image returned by a tool therefore reaches Gemini as a JSON string: Claude Code's `Read` on a PNG, or an MCP screenshot tool, are common sources. The string lands inside `functionResponse.response.result`, or inside the context text used for signature-less history.
- The model receives the base64 as text instead of the image, and a screenshot of a few hundred KB costs as many context tokens as its base64 length.
- `claude-to-openai.ts` fixed exactly this flattening in #5100, by lifting images into a following image turn. The direct Claude → Gemini path (`/v1/messages` to a Gemini or Vertex provider) still had it; that line dates from v1.0.0.
- Fix: each base64 image in a `tool_result` becomes an `inlineData` part, inserted right after the message's last tool response and ahead of any text that follows it. Claude Code routinely appends `<system-reminder>` text after tool results. This is where the Claude → OpenAI → Gemini path ends up placing the image once `openai-to-gemini.ts` collapses consecutive user turns: tool responses, then images, then text. An image-only result gets the same `"[tool returned an image; see attached]"` text the OpenAI path uses. Text blocks and any other block type are flattened exactly as before.

Measured through `translateRequest(CLAUDE → GEMINI)`, with a Read `tool_result` holding one PNG:

| | base64 inside text / functionResponse | `inlineData` parts |
| --- | --- | --- |
| before | yes | 0 |
| after | no | 1 |

## Related Issues

- Related to #5100 (the same fix on the Claude → OpenAI path)

## Validation

- [x] Change type: provider (translator)
- [x] Focused tests: the new test file, `translator-claude-to-gemini.test.ts`, `claude-gemini-thought-signature-8979.test.ts`, `claude-to-gemini-consecutive-roles.test.ts` (32/32)
- [x] `prettier --check` on the changed lines; `eslint` reports only the 3 errors the file already has on the base branch
- [x] Based on the current `release/v3.8.51`
- [x] Production-code change includes a new automated test

## Tests Added Or Updated

- `tests/unit/claude-to-gemini-tool-result-image.test.ts` (new; kept out of `translator-claude-to-gemini.test.ts` because #12785 also appends to that file)
  - Signed history: `[functionResponse { result: "a.png (1x1)" }, inlineData { image/png }]`.
  - Image-only result followed by `<system-reminder>` text: `[functionResponse { result: "[tool returned an image; see attached]" }, inlineData, text]`.
  - Signature-less history (context text): no base64 in any text part, and the image is sent as `inlineData`.

With the source change reverted, all three fail.

## Coverage Notes

- `open-sse/translator/request/claude-to-gemini.ts`: the new branch (image, text, other block types, image-only fallback text) and the placement before trailing text are exercised by the three tests and the existing tool_result tests.

## Reviewer Notes

- Open PR #12785 edits the same file, at the imports and around line 82 (`stop_sequences`). This change is in the `tool_result` case (lines ~136–240), so the hunks do not overlap, and the tests live in a separate file. I kept the import block exactly as it is, although `prettier --write` would reflow it.
- Only `source.type === "base64"` images are lifted, matching #5100 and the `image` case in this same file. URL images are still flattened as before.
