### PR TITLE
test(coverage): clean stale coverage output before test:coverage runs

### DIFF
--- a/changelog.d/maintenance/13408-test-coverage-clean.md
+++ b/changelog.d/maintenance/13408-test-coverage-clean.md
@@ -1,0 +1,1 @@
+- **test(coverage):** clean stale `coverage/` output before `test:coverage` runs, stopping unbounded accumulation of c8 raw snapshots and reports ([#13408](https://github.com/diegosouzapw/OmniRoute/pull/13408)) — thanks @MumuTW

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "test:mutation": "stryker run",
     "test:ecosystem": "node scripts/dev/run-ecosystem-tests.mjs",
     "test:system": "cross-env DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm --import ./open-sse/utils/setupPolyfill.ts --import ./tests/_setup/isolateDataDir.ts --test --test-force-exit --test-concurrency=1 tests/e2e/system-failover.test.ts",
+    "pretest:coverage": "rm -rf coverage",
     "test:coverage": "cross-env DISABLE_SQLITE_AUTO_BACKUP=true NODE_OPTIONS=--max-old-space-size=8192 c8 --merge-async --output-dir coverage --exclude=tests/** --exclude=**/*.test.* --reporter=text-summary --reporter=html --reporter=json-summary --reporter=lcov --check-coverage --statements 60 --lines 60 --functions 60 --branches 60 npm run test:coverage:runner",
     "test:coverage:legacy": "c8 --output-dir coverage --exclude=open-sse --check-coverage --lines 50 --functions 50 --branches 50 node --import tsx/esm --test tests/unit/*.test.ts",
     "coverage:report": "cross-env NODE_OPTIONS=--max-old-space-size=8192 c8 report --merge-async --output-dir coverage --exclude=tests/** --exclude=**/*.test.* --reporter=text --reporter=text-summary --reporter=html --reporter=json-summary --reporter=lcov",


### PR DESCRIPTION
⚠️ base-red inherited: #12732

## Summary

- `npm run test:coverage` never removes `coverage/` between runs. c8 `--merge-async` raw per-process snapshots and generated reports accumulate without bound (reached 13 GB on a contributor machine).
- Adds a `pretest:coverage` lifecycle script that removes `coverage/` before each run, using the same `rm -rf` idiom as `build:release`.

## Related Issues

- Related to #12732 (housekeeping; no tracking issue exists for the coverage accumulation itself)

## Validation

- [x] Change type: build-deploy / other (test tooling)
- [x] Focused checks: `npm run pretest:coverage` verified to remove an existing `coverage/` dir; `npx prettier --check package.json` clean; `node -e` JSON parse OK
- [ ] `npm run lint` — not run: package.json-only change, no lintable code touched
- [x] Reconciled with the current active release base (`release/v3.8.51`)
- [ ] Production-code changes include a new or updated automated test in this PR — N/A, no production code changed

## Tests Added Or Updated

- No production code changed; no tests added or updated.

## Coverage Notes

- N/A — no `src/`, `open-sse/`, `electron/`, or `bin/` changes.

## Reviewer Notes

- `coverage:report` intentionally still reads existing `coverage/` artifacts, so the pre-clean is attached only to `test:coverage` (the accumulation entry point), not to `coverage:report`.