### PR TITLE
fix(build): copy ioredis and bcryptjs into the standalone bundle

### DIFF
--- a/scripts/build/assembleStandalone.mjs
+++ b/scripts/build/assembleStandalone.mjs
@@ -163,6 +163,43 @@ const EXTRA_MODULE_ENTRIES = [
     dest: ["node_modules", "pino-pretty"],
   },
   { label: "split2", src: ["node_modules", "split2"], dest: ["node_modules", "split2"] },
+  {
+    // ioredis is a deliberately LAZY dependency (Redis is optional — see the
+    // #6559 comment in src/shared/utils/rateLimiter.ts) — reached only via a
+    // runtime `await import("ioredis")` in rateLimiter.ts,
+    // warmupScheduler/circuitBreakerFactory.ts and quota/redisQuotaStore.ts,
+    // never through a static top-level import. The standalone tracer only
+    // follows statically-analyzable imports, so it never sees these call
+    // sites and drops ioredis from node_modules/ entirely. Any self-hosted
+    // deployment that actually sets REDIS_URL crashes the first time it
+    // reaches one of those call sites with "Cannot find module 'ioredis'" —
+    // reproduced on a production Docker deployment (REDIS_URL configured,
+    // v3.8.49) where the standalone image shipped ioredis/package.json but
+    // none of its own dependencies or built/ output.
+    label: "ioredis (dynamic import — #6559)",
+    src: ["node_modules", "ioredis"],
+    dest: ["node_modules", "ioredis"],
+  },
+  {
+    // bcryptjs IS statically imported by src/lib/auth/managementPassword.ts,
+    // so the main server bundle is fine — Next's server compiler inlines the
+    // small pure-JS package directly into the compiled route chunk instead of
+    // leaving it as an external node_modules dependency. bin/cli/settings-
+    // store.mjs (the `omniroute reset-password` / bin/reset-password.mjs
+    // CLI, used to recover a lost dashboard password) is a separate,
+    // unbundled entrypoint that does a plain runtime `import bcrypt from
+    // "bcryptjs"` and needs the real package physically present in
+    // node_modules/ — which nothing else requires as a loose runtime
+    // dependency, so it is never copied. Reproduced on a production
+    // deployment: `node bin/reset-password.mjs --password-stdin` failed with
+    // "Cannot find package 'bcryptjs' imported from
+    // /app/bin/cli/settings-store.mjs" (ERR_MODULE_NOT_FOUND) even though the
+    // same container's dashboard login (which also depends on bcryptjs) was
+    // working normally.
+    label: "bcryptjs (bin/cli/settings-store.mjs — reset-password CLI)",
+    src: ["node_modules", "bcryptjs"],
+    dest: ["node_modules", "bcryptjs"],
+  },
   { label: "migrations", src: ["src", "lib", "db", "migrations"], dest: ["migrations"] },
   { label: "MITM server", src: ["src", "mitm", "server.cjs"], dest: ["src", "mitm", "server.cjs"] },
   {

--- a/tests/unit/build/assemble-standalone.test.ts
+++ b/tests/unit/build/assemble-standalone.test.ts
@@ -40,6 +40,10 @@ function seedSidecarSources(root: string) {
     "node_modules/pino-abstract-transport/index.js",
     "node_modules/pino-pretty/index.js",
     "node_modules/split2/index.js",
+    "node_modules/ioredis/package.json",
+    "node_modules/ioredis/built/index.js",
+    "node_modules/bcryptjs/package.json",
+    "node_modules/bcryptjs/index.js",
     "node_modules/playwright-core/index.js",
     "node_modules/sql.js/package.json",
     "node_modules/sql.js/dist/sql-wasm.js",
@@ -172,6 +176,19 @@ test("async and sync sidecar copy paths produce identical bundle trees", async (
     "node_modules/sql.js/dist/sql-wasm.wasm",
   ]) {
     assert.ok(asyncTree.includes(sqlJsFile), `sql.js runtime file copied: ${sqlJsFile}`);
+  }
+  // #6559 / reset-password CLI: both are only reachable at runtime (a dynamic
+  // `import("ioredis")`, or a separate unbundled bin/cli/ entrypoint for
+  // bcryptjs), so the standalone tracer never picks them up on its own —
+  // regression guard for the two "Cannot find module/package" crashes
+  // reproduced on a real self-hosted deployment.
+  for (const runtimeOnlyFile of [
+    "node_modules/ioredis/package.json",
+    "node_modules/ioredis/built/index.js",
+    "node_modules/bcryptjs/package.json",
+    "node_modules/bcryptjs/index.js",
+  ]) {
+    assert.ok(asyncTree.includes(runtimeOnlyFile), `runtime-only dep copied: ${runtimeOnlyFile}`);
   }
   fs.rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });


