### PR TITLE
fix(opencode-plugin): report disk-cache age in the stale-fallback warning

### DIFF
--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -5518,9 +5518,17 @@ export function createOmniRouteConfigHook(
         if (modelsFetchThrew && wantDiskCache && !warmSnapshot) {
           const snapshot = await diskSnapshotReader(resolved.providerId, snapshotFingerprint);
           if (snapshot && snapshot.rawModels.length > 0) {
+            // Report snapshot age like the warm-startup path already does:
+            // "stale" alone reads as a transient blip, so a week-old catalog
+            // is indistinguishable from a five-minute-old one.
+            const snapshotAge = snapshot.writtenAt;
+            const snapshotAgeLabel =
+              typeof snapshotAge === "number"
+                ? `${Math.round((Date.now() - snapshotAge) / 3_600_000)}h`
+                : "unknown";
             logAt(
               "warn",
-              `config shim: /v1/models unreachable; using stale disk cache (${snapshot.rawModels.length} models)`
+              `config shim: /v1/models unreachable; using stale disk cache (${snapshot.rawModels.length} models, age ${snapshotAgeLabel})`
             );
             localRawModels = snapshot.rawModels;
             localRawCombos = snapshot.rawCombos;

--- a/changelog.d/fixes/13426-opencode-plugin-stale-cache-age.md
+++ b/changelog.d/fixes/13426-opencode-plugin-stale-cache-age.md
@@ -1,0 +1,1 @@
+- **fix(opencode-plugin):** The stale disk-cache fallback warning now reports the snapshot's age (`using stale disk cache (N models, age 168h)`), matching the existing warm-startup log. Previously a week-old catalog was indistinguishable from a five-minute-old one, so silent model drift went unnoticed. (#13426)


### PR DESCRIPTION
## Summary

When `/v1/models` is unreachable, `@omniroute/opencode-plugin` hydrates the catalog from its last-known-good disk snapshot and logs:

```
config shim: /v1/models unreachable; using stale disk cache (1325 models)
```

The message says the cache is stale but not *how* stale. A snapshot written five minutes ago and one written a week ago produce identical output, so there is no signal that the catalog has drifted.

The warm-startup path in the same file already solves this, using the same `writtenAt` field:

```
config shim: warm startup from disk snapshot (1325 models, age 3h)
```

This change makes the fallback path consistent with it.

## Why it matters

On my machine the snapshot was seven days old. Diffed against a successful live fetch:

| | Stale snapshot | Live catalog |
|---|---|---|
| Model IDs | 1684 | 1352 |
| IDs present but gone upstream | **422** | — |
| Live IDs missing from snapshot | — | **90** |

The 90 missing models included the entire `cc/*` family, one of which was my configured `small_model`. Every small-model call resolved against a catalog that predated that model's existence.

The one warn line was present in my logs the whole time. I read it as a transient blip, because nothing indicated it was a week old, and moved on. `age 168h` would have made it obvious at a glance.

Reported in #13390, which also covers bounding the cache age. This PR addresses only the reporting half — the smallest change that makes the condition diagnosable — and deliberately leaves the retention policy question open for maintainers.

## Change

```diff
+            // Report snapshot age like the warm-startup path already does:
+            // "stale" alone reads as a transient blip, so a week-old catalog
+            // is indistinguishable from a five-minute-old one.
+            const snapshotAge = snapshot.writtenAt;
+            const snapshotAgeLabel =
+              typeof snapshotAge === "number"
+                ? `${Math.round((Date.now() - snapshotAge) / 3_600_000)}h`
+                : "unknown";
             logAt(
               "warn",
-              `config shim: /v1/models unreachable; using stale disk cache (${snapshot.rawModels.length} models)`
+              `config shim: /v1/models unreachable; using stale disk cache (${snapshot.rawModels.length} models, age ${snapshotAgeLabel})`
             );
```

`writtenAt` is already declared optional on `OmniRouteDiskSnapshotReader`'s return type:

```ts
) => Promise<(Omit<OmniRouteFetchCacheEntry, "expiresAt"> & { writtenAt?: number }) | undefined>;
```

so no cast, no signature change, and no behavioural change beyond the log text. Snapshots written by older plugin versions without the field fall back to `age unknown`.

## Validation

Ran from `@omniroute/opencode-plugin`, branched from `release/v3.8.51` per CONTRIBUTING:

```
npx tsc --noEmit -p tsconfig.json     # exit 0
npm run build                          # ESM + DTS build success
npm test                               # ℹ pass 368  ℹ fail 1
```

The single failure is `debug instance retains config diagnostics after an error instance is created`. It is **pre-existing on unmodified `release/v3.8.51`** — verified by stashing this patch, rebuilding, and re-running:

```
BASELINE (no patch):  ℹ pass 368   ℹ fail 1   ✖ debug instance retains config diagnostics…
WITH PATCH:           ℹ pass 368   ℹ fail 1   ✖ debug instance retains config diagnostics…
```

Identical counts and the same test, so it is untouched by this change.

## Tests Added Or Updated

None. This changes a log message's content, not behaviour — there is no observable contract a test could meaningfully pin without asserting on log wording, which would be brittle and is not something the existing suite does for this file.

Happy to add coverage if you'd prefer the age label pinned.

## Coverage Notes

No production logic branches added or removed. The new `typeof` check is a formatting guard on an already-optional field, mirroring the identical guard in the warm-startup path a few hundred lines above.

## Reviewer Notes

- Branched from `release/v3.8.51` as CONTRIBUTING requires (not `main`).
- Changelog fragment added under `changelog.d/fixes/` with this PR's number.
- Scope is deliberately minimal. #13390 also proposes bounding the cache age, escalating log level with age, and surfacing staleness to the user — all policy decisions I did not want to make unilaterally. This PR is just the diagnostic.
- `age` is rounded to whole hours to match the existing warm-startup label exactly. A sub-hour snapshot reports `age 0h`; if you'd prefer minutes below one hour, that's a one-line change.
