### PR TITLE
fix(tests): update stale GLM arity assertion broken by #12925

### DIFF
--- a/tests/unit/glm-sse-transform-arity.test.ts
+++ b/tests/unit/glm-sse-transform-arity.test.ts
@@ -6,11 +6,12 @@ import { dirname, join } from "node:path";
 
 /**
  * GLM's translateSseResponse used to pass a 16th positional (65536) to
- * createSSETransformStreamWithLogger. The helper only has 15 parameters
- * (last is requestToolIdentityMap) — tsc reports TS2554 and the number
- * never reached TransformStream.
+ * createSSETransformStreamWithLogger. #12925 legitimised the buffer-size
+ * argument as a named constant (GLM_STREAM_BUFFER_BYTES), so the call now
+ * ends with that constant instead of suppressThinkClose.
  *
- * Guard the call site in source: no 65536, last arg is suppressThinkClose.
+ * Guard the call site in source: no hardcoded 65536 literal, last arg is
+ * GLM_STREAM_BUFFER_BYTES (the named constant introduced by #12925).
  */
 const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -47,5 +48,5 @@ test("GLM translateSseResponse does not pass a 16th positional to the stream hel
   assert.ok(callAt >= 0);
   const call = extractParens(body, callAt + "createSSETransformStreamWithLogger".length);
   assert.equal(/65536/.test(call), false, `dead 16th arg still present:\n${call}`);
-  assert.match(call, /suppressThinkClose\s*\)\s*$/);
+  assert.match(call, /GLM_STREAM_BUFFER_BYTES\s*\)\s*$/, "call should end with GLM_STREAM_BUFFER_BYTES, not a hardcoded literal");
 });


### PR DESCRIPTION
## Summary

`tests/unit/glm-sse-transform-arity.test.ts` fails on `release/v3.8.51` base at `af49d4972`, independently of any PR. Every PR targeting this base inherits a red Unit Tests job.

## Root cause

`#12770` added an arity guard asserting the GLM call ends with `suppressThinkClose`. `#12925` then legitimised the buffer-size argument (`GLM_STREAM_BUFFER_BYTES`), so the call now ends with three more positionals after `suppressThinkClose`. The second assertion is stale.

## Fix

Update the assertion to expect `GLM_STREAM_BUFFER_BYTES` as the final argument while keeping the hardcoded `65536` dead-literal guard from `#12770`.

```diff
- assert.match(call, /suppressThinkClose\s*\)\s*$/);
+ assert.match(call, /GLM_STREAM_BUFFER_BYTES\s*\)\s*$/, "call should end with GLM_STREAM_BUFFER_BYTES, not a hardcoded literal");
```

Also updated the JSDoc to explain the change.

## Tests

```
✔ createSSETransformStreamWithLogger has no highWaterMark slot
✔ GLM translateSseResponse does not pass a 16th positional to the stream helper
```

## Related

Fixes #13319