### PR TITLE
fix(logging): mask *-api-key headers in request-log pipeline

### DIFF
--- a/open-sse/utils/requestLogger.ts
+++ b/open-sse/utils/requestLogger.ts
@@ -90,6 +90,7 @@ function maskSensitiveHeaders(headers: HeaderInput): Record<string, unknown> {
   const sensitiveKeys = [
     "authorization",
     "x-api-key",
+    "apikey",
     "cookie",
     "token",
     "runtimekey",
@@ -109,7 +110,8 @@ function maskSensitiveHeaders(headers: HeaderInput): Record<string, unknown> {
       masked[key] = "[REDACTED]";
       continue;
     }
-    if (!sensitiveKeys.some((candidate) => lowerKey.includes(candidate))) {
+    const compactedKey = lowerKey.replace(/-/g, "");
+    if (!sensitiveKeys.some((candidate) => compactedKey.includes(candidate.replace(/-/g, "")))) {
       continue;
     }
 

--- a/src/lib/logPayloads.ts
+++ b/src/lib/logPayloads.ts
@@ -14,6 +14,7 @@ const SENSITIVE_KEYS = new Set([
   "x-api-key",
   "X-Api-Key",
   "x-goog-api-key",
+  "xi-api-key",
   "access_token",
   "accessToken",
   "refresh_token",

--- a/tests/unit/request-logger-header-mask-apikey-13273.test.ts
+++ b/tests/unit/request-logger-header-mask-apikey-13273.test.ts
@@ -1,0 +1,117 @@
+// Regression test for #13273: maskSensitiveHeaders missed *-api-key spellings
+// (x-goog-api-key, api-key, xi-api-key) — provider keys landed in the log
+// pipeline unmasked.
+//
+// maskSensitiveHeaders uses substring matching on a sensitiveKeys list; adding
+// "apikey" (no hyphens) catches every current and future *-api-key header
+// spelling as a single catch-all.
+//
+// protectPayloadForLog / redactPayload in logPayloads.ts is a separate layer
+// that also needs xi-api-key in SENSITIVE_KEYS for body-level redaction.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const { createRequestLogger } = await import("../../open-sse/utils/requestLogger.ts");
+const { protectPayloadForLog } = await import("../../src/lib/logPayloads.ts");
+
+// --- maskSensitiveHeaders (via logTargetRequest -> getPipelinePayloads) ---
+
+test("maskSensitiveHeaders redacts x-goog-api-key (Gemini)", async () => {
+  const logger = await createRequestLogger("openai", "gemini", "gemini-2.5-flash", {});
+  logger.logTargetRequest("https://generativelanguage.googleapis.com/v1", {
+    "x-goog-api-key": "super-secret-gemini-key-12345",
+  }, {});
+
+  const payload = logger.getPipelinePayloads();
+  const headers = payload?.providerRequest?.headers as Record<string, unknown>;
+  assert.ok(headers, "providerRequest.headers must exist");
+  assert.notEqual(headers["x-goog-api-key"], "super-secret-gemini-key-12345",
+    "x-goog-api-key must not appear verbatim");
+  assert.ok(
+    typeof headers["x-goog-api-key"] === "string" && headers["x-goog-api-key"] !== "",
+    "x-goog-api-key must be masked"
+  );
+});
+
+test("maskSensitiveHeaders redacts api-key (Azure OpenAI)", async () => {
+  const logger = await createRequestLogger("openai", "azure-openai", "gpt-4o", {});
+  logger.logTargetRequest("https://myazure.openai.azure.com/openai/deployments/gpt-4o", {
+    "api-key": "azure-secret-key-67890",
+  }, {});
+
+  const payload = logger.getPipelinePayloads();
+  const headers = payload?.providerRequest?.headers as Record<string, unknown>;
+  assert.ok(headers, "providerRequest.headers must exist");
+  assert.notEqual(headers["api-key"], "azure-secret-key-67890",
+    "api-key must not appear verbatim");
+});
+
+test("maskSensitiveHeaders redacts xi-api-key (ElevenLabs)", async () => {
+  const logger = await createRequestLogger("openai", "elevenlabs", "eleven_multilingual_v2", {});
+  logger.logTargetRequest("https://api.elevenlabs.io/v1/text-to-speech", {
+    "xi-api-key": "elevenlabs-secret-key-abcde",
+  }, {});
+
+  const payload = logger.getPipelinePayloads();
+  const headers = payload?.providerRequest?.headers as Record<string, unknown>;
+  assert.ok(headers, "providerRequest.headers must exist");
+  assert.notEqual(headers["xi-api-key"], "elevenlabs-secret-key-abcde",
+    "xi-api-key must not appear verbatim");
+});
+
+test("maskSensitiveHeaders still masks x-api-key (Anthropic)", async () => {
+  const logger = await createRequestLogger("openai", "anthropic", "claude-sonnet-4", {});
+  logger.logTargetRequest("https://api.anthropic.com/v1/messages", {
+    "x-api-key": "anthropic-key-xyz",
+  }, {});
+
+  const payload = logger.getPipelinePayloads();
+  const headers = payload?.providerRequest?.headers as Record<string, unknown>;
+  assert.ok(headers, "providerRequest.headers must exist");
+  assert.notEqual(headers["x-api-key"], "anthropic-key-xyz",
+    "x-api-key must not appear verbatim");
+});
+
+test("maskSensitiveHeaders does NOT mask x-ratelimit- headers", async () => {
+  const logger = await createRequestLogger("openai", "openai", "gpt-4o", {});
+  logger.logTargetRequest("https://api.openai.com/v1/chat/completions", {
+    "x-ratelimit-remaining-requests": "100",
+    "x-ratelimit-reset-requests": "1m",
+  }, {});
+
+  const payload = logger.getPipelinePayloads();
+  const headers = payload?.providerRequest?.headers as Record<string, unknown>;
+  assert.ok(headers, "providerRequest.headers must exist");
+  assert.equal(headers["x-ratelimit-remaining-requests"], "100",
+    "x-ratelimit- headers must NOT be masked");
+});
+
+// --- protectPayloadForLog (logPayloads.ts SENSITIVE_KEYS) ---
+
+test("protectPayloadForLog redacts xi-api-key in body payloads", () => {
+  const protectedPayload = protectPayloadForLog({
+    headers: {
+      "xi-api-key": "elevenlabs-secret-key-abcde",
+    },
+    body: {
+      text: "Hello world",
+    },
+  }) as Record<string, unknown>;
+
+  const headers = protectedPayload.headers as Record<string, unknown>;
+  assert.equal(headers["xi-api-key"], "[REDACTED]",
+    "xi-api-key must be redacted by protectPayloadForLog");
+});
+
+test("protectPayloadForLog redacts x-goog-api-key in body payloads", () => {
+  const protectedPayload = protectPayloadForLog({
+    headers: {
+      "x-goog-api-key": "gemini-secret-key",
+    },
+  }) as Record<string, unknown>;
+
+  const headers = protectedPayload.headers as Record<string, unknown>;
+  assert.equal(headers["x-goog-api-key"], "[REDACTED]",
+    "x-goog-api-key must be redacted by protectPayloadForLog");
+});


### PR DESCRIPTION
## Summary

`maskSensitiveHeaders` in `open-sse/utils/requestLogger.ts` matched a hardcoded substring list that missed several real upstream credential headers:

| Header | Provider | Was masked? |
|--------|----------|-------------|
| `x-goog-api-key` | Gemini / Vertex | ❌ unmasked |
| `api-key` | Azure OpenAI | ❌ unmasked |
| `xi-api-key` | ElevenLabs | ❌ unmasked |
| `x-api-key` | Anthropic | ✅ masked |

These passed through verbatim into the request-log pipeline (`logTargetRequest` → `getPipelinePayloads`).

## Fix

**1. Compact header matching** (`open-sse/utils/requestLogger.ts`):

Strip hyphens from both the header key and each candidate before comparing, so the `"apikey"` catch-all in `sensitiveKeys` matches every current and future `*-api-key` spelling:

```typescript
const compactedKey = lowerKey.replace(/-/g, "");
if (!sensitiveKeys.some((c) => compactedKey.includes(c.replace(/-/g, "")))) continue;
```

**2. Add `xi-api-key` to `SENSITIVE_KEYS`** (`src/lib/logPayloads.ts`):

Defense-in-depth for body-level redaction via `protectPayloadForLog` / `redactPayload`.

## Tests

New regression test file `tests/unit/request-logger-header-mask-apikey-13273.test.ts` with 7 tests covering:

- `x-goog-api-key` (Gemini) — previously unmasked, now masked
- `api-key` (Azure OpenAI) — previously unmasked, now masked
- `xi-api-key` (ElevenLabs) — previously unmasked, now masked
- `x-api-key` (Anthropic) — still masked (regression guard)
- `x-ratelimit-` headers — still NOT masked (whitelist preserved)
- `protectPayloadForLog` redacts `xi-api-key` and `x-goog-api-key` in body payloads

All existing tests pass: `request-log-payloads` (26/26), `request-logger-bounded-idempotence` (6/6).

## Related

Fixes #13273