### PR TITLE
chore(quality): retighten the chat.ts unused-vars suppression to 8

### DIFF
--- a/changelog.d/maintenance/chat-unused-vars-count-20260911.md
+++ b/changelog.d/maintenance/chat-unused-vars-count-20260911.md
@@ -1,0 +1,1 @@
+- **chore(quality):** retighten the `src/sse/handlers/chat.ts` unused-vars suppression count to the 8 violations that actually remain

--- a/config/quality/eslint-suppressions.json
+++ b/config/quality/eslint-suppressions.json
@@ -2080,7 +2080,7 @@
   },
   "src/sse/handlers/chat.ts": {
     "@typescript-eslint/no-unused-vars": {
-      "count": 9
+      "count": 8
     }
   },
   "src/sse/handlers/chatHelpers.ts": {


### PR DESCRIPTION
#12975 lowered this entry to 8 when it started using `runtimeOptions.correlationId`, but a later merge today carried the old 9 back in. `src/sse/handlers/chat.ts` has 8 `no-unused-vars` violations, so a count of 9 makes ESLint reject any commit that stages the file.

```
eslint src/sse/handlers/chat.ts --suppressions-location …   exit 0
```

⚠️ base-red inherited: #12732