### PR TITLE
chore(quality): drop two stale ESLint suppression entries

### DIFF
--- a/changelog.d/maintenance/stale-eslint-suppressions-20260911.md
+++ b/changelog.d/maintenance/stale-eslint-suppressions-20260911.md
@@ -1,0 +1,1 @@
+- **chore(quality):** drop two ESLint suppression entries whose violations no longer exist, so `eslint --suppressions-location` stops rejecting every commit that touches the surrounding files

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -568,11 +568,6 @@
       "count": 1
     }
   },
-  "open-sse/services/imageCombo.ts": {
-    "@typescript-eslint/no-unused-vars": {
-      "count": 1
-    }
-  },
   "open-sse/services/inAppLoginService.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
@@ -2804,11 +2799,6 @@
   "tests/unit/chat-cooldown-aware-retry.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 10
-    }
-  },
-  "tests/unit/chat-helpers.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 13
     }
   },
   "tests/unit/chat-rate-limit-body-lock.test.ts": {


### PR DESCRIPTION
#12653 and #12358 fixed the violations these entries covered but left the entries in place, and ESLint treats a suppression with nothing left to suppress as an error. The practical effect is that the pre-commit hook rejects any commit whose staged set includes either file — which is how I found it, reconciling a PR against the tip.

- `open-sse/services/imageCombo.ts` — `no-unused-vars`
- `tests/unit/chat-helpers.test.ts` — `no-explicit-any`

Both are deleted rather than re-counted, so this tightens the ratchet.

Not touched here: the three `no-explicit-any` errors in `tests/unit/volcengine-plan-binding-upsert.test.ts`, which make `npm run lint` exit 2 on the pure tip today. Issue #13215 is closed but that red is still live on `release/v3.8.51`.

⚠️ base-red inherited: #12732