### PR TITLE
fix(test): update stale GLM arity assertion after #12925 added buffer-size param (#13319)

### DIFF
--- a/tests/unit/glm-sse-transform-arity.test.ts
+++ b/tests/unit/glm-sse-transform-arity.test.ts
@@ -47,5 +47,11 @@ test("GLM translateSseResponse does not pass a 16th positional to the stream hel
   assert.ok(callAt >= 0);
   const call = extractParens(body, callAt + "createSSETransformStreamWithLogger".length);
   assert.equal(/65536/.test(call), false, `dead 16th arg still present:\n${call}`);
-  assert.match(call, /suppressThinkClose\s*\)\s*$/);
+  // #12770 originally pinned suppressThinkClose as the final arg to guard
+  // against accidental 16th positionals.  #12925 legitimately added trailing
+  // args (including GLM_STREAM_BUFFER_BYTES as the buffer-size parameter), so
+  // we only verify suppressThinkClose is still present and that the named
+  // constant GLM_STREAM_BUFFER_BYTES appears as the last argument.
+  assert.match(call, /suppressThinkClose/, "suppressThinkClose must be passed");
+  assert.match(call, /GLM_STREAM_BUFFER_BYTES\s*\)\s*$/);
 });


### PR DESCRIPTION
## Summary

Fixes #13319

`tests/unit/glm-sse-transform-arity.test.ts` fails on `release/v3.8.51` base, causing every PR targeting this base to inherit a red Unit Tests job. The failure is a stale test assertion, not a product regression.

## Root Cause

- **#12770** added an arity guard asserting the `createSSETransformStreamWithLogger(` call ends right after `suppressThinkClose`
- **#12925** then legitimately added trailing arguments (`undefined, undefined, GLM_STREAM_BUFFER_BYTES`) to the same call site

The stale assertion `assert.match(call, /suppressThinkClose\s*\)\s*$/)` no longer matches because the call now ends with `GLM_STREAM_BUFFER_BYTES`.

## Fix

Update the assertion in `tests/unit/glm-sse-transform-arity.test.ts`:

| Before | After |
|--------|-------|
| `assert.match(call, /suppressThinkClose\s*\)\s*$/)` | Two assertions: `suppressThinkClose` is present, and `GLM_STREAM_BUFFER_BYTES` is the final argument |

The dead-`65536` literal guard from #12770 is preserved (still valid since the source uses the named constant).

## Test Results

- ✅ 2/2 `glm-sse-transform-arity` tests pass
- ✅ 5/5 `sse-stream-buffer-bytes` tests pass
