### PR TITLE
fix(codex): bump client version fingerprint for GPT-6 Astra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -340,7 +340,7 @@ RUN --mount=type=cache,id=s/92ca8a61-c1ba-421f-a389-d48ac7258c2d-apt-cache,targe
 #      build, not the floating `@latest`.
 RUN --mount=type=cache,id=s/92ca8a61-c1ba-421f-a389-d48ac7258c2d-npm-cache,target=/root/.npm \
   npm install -g --no-audit --no-fund \
-    @openai/codex@0.153.2 \
+    @openai/codex@0.153.4 \
     @anthropic-ai/claude-code@2.1.260 \
     droid@0.212.0 \
     openclaw@2026.9.1

--- a/docs/security/STEALTH_GUIDE.md
+++ b/docs/security/STEALTH_GUIDE.md
@@ -242,7 +242,7 @@ All MITM endpoints require management auth (`requireCliToolsAuth`). The sudo pas
 | Variable                 | Default                                                         |
 | ------------------------ | --------------------------------------------------------------- |
 | `CLAUDE_USER_AGENT`      | `claude-cli/2.1.258 (external, cli)`                            |
-| `CODEX_USER_AGENT`       | `codex-cli/0.149.0 (Windows 10.0.26200; x64)`                   |
+| `CODEX_USER_AGENT`       | `codex-cli/0.153.4 (Windows 10.0.26200; x64)`                   |
 | `GITHUB_USER_AGENT`      | `GitHubCopilotChat/0.54.0`                                      |
 | `ANTIGRAVITY_USER_AGENT` | `antigravity/2.0.1 linux/arm64 google-api-nodejs-client/10.3.0` |
 | `KIRO_USER_AGENT`        | `AWS-SDK-JS/3.0.0 kiro-ide/1.0.0`                               |

--- a/src/shared/constants/codexClient.ts
+++ b/src/shared/constants/codexClient.ts
@@ -3,7 +3,7 @@
 // refresh this so the fingerprint OpenAI sees from the OAuth/Responses face
 // matches the real client version. Overridable per-deployment via
 // CODEX_CLIENT_VERSION.
-export const DEFAULT_CODEX_CLIENT_VERSION = "0.153.2";
+export const DEFAULT_CODEX_CLIENT_VERSION = "0.153.4";
 export const CODEX_CLI_RS_ORIGINATOR = "codex_cli_rs";
 
 export function getCodexCliRsHeaders(

--- a/tests/snapshots/provider/translate-path.json
+++ b/tests/snapshots/provider/translate-path.json
@@ -1311,16 +1311,16 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.153.2 (<OS>; <ARCH>)",
-        "Version": "0.153.2",
+        "User-Agent": "codex-cli/0.153.4 (<OS>; <ARCH>)",
+        "Version": "0.153.4",
         "X-Codex-Beta-Features": "responses_websockets"
       },
       "nonStream": {
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.153.2 (<OS>; <ARCH>)",
-        "Version": "0.153.2",
+        "User-Agent": "codex-cli/0.153.4 (<OS>; <ARCH>)",
+        "Version": "0.153.4",
         "X-Codex-Beta-Features": "responses_websockets"
       },
       "oauth": {
@@ -1328,8 +1328,8 @@
         "Authorization": "Bearer <TOK>",
         "Content-Type": "application/json",
         "Openai-Beta": "responses=experimental",
-        "User-Agent": "codex-cli/0.153.2 (<OS>; <ARCH>)",
-        "Version": "0.153.2",
+        "User-Agent": "codex-cli/0.153.4 (<OS>; <ARCH>)",
+        "Version": "0.153.4",
         "X-Codex-Beta-Features": "responses_websockets"
       }
     },