### PR DESCRIPTION
## Problem

Two packages are silently dropped from the standalone build output because they are only
reached through code paths the standalone tracer (Next's NFT-based tracing, per the comment
block in `Dockerfile` / `scripts/build/assembleStandalone.mjs`) never follows:

- **`ioredis`** is a deliberately *lazy* dependency — Redis is optional, and it's reached only
  via a runtime `await import("ioredis")` in `src/shared/utils/rateLimiter.ts` (see the
  existing `#6559` comment there), `src/lib/warmupScheduler/circuitBreakerFactory.ts` and
  `src/lib/quota/redisQuotaStore.ts`, never through a static top-level import. Any self-hosted
  deployment that sets `REDIS_URL` crashes the first time it reaches one of those call sites:

  ```
  Error: Cannot find module 'ioredis'
  ```

  Reproduced on a real production Docker deployment (v3.8.49, `REDIS_URL` configured) — the
  standalone image shipped `node_modules/ioredis/package.json` but none of its actual
  dependencies or `built/` output, because nothing had copied the rest of the package.

- **`bcryptjs`** *is* statically imported by `src/lib/auth/managementPassword.ts`, so the main
  server bundle is fine (Next inlines the small pure-JS package directly into the compiled
  route chunk instead of leaving it as an external `node_modules` dependency — dashboard login
  keeps working). `bin/cli/settings-store.mjs` — the `omniroute reset-password` /
  `bin/reset-password.mjs` CLI used to recover a lost dashboard password — is a separate,
  unbundled entrypoint that does a plain runtime `import bcrypt from "bcryptjs"` and needs the
  real package physically present in `node_modules/`, which nothing else requires as a loose
  runtime dependency, so it's never copied. Reproduced on the same deployment:

  ```
  node bin/reset-password.mjs --password-stdin
  # Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'bcryptjs' imported from
  # /app/bin/cli/settings-store.mjs
  ```

  ...even though the same container's dashboard login (which also depends on `bcryptjs`) was
  working normally at the time.

## Fix

Add both to `EXTRA_MODULE_ENTRIES` in `scripts/build/assembleStandalone.mjs` — the single
source of truth cited in `Dockerfile` for exactly this class of dynamically-reached /
separate-entrypoint dependency (same pattern already used for `pino-pretty`, `split2`,
`@swc/helpers`, the MITM `_internal` shims, etc).

## Tests

Extended `tests/unit/build/assemble-standalone.test.ts`:
- `seedSidecarSources` now seeds `node_modules/ioredis/{package.json,built/index.js}` and
  `node_modules/bcryptjs/{package.json,index.js}`.
- The sync/async parity test asserts both are present in the copied tree — regression guard
  for the two "Cannot find module/package" crashes reproduced above.

```
node --import tsx/esm --test tests/unit/build/assemble-standalone.test.ts
# tests 6, pass 6, fail 0
```

`npm run lint` and `npx prettier --check` clean on both changed files.

## Checklist

- [x] Tests added/updated in the same PR (production code change in `scripts/build/`)
- [x] `npm run lint` clean
- [x] Conventional commit message
- [x] No `Co-Authored-By` trailers
- [x] Branched from `release/v3.8.51` (active release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgcSrNE33CD9GAvrUmH4s1
