### PR TITLE
fix(tests): correct stale Jina catalog prefix in custom-models test

### DIFF
--- a/tests/unit/models-catalog-route.test.ts
+++ b/tests/unit/models-catalog-route.test.ts
@@ -1092,9 +1092,9 @@ test("v1 models catalog does not duplicate custom Jina specialty models", async 
 
   assert.equal(response.status, 200);
   assert.equal(visibleJinaEmbeddingRows.length, 1);
-  assert.equal(visibleJinaEmbeddingRows[0].id, "jina-ai/jina-embeddings-v5-text-small");
+  assert.equal(visibleJinaEmbeddingRows[0].id, "jina/jina-embeddings-v5-text-small");
   assert.equal(visibleJinaRerankRows.length, 1);
-  assert.equal(visibleJinaRerankRows[0].id, "jina-ai/jina-reranker-v3");
+  assert.equal(visibleJinaRerankRows[0].id, "jina/jina-reranker-v3");
 });
 
 test("v1 models catalog exposes image model input and output modalities for advanced image providers", async () => {


### PR DESCRIPTION
## Summary

The `v1 models catalog does not duplicate custom Jina specialty models` test asserts catalog IDs prefixed with `jina-ai/` (the connection/provider ID), but the catalog builder uses the provider alias `jina` — introduced in v3.8.36. The test above it (`does not duplicate imported Jina specialty models`) already asserts `jina/` and passes; this second test was simply never updated.

## Fix

Two `assert.equal` strings changed from `jina-ai/` to `jina/`:

```diff
- assert.equal(visibleJinaEmbeddingRows[0].id, "jina-ai/jina-embeddings-v5-text-small");
+ assert.equal(visibleJinaEmbeddingRows[0].id, "jina/jina-embeddings-v5-text-small");
- assert.equal(visibleJinaRerankRows[0].id, "jina-ai/jina-reranker-v3");
+ assert.equal(visibleJinaRerankRows[0].id, "jina/jina-reranker-v3");
```

## Tests

```
✔ v1 models catalog does not duplicate custom Jina specialty models
✔ v1 models catalog does not duplicate imported Jina specialty models
✔ all 44 tests in models-catalog-route.test.ts pass
```

## Note

The companion pt-BR compression integration tests (`chatcore-compression-integration.test.ts`) mentioned in #13313 need separate investigation — the output-style system message injection appears to have a deeper behavioral change beyond just the language string, with the first message role being `"user"` instead of `"system"`.

## Related

Partially fixes #13313