@@ -1998,6 +1998,29 @@
     "url": {
       "nonStream": "https://api.electronhub.ai/v1/chat/completions",
       "stream": "https://api.electronhub.ai/v1/chat/completions"
+    }
+  },
+  "eurouter": {
+    "format": "openai",
+    "headers": {
+      "apiKey": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "nonStream": {
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "oauth": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      }
+    },
+    "url": {
+      "nonStream": "https://api.eurouter.ai/v1/chat/completions",
+      "stream": "https://api.eurouter.ai/v1/chat/completions"
     }
   },
   "factory": {
@@ -2742,6 +2765,29 @@
     "url": {
       "nonStream": "https://api.z.ai/api/coding/paas/v4/chat/completions",
       "stream": "https://api.z.ai/api/coding/paas/v4/chat/completions"
+    }
+  },
+  "greenpt": {
+    "format": "openai",
+    "headers": {
+      "apiKey": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "nonStream": {
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      },
+      "oauth": {
+        "Accept": "text/event-stream",
+        "Authorization": "Bearer <TOK>",
+        "Content-Type": "application/json"
+      }
+    },
+    "url": {
+      "nonStream": "https://api.greenpt.ai/v1/chat/completions",
+      "stream": "https://api.greenpt.ai/v1/chat/completions"
     }
   },
   "grok-cli": {

--- a/tests/unit/agentrouter-chatcore-protocols.test.ts
+++ b/tests/unit/agentrouter-chatcore-protocols.test.ts
@@ -112,7 +112,7 @@ test("AgentRouter Responses requests automatically use the native Responses prot
       body: structuredClone(body),
       headers: new Headers({ accept: "application/json", originator: "codex_cli_rs" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.ok(captured);
@@ -176,7 +176,7 @@ test("AgentRouter OpenAI Chat requests automatically use the native Chat protoco
       body: structuredClone(body),
       headers: new Headers({ accept: "application/json" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.equal(result.success, true);
@@ -304,7 +304,7 @@ test("AgentRouter Responses streaming stays native without a connection protocol
       body: structuredClone(body),
       headers: new Headers({ accept: "text/event-stream", originator: "codex_cli_rs" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.equal(result.success, true);
@@ -383,7 +383,7 @@ test("AgentRouter OpenAI Chat streaming stays native without a connection protoc
       body: structuredClone(body),
       headers: new Headers({ accept: "text/event-stream" }),
     },
-    userAgent: "codex_cli_rs/0.149.0",
+    userAgent: "codex_cli_rs/0.153.4",
   });
 
   assert.equal(result.success, true);

--- a/tests/unit/claude-codex-identity-version-sync.test.ts
+++ b/tests/unit/claude-codex-identity-version-sync.test.ts
@@ -90,7 +90,7 @@ test("Codex client version locksteps Dockerfile @openai/codex", () => {
   const match = dockerfile.match(/@openai\/codex@([0-9]+\.[0-9]+\.[0-9]+)/);
   assert.ok(match, "Dockerfile must pin @openai/codex@x.y.z");
   const pinned = match[1];
-  assert.notEqual(pinned, "0.149.0");
+  assert.equal(pinned, "0.153.4");
   assert.equal(codexCfg.DEFAULT_CODEX_CLIENT_VERSION, pinned);
   assert.equal(codexCfg.getCodexClientVersion(), pinned);
   assert.equal(codexCfg.getCodexDefaultHeaders().Version, pinned);

--- a/tests/unit/executor-codex.test.ts
+++ b/tests/unit/executor-codex.test.ts
@@ -184,10 +184,10 @@ test("CodexExecutor.buildHeaders binds workspace ids and disables SSE accept for
   assert.equal(standardHeaders.Authorization, "Bearer codex-token");
   assert.equal(standardHeaders.Accept, "text/event-stream");
   assert.equal(standardHeaders["chatgpt-account-id"], "workspace-1");
-  assert.equal(standardHeaders.Version, "0.153.2");
+  assert.equal(standardHeaders.Version, "0.153.4");
   assert.equal(standardHeaders["Openai-Beta"], "responses=experimental");
   assert.equal(standardHeaders["X-Codex-Beta-Features"], "responses_websockets");
-  assert.equal(standardHeaders["User-Agent"], "codex-cli/0.153.2 (Windows 10.0.26200; x64)");
+  assert.equal(standardHeaders["User-Agent"], "codex-cli/0.153.4 (Windows 10.0.26200; x64)");
   assert.equal(compactHeaders.Accept, "application/json");
 });
 
@@ -213,7 +213,7 @@ test("CodexExecutor.buildHeaders honors safe env overrides for Version and User-
     },
     () => {
       const headers = executor.buildHeaders({ accessToken: "codex-token" }, true);
-      assert.equal(headers.Version, "0.153.2");
+      assert.equal(headers.Version, "0.153.4");
       assert.equal(headers["User-Agent"], "custom-codex/9.9.9");
     }
   );


### PR DESCRIPTION
## Summary

The Codex provider sent a client version fingerprint that GPT-6 Astra rejected as too old. Raise the default fingerprint to `0.153.4`, pin the matching `@openai/codex` image, and update the stealth guide table, keeping the `CODEX_CLIENT_VERSION` override.

## Related Issues

- Closes #12761

## Validation

Choose the change type and focused loop from the
[Contribution Golden Path](../docs/ops/CONTRIBUTION_GOLDEN_PATH.md). The full unit suite,
Vitest, the 60% coverage gate, and the production build all run in CI on this PR (#8329):

- [x] Change type: provider / build-deploy
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base; focused checks rerun afterward
- [x] Production-code changes include a new or updated automated test in this PR
- SonarQube is temporarily opt-in while the private project has no quota; it is not a PR gate.

## Tests Added Or Updated

- `tests/unit/agentrouter-chatcore-protocols.test.ts`
- `tests/unit/claude-codex-identity-version-sync.test.ts`
- `tests/unit/executor-codex.test.ts`
- `tests/snapshots/provider/translate-path.json`

## Coverage Notes

- The Codex provider identity change is covered by the updated lockstep, executor, AgentRouter, and provider snapshot tests.
- No coverage percentage change was measured locally.

## Reviewer Notes

- @diegosouzapw
- @anhtahaylove
