### PR TITLE
fix(reasoning): expand deepseek-v4 model regex to match v4.1 and add command-code provider (#13430)

### DIFF
--- a/open-sse/services/reasoningCache.ts
+++ b/open-sse/services/reasoningCache.ts
@@ -45,13 +45,16 @@ const REASONING_REPLAY_PROVIDERS = new Set([
   // 400s with "Param Incorrect: The reasoning_content in the thinking mode
   // must be passed back to the API."
   "xiaomi-mimo",
+  // Command Code serves upstream DeepSeek models (e.g.
+  // command-code/deepseek-v4.1-flash) and requires reasoning replay.
+  "command-code",
 ]);
 
 const REASONING_REPLAY_MODEL_PATTERNS = [
   /deepseek-r1/i,
   /deepseek-reasoner/i,
   /deepseek-chat/i,
-  /deepseek[-/]v4[-.](flash|pro)(-free)?/i,
+  /deepseek[-/]v4(?:[-.]1)?[-.](flash|pro)(-free)?/i,
   /zen\/deepseek-v4/i,
   // Match native kimi-kN and namespaced kimi/kN families without treating
   // generic aliases such as kimi-latest as strict thinking models.
@@ -64,7 +67,7 @@ const REASONING_REPLAY_MODEL_PATTERNS = [
   /^mimo[-.]?v\d/i,
 ];
 
-const DEEPSEEK_V4_MODEL_PATTERN = /deepseek[-/]v4[-.](flash|pro)/i;
+const DEEPSEEK_V4_MODEL_PATTERN = /deepseek[-/]v4(?:[-.]1)?[-.](flash|pro)/i;
 const K3_REASONING_REPLAY_MODEL_PATTERN = /(?:^|\/)(?:kimi-)?k3(?:$|-)/i;
 const NATIVE_K27_REASONING_REPLAY_MODEL_PATTERN = /(?:^|\/)kimi-k2\.7-code(?:$|-)/i;
 

--- a/tests/unit/reasoning-cache.test.ts
+++ b/tests/unit/reasoning-cache.test.ts
@@ -1288,3 +1288,81 @@ describe("Reasoning Replay Cache — API Route", () => {
     assert.equal(lookupReasoning("call_api_provider_kimi"), "Keep provider");
   });
 });
+
+// ──────────── #13430: v4.1 model regex + command-code provider ────────────
+
+describe("requiresReasoningReplay — v4.1 model patterns (#13430)", () => {
+  it("matches deepseek-v4.1-flash via model pattern", () => {
+    assert.equal(
+      requiresReasoningReplay({
+        provider: "some-provider",
+        model: "deepseek-v4.1-flash",
+        thinkingEnabled: true,
+      }),
+      true
+    );
+  });
+
+  it("matches deepseek-v4.1-pro via model pattern", () => {
+    assert.equal(
+      requiresReasoningReplay({
+        provider: "some-provider",
+        model: "deepseek-v4.1-pro",
+        thinkingEnabled: true,
+      }),
+      true
+    );
+  });
+
+  it("matches command-code/deepseek-v4.1-flash", () => {
+    assert.equal(
+      requiresReasoningReplay({
+        provider: "command-code",
+        model: "deepseek-v4.1-flash",
+      }),
+      true
+    );
+  });
+
+  it("matches command-code/deepseek-v4-flash (no minor version)", () => {
+    assert.equal(
+      requiresReasoningReplay({
+        provider: "command-code",
+        model: "deepseek-v4-flash",
+      }),
+      true
+    );
+  });
+
+  it("isDeepSeekReasoningModel matches v4.1-flash with thinking enabled", () => {
+    assert.equal(
+      isDeepSeekReasoningModel({
+        provider: "command-code",
+        model: "deepseek-v4.1-flash",
+        thinkingEnabled: true,
+      }),
+      true
+    );
+  });
+
+  it("isDeepSeekReasoningModel does NOT match without thinking enabled", () => {
+    assert.equal(
+      isDeepSeekReasoningModel({
+        provider: "command-code",
+        model: "deepseek-v4.1-flash",
+        thinkingEnabled: false,
+      }),
+      false
+    );
+  });
+
+  it("still matches legacy deepseek-v4-flash (no dot)", () => {
+    assert.equal(
+      requiresReasoningReplay({
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+      }),
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The Reasoning Replay Cache regex never matches `deepseek-v4.1-flash` because the dot in `v4.1` was consumed by the character class but the `1` was not accounted for. Additionally, the `command-code` provider was missing from the legacy provider fallback set.

This means command-code/deepseek-v4.1-flash traffic never triggers reasoning replay, resulting in 400 errors: "The reasoning_content in the thinking mode must be passed back to the API."

## Changes

- **`open-sse/services/reasoningCache.ts`**:
  - Update `DEEPSEEK_V4_MODEL_PATTERN` to `v4(?:[-.]1)?[-.](flash|pro)` — optionally consumes the minor version segment
  - Same fix in `REASONING_REPLAY_MODEL_PATTERNS` array
  - Add `"command-code"` to `REASONING_REPLAY_PROVIDERS`
- **`tests/unit/reasoning-cache.test.ts`**: 7 new tests covering v4.1-flash, v4.1-pro, command-code provider, isDeepSeekReasoningModel with thinking toggle, and legacy v4-flash backward compatibility

## Test Results

67/67 tests pass including 7 new ones.

Closes #13430