### PR TITLE
chore(skills): regenerate cli-tunnel after the addArgument parser fix

### DIFF
--- a/changelog.d/maintenance/13365-regenerate-cli-tunnel-skill.md
+++ b/changelog.d/maintenance/13365-regenerate-cli-tunnel-skill.md
@@ -1,0 +1,1 @@
+- **chore(skills):** regenerate the `cli-tunnel` skill reference so it documents the optional `[type]` argument `omniroute tunnel create` accepts — the committed artifact predated the parser learning to read `.addArgument()` positionals, which left the generated-skills gate red on every PR ([#13365](https://github.com/diegosouzapw/OmniRoute/pull/13365))

--- a/skills/cli-tunnel/SKILL.md
+++ b/skills/cli-tunnel/SKILL.md
@@ -37,12 +37,12 @@ omniroute tunnel
 omniroute tunnel list
 ```
 
-### `tunnel create`
+### `tunnel create [type]`
 
 **Example:**
 
 ```bash
-omniroute tunnel create
+omniroute tunnel create [type]
 ```
 
 ### `tunnel stop <type>`


### PR DESCRIPTION
Generated output only — one file, two lines. This is the follow-up #13009 needs, and **`Merge integrity (changelog + generated skills)` has failed on every open PR since it landed this morning.**

## Why it drifted

@dat-nguyen-thanh's #13009 taught the CLI registry parser to read positionals declared with `.addArgument()`. That is correct — `omniroute tunnel create` genuinely takes an optional `[type]`:

```js
// bin/cli/commands/tunnel.mjs:21
.command("create")
.description(t("tunnel.createDescription"))
.addArgument(
  new Argument("[type]", "Tunnel type").choices(VALID_TUNNEL_TYPES).default("cloudflare")
)
```

`skills/cli-tunnel/SKILL.md` was last generated on **8 Sep** (#12970), before that parser fix, so it documents `tunnel create` without the argument the command accepts. The parser improved; the committed artifact didn't follow.

## I checked this was the right direction before running --apply

The generator wanting to *add* `[type]` looked at first like it might be undoing @gonisulaimann's #12368 (*"remove duplicate positional argument in tunnel create command"*), which would have been a regression to re-introduce. It isn't. That PR changed `.command("create [type]")` → `.command("create")` because declaring the positional **twice** crashed the command — the `.addArgument()` declaration stayed, so the argument still exists and documenting it is right.

Worth spelling out because "just run the generator" would have produced the same diff without establishing whether the diff was correct.

## Verification

```
before   Generated: 1 · Unchanged: 45    exit 2
after    Generated: 0 · Unchanged: 46    exit 0
```

`node scripts/skills/generate-agent-skills.mjs --apply` touches this one file and nothing else — `git status` after the run shows only `skills/cli-tunnel/SKILL.md`.

Whole diff:

```diff
-### `tunnel create`
+### `tunnel create [type]`
-omniroute tunnel create
+omniroute tunnel create [type]
```

Unblocks one of the four gates currently red on every PR. The other three are tracked separately: docs counts (#13135), the redaction truncation (#13144 / #13295), and the ESLint `as any` casts from #12950.
