### PR TITLE
fix(db): prune health-check repair backups

### DIFF
--- a/src/lib/db/backup.ts
+++ b/src/lib/db/backup.ts
@@ -15,11 +15,11 @@ import {
 } from "./core";
 import { resetAllDbModuleState } from "./stateReset";
 import {
-  MAX_DB_BACKUPS,
-  DEFAULT_DB_BACKUP_RETENTION_DAYS,
-  parsePositiveInt,
-  parseNonNegativeInt,
+  DB_BACKUP_SETTINGS_NAMESPACE,
+  DB_BACKUP_MAX_FILES_KEY,
+  DB_BACKUP_RETENTION_DAYS_KEY,
   pruneBackupDirectory,
+  resolveDbBackupRetention,
 } from "./backupRetention";
 import { isAutomatedTestProcess } from "@/shared/utils/testProcess";
 
@@ -37,24 +37,6 @@ const TRUE_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 // keys on every update). It is intentionally separate from the orphan
 // `databaseSettings.backup.keepLastNBackups` (default 5) so existing installs keep the
 // historical default of 20 until an operator explicitly changes it here.
-const DB_BACKUP_SETTINGS_NAMESPACE = "dbBackup";
-const DB_BACKUP_MAX_FILES_KEY = "maxFiles";
-const DB_BACKUP_RETENTION_DAYS_KEY = "retentionDays";
-
-function getStoredDbBackupInteger(key: string, options: { min: number }): number | undefined {
-  try {
-    const db = getDbInstance();
-    const row = db
-      .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
-      .get(DB_BACKUP_SETTINGS_NAMESPACE, key) as { value?: string } | undefined;
-    if (!row?.value) return undefined;
-    const parsed = JSON.parse(row.value);
-    return Number.isInteger(parsed) && parsed >= options.min ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function setStoredDbBackupInteger(key: string, value: number, options: { min: number }): void {
   if (!Number.isInteger(value) || value < options.min) return;
   const db = getDbInstance();
@@ -71,11 +53,7 @@ export function setDbBackupMaxFiles(value: number): void {
 }
 
 export function getDbBackupMaxFiles() {
-  // Precedence: DB_BACKUP_MAX_FILES env override (ops) → persisted UI value → default.
-  if (process.env.DB_BACKUP_MAX_FILES) {
-    return parsePositiveInt(process.env.DB_BACKUP_MAX_FILES, MAX_DB_BACKUPS);
-  }
-  return getStoredDbBackupInteger(DB_BACKUP_MAX_FILES_KEY, { min: 1 }) ?? MAX_DB_BACKUPS;
+  return resolveDbBackupRetention(getDbInstance()).maxFiles;
 }
 
 /** Persist the operator-chosen age-based backup retention window. */
@@ -84,17 +62,7 @@ export function setDbBackupRetentionDays(value: number): void {
 }
 
 export function getDbBackupRetentionDays() {
-  // Precedence: DB_BACKUP_RETENTION_DAYS env override (ops) → persisted UI value → default.
-  if (process.env.DB_BACKUP_RETENTION_DAYS) {
-    return parseNonNegativeInt(
-      process.env.DB_BACKUP_RETENTION_DAYS,
-      DEFAULT_DB_BACKUP_RETENTION_DAYS
-    );
-  }
-  return (
-    getStoredDbBackupInteger(DB_BACKUP_RETENTION_DAYS_KEY, { min: 0 }) ??
-    DEFAULT_DB_BACKUP_RETENTION_DAYS
-  );
+  return resolveDbBackupRetention(getDbInstance()).retentionDays;
 }
 
 function getBackupDir() {

--- a/src/lib/db/backupRetention.ts
+++ b/src/lib/db/backupRetention.ts
@@ -1,8 +1,8 @@
 /**
- * Backup retention primitives — pure filesystem work, no `core.ts` dependency.
+ * Backup retention primitives — no `core.ts` dependency.
  *
- * `backup.ts` (manual/API/auto backups) resolves the operator's settings from the
- * database and delegates pure family pruning here. The migration runner deliberately
+ * Manual and health-check backups resolve the operator's settings here and delegate
+ * pure family pruning to the same function. The migration runner deliberately
  * does not prune during its concurrent safety window: its snapshots are content-addressed
  * and reused for an identical DB state, while manual/scheduled cleanup remains the single
  * retention boundary. Before #10421, repeated failed starts created distinct timestamped
@@ -12,8 +12,13 @@
 import fs from "fs";
 import path from "path";
 
+import type { SqliteAdapter } from "./adapters/types";
+
 export const MAX_DB_BACKUPS = 20;
 export const DEFAULT_DB_BACKUP_RETENTION_DAYS = 0;
+export const DB_BACKUP_SETTINGS_NAMESPACE = "dbBackup";
+export const DB_BACKUP_MAX_FILES_KEY = "maxFiles";
+export const DB_BACKUP_RETENTION_DAYS_KEY = "retentionDays";
 
 export function parsePositiveInt(value: string | undefined, fallback: number) {
   if (!value) return fallback;
@@ -25,6 +30,37 @@ export function parseNonNegativeInt(value: string | undefined, fallback: number)
   if (value === undefined) return fallback;
   const parsed = Number.parseInt(value, 10);
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function getStoredInteger(
+  db: Pick<SqliteAdapter, "prepare">,
+  key: string,
+  min: number
+): number | undefined {
+  try {
+    const row = db
+      .prepare("SELECT value FROM key_value WHERE namespace = ? AND key = ?")
+      .get(DB_BACKUP_SETTINGS_NAMESPACE, key) as { value?: string } | undefined;
+    if (!row?.value) return undefined;
+    const parsed = JSON.parse(row.value);
+    return Number.isInteger(parsed) && parsed >= min ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveDbBackupRetention(
+  db: Pick<SqliteAdapter, "prepare">,
+  env: NodeJS.ProcessEnv = process.env
+) {
+  return {
+    maxFiles: env.DB_BACKUP_MAX_FILES
+      ? parsePositiveInt(env.DB_BACKUP_MAX_FILES, MAX_DB_BACKUPS)
+      : (getStoredInteger(db, DB_BACKUP_MAX_FILES_KEY, 1) ?? MAX_DB_BACKUPS),
+    retentionDays: env.DB_BACKUP_RETENTION_DAYS
+      ? parseNonNegativeInt(env.DB_BACKUP_RETENTION_DAYS, DEFAULT_DB_BACKUP_RETENTION_DAYS)
+      : (getStoredInteger(db, DB_BACKUP_RETENTION_DAYS_KEY, 0) ?? DEFAULT_DB_BACKUP_RETENTION_DAYS),
+  };
 }
 
 /**

--- a/src/lib/db/core.ts
+++ b/src/lib/db/core.ts
@@ -19,6 +19,7 @@ import { resolveWritableDataDir, getLegacyDotDataDir } from "../dataPaths";
 import { isNextBuildPhase } from "../buildPhase";
 import { runMigrations } from "./migrationRunner";
 import { runDbHealthCheck } from "./healthCheck";
+import { pruneBackupDirectory, resolveDbBackupRetention } from "./backupRetention";
 import { resetAllDbModuleState } from "./stateReset";
 import { parseStoredPayload } from "../logPayloads";
 import { DEFAULT_DATABASE_SETTINGS, type DatabaseSettings } from "@/types/databaseSettings";
@@ -860,6 +861,7 @@ function createManagedDbBackup(db: SqliteDatabase, reason: string): boolean {
 
     db.exec(`VACUUM INTO '${escapedBackupPath}'`);
     console.log(`[DB] Backup created (${reason}): ${backupPath}`);
+    pruneBackupDirectory({ backupDir, ...resolveDbBackupRetention(db) });
     return true;
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);

--- a/tests/unit/db-health-backup-retention-13308.test.ts
+++ b/tests/unit/db-health-backup-retention-13308.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-health-backup-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("health-check repair backups apply the shared retention policy (#13308)", () => {
+  const db = core.getDbInstance();
+  db.prepare(
+    `INSERT INTO quota_snapshots
+      (provider, connection_id, window_key, remaining_percentage, is_exhausted, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run("openai", "missing-connection", "monthly", 75, 0, new Date().toISOString());
+
+  fs.mkdirSync(core.DB_BACKUPS_DIR, { recursive: true });
+  for (const name of [
+    "db_2026-01-01T00-00-00-000Z_health-check-repair.sqlite",
+    "db_2026-01-02T00-00-00-000Z_health-check-repair.sqlite",
+  ]) {
+    fs.writeFileSync(path.join(core.DB_BACKUPS_DIR, name), name);
+  }
+
+  const argv = [...process.argv];
+  const execArgv = [...process.execArgv];
+  const nodeEnv = process.env.NODE_ENV;
+  const vitest = process.env.VITEST;
+  process.argv.splice(0, process.argv.length, "node", "omniroute.js");
+  process.execArgv.splice(0);
+  delete process.env.NODE_ENV;
+  delete process.env.VITEST;
+  process.env.DB_BACKUP_MAX_FILES = "1";
+
+  try {
+    const result = core.runManagedDbHealthCheck({ autoRepair: true });
+    assert.equal(result.backupCreated, true);
+  } finally {
+    process.argv.splice(0, process.argv.length, ...argv);
+    process.execArgv.splice(0, process.execArgv.length, ...execArgv);
+    if (nodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = nodeEnv;
+    if (vitest === undefined) delete process.env.VITEST;
+    else process.env.VITEST = vitest;
+    delete process.env.DB_BACKUP_MAX_FILES;
+  }
+
+  const backups = fs.readdirSync(core.DB_BACKUPS_DIR);
+  assert.equal(backups.length, 1);
+  assert.match(backups[0]!, /health-check-repair\.sqlite$/);
+});


### PR DESCRIPTION
## Summary

- apply configured backup retention after health-check repair snapshots
- share persisted and environment retention resolution with manual backups
- add a Windows-tested regression that creates, repairs, and prunes real SQLite backups

## Validation

- `node --import tsx/esm --test tests/unit/db-health-backup-retention-13308.test.ts tests/unit/db-backup-extended.test.ts` — 16 passed, 1 existing Windows skip
- `npm run typecheck:core`
- `npm run check:cycles`
- ESLint passed for the changed retention and test files; `core.ts` still reports the three unused-symbol errors already present on the base

⚠️ base-red inherited: #13319

Fixes #13308