### PR TITLE
test(compression): assert idle eviction terminates at the resource level

### DIFF
--- a/changelog.d/maintenance/12542-compression-idle-terminate-test.md
+++ b/changelog.d/maintenance/12542-compression-idle-terminate-test.md
@@ -1,0 +1,1 @@
+- **test(compression):** cover idle worker eviction at the resource level — the pool must call `terminate()` and must not retain the worker's `MessagePort`, complementing the `exit`-event assertion added with the fix

--- a/tests/unit/compression/compression-worker.test.ts
+++ b/tests/unit/compression/compression-worker.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { after, describe, it } from "node:test";
+import { Worker } from "node:worker_threads";
 import {
   isCompressionWorkerEligible,
   isStrictlySerializable,
@@ -133,6 +134,40 @@ describe("compression worker execution", () => {
       assert.deepEqual(result, { body, compressed: false, stats: null });
     } finally {
       await pool.close();
+    }
+  });
+
+  it("terminates an idle worker instead of only dropping it from the pool", async () => {
+    const spawned = new Set<Worker>();
+    const terminated: Promise<number>[] = [];
+    const originalPostMessage = Worker.prototype.postMessage;
+    const originalTerminate = Worker.prototype.terminate;
+    Worker.prototype.postMessage = function (this: Worker, ...args) {
+      spawned.add(this);
+      return originalPostMessage.apply(this, args);
+    };
+    Worker.prototype.terminate = function (this: Worker) {
+      const exit = originalTerminate.call(this);
+      terminated.push(exit);
+      return exit;
+    };
+    const messagePorts = () =>
+      process.getActiveResourcesInfo().filter((resource) => resource === "MessagePort").length;
+    const portsBefore = messagePorts();
+    const pool = new CompressionWorkerPool({ size: 1, idleMs: 50 });
+    try {
+      await pool.run(body, "stacked", { config });
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      assert.equal(spawned.size, 1);
+      assert.equal(terminated.length, 1, "idle eviction must terminate the worker thread");
+      await Promise.all(terminated);
+      assert.ok(messagePorts() <= portsBefore, "idle eviction must not retain the worker's port");
+    } finally {
+      Worker.prototype.postMessage = originalPostMessage;
+      Worker.prototype.terminate = originalTerminate;
+      await pool.close();
+      // Reap anything the pool forgot so a regression fails instead of hanging the runner.
+      await Promise.all([...spawned].map((worker) => worker.terminate().catch(() => undefined)));
     }
   });
 


### PR DESCRIPTION
Carries the test case from #12542 by @pacocartones, whose fix was subsumed by #13091 (merged earlier today, same diagnosis reached independently).

#13091 guards the idle-eviction leak by asserting the worker's `exit` event fires — that is what separates a terminated thread from a merely dereferenced one. This adds the complementary, resource-level angle: it counts actual `terminate()` calls and checks that `process.getActiveResourcesInfo()` does not retain the worker's `MessagePort`. A regression that drops the slot while leaving the OS handle alive is caught by this one and not by the other.

Verified both directions on the current tip:

```
with the fix:                       8 pass / 0 fail
with remove() made to skip terminate():  7 pass / 1 fail (this case)
```

Test-only, plus a maintenance changelog fragment.

⚠️ base-red inherited: #12732