### PR TITLE
feat(cli): make startup readiness budget configurable (#13369)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1793,6 +1793,9 @@ APP_LOG_TO_FILE=true
 # Per-attempt HTTP timeout for CLI → server calls (milliseconds). Default: 30000.
 # OMNIROUTE_HTTP_TIMEOUT_MS=30000
 
+# Maximum milliseconds to wait for server readiness during `omniroute serve`. Default: 60000.
+# OMNIROUTE_READY_TIMEOUT_MS=60000
+
 # Set to 1 to print retry/backoff details to stderr during CLI commands.
 # OMNIROUTE_VERBOSE=0
 

--- a/bin/cli/commands/env.mjs
+++ b/bin/cli/commands/env.mjs
@@ -13,6 +13,7 @@ const OMNIROUTE_ENV_VARS = [
   "OMNIROUTE_API_KEY",
   "OMNIROUTE_BASE_URL",
   "OMNIROUTE_HTTP_TIMEOUT_MS",
+  "OMNIROUTE_READY_TIMEOUT_MS",
 ];
 
 const ENV_DEFAULTS = {
@@ -20,6 +21,7 @@ const ENV_DEFAULTS = {
   DASHBOARD_PORT: "20128",
   DATA_DIR: "~/.omniroute",
   NODE_ENV: "production",
+  OMNIROUTE_READY_TIMEOUT_MS: "60000",
 };
 
 export function registerEnv(program) {

--- a/bin/cli/commands/serve.mjs
+++ b/bin/cli/commands/serve.mjs
@@ -68,6 +68,12 @@ export function registerServe(program) {
       t("serve.tls_key") ||
         "Path to the TLS private key (PEM) to serve HTTPS (also OMNIROUTE_TLS_KEY)"
     )
+    .option(
+      "--ready-timeout <ms>",
+      t("serve.ready_timeout") ||
+        "Maximum milliseconds to wait for server readiness (also OMNIROUTE_READY_TIMEOUT_MS)",
+      parseInt
+    )
     .action(async (opts) => {
       await runServe(opts);
     });
@@ -98,6 +104,23 @@ export function maybeReportInstrumentationHookFailure(text) {
 /** Test-only reset for the once-per-process hint guard. */
 export function resetInstrumentationFailureHintForTests() {
   instrumentationFailureHintPrinted = false;
+}
+
+/**
+ * Resolves server readiness timeout in ms from opts or OMNIROUTE_READY_TIMEOUT_MS,
+ * defaulting to 60000ms.
+ *
+ * @param {Record<string, any>} [opts]
+ * @returns {number}
+ */
+export function resolveReadyTimeout(opts = {}) {
+  if (opts.readyTimeout !== undefined && opts.readyTimeout !== null) {
+    const parsed = Number.parseInt(String(opts.readyTimeout), 10);
+    if (!Number.isNaN(parsed) && parsed > 0) return parsed;
+  }
+  const envVal = Number.parseInt(process.env.OMNIROUTE_READY_TIMEOUT_MS || "", 10);
+  if (!Number.isNaN(envVal) && envVal > 0) return envVal;
+  return 60000;
 }
 
 export async function runServe(opts = {}) {
@@ -452,7 +475,8 @@ async function runWithSupervisor(
   });
 
   if (!showLog) {
-    waitForServer(dashboardPort, 60000).then(async (up) => {
+    const readyTimeout = resolveReadyTimeout(opts);
+    waitForServer(dashboardPort, readyTimeout).then(async (up) => {
       if (up) {
         if (useTray) {
           const trayReady = await maybeStartTray(dashboardPort, apiPort, supervisor);
@@ -476,7 +500,7 @@ async function runWithSupervisor(
         }
         onReady(dashboardPort, apiPort, noOpen, startedAt);
       } else {
-        reportReadinessTimeout(dashboardPort, supervisor);
+        reportReadinessTimeout(dashboardPort, supervisor, readyTimeout);
       }
     });
   }
@@ -488,9 +512,10 @@ async function runWithSupervisor(
 // stuck (issue reports show the server sometimes actually comes up later, or is
 // reachable directly while the CLI still looks hung). Surface a clear diagnostic
 // plus whatever stdout/stderr the child buffered instead of going silent.
-export function reportReadinessTimeout(dashboardPort, supervisor) {
+export function reportReadinessTimeout(dashboardPort, supervisor, timeoutMs = 60000) {
+  const seconds = Math.max(1, Math.round(timeoutMs / 1000));
   console.error(
-    `\n\x1b[33m⚠ Server did not respond within 60s.\x1b[0m It may still be starting, or may` +
+    `\n\x1b[33m⚠ Server did not respond within ${seconds}s.\x1b[0m It may still be starting, or may` +
       ` have failed silently.`
   );
   console.error(`  Try:  curl -I http://localhost:${dashboardPort}/api/monitoring/health`);

--- a/bin/cli/utils/pid.mjs
+++ b/bin/cli/utils/pid.mjs
@@ -72,8 +72,12 @@ export function sleep(ms) {
 // but the HTTP server is clearly alive and responsive) — never for a
 // socket that merely accepts TCP and then hangs without ever completing
 // a single request (#6800: that's a still-booting/CPU-bound process, not
-// a "route not mounted" gap, and must NOT be reported as ready).
-export async function waitForServer(port, timeout = 60000) {
+// #13369: readiness timeout is configurable via OMNIROUTE_READY_TIMEOUT_MS,
+// preserving the 60000 default.
+export async function waitForServer(
+  port,
+  timeout = Number.parseInt(process.env.OMNIROUTE_READY_TIMEOUT_MS || "", 10) || 60000
+) {
   const start = Date.now();
   let tcpListeningSince = null;
   while (Date.now() - start < timeout) {

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -98,6 +98,7 @@ The warnings come from stale peer-dependency ranges in third-party packages Omni
 | Docker `curl: (56) Recv failure: Connection reset by peer` | Your Docker port bind may be landing on IPv6. Use `-p 127.0.0.1:20128:20128` to force IPv4, or test with `curl -4`. See [Docker IPv6](#docker-ipv6) below |
 | Antivirus quarantines `README.md`                          | False positive — see [Antivirus false positives](#antivirus-false-positives) below                                                                        |
 | Kaspersky flags the Desktop app as a Trojan                | Behavioral false positive on the unsigned installer — see [Antivirus false positives](#antivirus-false-positives) below                                   |
+| "Server did not respond within 60s" on slow boot           | Set `OMNIROUTE_READY_TIMEOUT_MS=180000` (or `omniroute serve --ready-timeout 180000`) to raise the readiness budget for slow cold starts (e.g. on Windows with antivirus or heavy schema migrations) |
 
 ---
 

--- a/docs/reference/ENVIRONMENT.md
+++ b/docs/reference/ENVIRONMENT.md
@@ -498,6 +498,7 @@ detection above).
 | `OMNIROUTE_SHOW_LOG`           | _(unset)_  | `bin/cli/runtime/processSupervisor.mjs` | Set to `1` to forward server stdout/stderr to the terminal in supervised mode. Equivalent to `--log` flag on `omniroute serve`.    |
 | `OMNIROUTE_CLI_TOKEN`          | _(unset)_  | `bin/cli/api.mjs`                       | Machine-auth token injected as `x-omniroute-cli-token` header. Auto-generated in task 8.12.                                        |
 | `OMNIROUTE_HTTP_TIMEOUT_MS`    | `30000`    | `bin/cli/api.mjs`                       | Per-attempt HTTP timeout (ms) for CLI → server requests.                                                                           |
+| `OMNIROUTE_READY_TIMEOUT_MS`   | `60000`    | `bin/cli/commands/serve.mjs`, `bin/cli/utils/pid.mjs` | Maximum milliseconds to wait for server readiness during `omniroute serve` before emitting a readiness timeout warning. Equivalent to `--ready-timeout <ms>`. |
 | `OMNIROUTE_VERBOSE`            | `0`        | `bin/cli/api.mjs`                       | Set to `1` to print retry/backoff diagnostics to stderr during CLI commands.                                                       |
 | `OMNIROUTE_PLUGIN_PATH`        | _(unset)_  | `bin/cli/plugins.mjs`                   | Custom directory for CLI plugin discovery (`omniroute-cmd-*` packages). Defaults to `~/.omniroute/plugins/` when unset. CLI-only — it never reaches the server-side plugin scanner, which is pointed by `OMNIROUTE_PLUGINS_DIR` (section 2). |
 

--- a/tests/unit/cli-ready-timeout-13369.test.ts
+++ b/tests/unit/cli-ready-timeout-13369.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+
+import { resolveReadyTimeout, reportReadinessTimeout } from "../../bin/cli/commands/serve.mjs";
+import { waitForServer } from "../../bin/cli/utils/pid.mjs";
+
+// #13369: verify configurable readiness timeout via --ready-timeout and OMNIROUTE_READY_TIMEOUT_MS
+
+test("resolveReadyTimeout returns 60000 by default when no option or env var is set (#13369)", () => {
+  const origEnv = process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  delete process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  try {
+    const timeout = resolveReadyTimeout({});
+    assert.equal(timeout, 60000);
+  } finally {
+    if (origEnv !== undefined) process.env.OMNIROUTE_READY_TIMEOUT_MS = origEnv;
+    else delete process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  }
+});
+
+test("resolveReadyTimeout respects OMNIROUTE_READY_TIMEOUT_MS env var (#13369)", () => {
+  const origEnv = process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  try {
+    process.env.OMNIROUTE_READY_TIMEOUT_MS = "150000";
+    const timeout = resolveReadyTimeout({});
+    assert.equal(timeout, 150000);
+  } finally {
+    if (origEnv !== undefined) process.env.OMNIROUTE_READY_TIMEOUT_MS = origEnv;
+    else delete process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  }
+});
+
+test("resolveReadyTimeout prioritizes opts.readyTimeout over OMNIROUTE_READY_TIMEOUT_MS (#13369)", () => {
+  const origEnv = process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  try {
+    process.env.OMNIROUTE_READY_TIMEOUT_MS = "150000";
+    const timeout = resolveReadyTimeout({ readyTimeout: 180000 });
+    assert.equal(timeout, 180000);
+
+    const stringTimeout = resolveReadyTimeout({ readyTimeout: "240000" });
+    assert.equal(stringTimeout, 240000);
+  } finally {
+    if (origEnv !== undefined) process.env.OMNIROUTE_READY_TIMEOUT_MS = origEnv;
+    else delete process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  }
+});
+
+test("resolveReadyTimeout ignores invalid or non-positive values and falls back safely (#13369)", () => {
+  const origEnv = process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  try {
+    process.env.OMNIROUTE_READY_TIMEOUT_MS = "invalid";
+    assert.equal(resolveReadyTimeout({ readyTimeout: -50 }), 60000);
+    assert.equal(resolveReadyTimeout({ readyTimeout: "not-a-number" }), 60000);
+  } finally {
+    if (origEnv !== undefined) process.env.OMNIROUTE_READY_TIMEOUT_MS = origEnv;
+    else delete process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  }
+});
+
+test("reportReadinessTimeout formats custom timeout seconds into message (#13369)", () => {
+  const logs: string[] = [];
+  const origErr = console.error.bind(console);
+  console.error = (...args: unknown[]) => logs.push(args.join(" "));
+
+  try {
+    reportReadinessTimeout(20128, { getRecentLog: () => [] }, 120000);
+    const combined = logs.join("\n");
+    assert.ok(
+      combined.includes("within 120s"),
+      `expected "within 120s" in message, got:\n${combined}`
+    );
+  } finally {
+    console.error = origErr;
+  }
+});
+
+test("OMNIROUTE_READY_TIMEOUT_MS is registered in CLI env vars (#13369)", async () => {
+  const envShowMod = await import("../../bin/cli/commands/env.mjs");
+  const logs: string[] = [];
+  const origLog = console.log.bind(console);
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+
+  try {
+    await envShowMod.runEnvShowCommand({ json: true });
+    const output = JSON.parse(logs.join("\n"));
+    assert.equal(output.defaults.OMNIROUTE_READY_TIMEOUT_MS, "60000");
+  } finally {
+    console.log = origLog;
+  }
+});
+
+test("waitForServer default timeout respects OMNIROUTE_READY_TIMEOUT_MS (#13369)", async () => {
+  const origEnv = process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  try {
+    process.env.OMNIROUTE_READY_TIMEOUT_MS = "1200";
+
+    const server = net.createServer();
+    const port = await new Promise<number>((resolve) => {
+      server.listen(0, () => {
+        const addr = server.address() as net.AddressInfo;
+        const p = addr.port;
+        server.close(() => resolve(p));
+      });
+    });
+
+    const start = Date.now();
+    const result = await waitForServer(port);
+    const elapsed = Date.now() - start;
+
+    assert.equal(result, false);
+    assert.ok(
+      elapsed >= 1000 && elapsed < 4000,
+      `expected waitForServer to respect OMNIROUTE_READY_TIMEOUT_MS=1200, elapsed=${elapsed}ms`
+    );
+  } finally {
+    if (origEnv !== undefined) process.env.OMNIROUTE_READY_TIMEOUT_MS = origEnv;
+    else delete process.env.OMNIROUTE_READY_TIMEOUT_MS;
+  }
+});


### PR DESCRIPTION
## Problem

On slow cold starts (such as on Windows with filesystem watchers, antivirus scans, or heavy schema migrations as reported in #10754), `omniroute serve` polls `/api/monitoring/health` for a hardcoded 60 seconds before printing:

```text
⚠ Server did not respond within 60s. It may still be starting, or may have failed silently.
```

Because the server boots normally just slightly after the budget, the warning was emitted on every cold start despite healthy operation.

## Solution

This PR implements the solution outlined and confirmed in #13369:

1. **Configurable Readiness Budget**:
   - `OMNIROUTE_READY_TIMEOUT_MS` environment variable is read with 60000ms default preserved.
   - `--ready-timeout <ms>` CLI flag is added to `omniroute serve` to override or specify the timeout.
   - Helper `resolveReadyTimeout(opts)` cleanly resolves flag > env var > 60000 default (safely falling back on invalid/non-positive values).
   - `waitForServer` in `bin/cli/utils/pid.mjs` defaults `timeout` to `OMNIROUTE_READY_TIMEOUT_MS` so all un-parameterized calls benefit automatically.

2. **Accurate Diagnostic Reporting**:
   - `reportReadinessTimeout` dynamically formats the message with `${seconds}s` instead of hardcoding `within 60s`.

3. **CLI Env Registration & Documentation**:
   - `OMNIROUTE_READY_TIMEOUT_MS` is registered in `bin/cli/commands/env.mjs` (`OMNIROUTE_ENV_VARS` and `ENV_DEFAULTS`).
   - Documented in `docs/reference/ENVIRONMENT.md`, `.env.example`, and added to the troubleshooting quick fixes in `docs/guides/TROUBLESHOOTING.md`.

4. **Testing**:
   - Added unit test suite in `tests/unit/cli-ready-timeout-13369.test.ts` covering option overrides, env var parsing, fallback behavior, dynamic warning formatting, and CLI env registration.

Closes #13369
