### PR TITLE
fix(oauth): parse numeric epoch expiry so the health check still refreshes tokens

### DIFF
--- a/changelog.d/fixes/13444-token-expiry-numeric-epoch.md
+++ b/changelog.d/fixes/13444-token-expiry-numeric-epoch.md
@@ -1,0 +1,1 @@
+- **fix(oauth):** token health check now parses a numeric epoch `expires_at` (number or string, seconds or milliseconds), so connections synced by external tools keep their expiry-driven refresh instead of being skipped forever — or refreshed on every sweep ([#13444](https://github.com/diegosouzapw/OmniRoute/pull/13444)) — thanks @elielsousa-pathbit

--- a/src/lib/tokenHealthCheck.ts
+++ b/src/lib/tokenHealthCheck.ts
@@ -60,29 +60,55 @@ export function extractResolvedProxyConfig(resolvedProxy: unknown) {
   return resolvedProxy ?? null;
 }
 
+const NUMERIC_STRING = /^\d+(\.\d+)?$/;
+
+/**
+ * Normalize any stored token-expiry value to epoch milliseconds.
+ *
+ * `provider_connections.expires_at` / `token_expires_at` are TEXT columns, so a
+ * numeric epoch written by an external sync tool reads back as a *string* —
+ * and `new Date("1789012345678")` is an Invalid Date. Both numeric shapes are
+ * accepted here with the seconds/ms heuristic the Copilot path already used,
+ * before falling back to `Date` for ISO 8601 and other date strings.
+ *
+ * @returns epoch ms, or 0 when the value carries no usable time
+ */
+export function parseTokenExpiryMs(expiresAt: unknown): number {
+  if (typeof expiresAt === "number") {
+    if (!Number.isFinite(expiresAt) || expiresAt <= 0) return 0;
+    return expiresAt < 1e12 ? expiresAt * 1000 : expiresAt;
+  }
+
+  if (typeof expiresAt === "string") {
+    const trimmed = expiresAt.trim();
+    if (!trimmed) return 0;
+
+    if (NUMERIC_STRING.test(trimmed)) {
+      const numeric = Number(trimmed);
+      if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+      return numeric < 1e12 ? numeric * 1000 : numeric;
+    }
+
+    const parsed = new Date(trimmed).getTime();
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
 function getEffectiveTokenExpiryIso(conn: any): string | null {
   if (!conn || typeof conn !== "object") return null;
   return conn.tokenExpiresAt || conn.expiresAt || null;
 }
 
 function getEffectiveTokenExpiryMs(conn: any): number {
-  const effectiveExpiry = getEffectiveTokenExpiryIso(conn);
-  if (!effectiveExpiry) return 0;
-  const expiryMs = new Date(effectiveExpiry).getTime();
-  return Number.isFinite(expiryMs) ? expiryMs : 0;
+  return parseTokenExpiryMs(getEffectiveTokenExpiryIso(conn));
 }
 
 const TOKEN_EXPIRY_BUFFER = 5 * 60 * 1000; // 5 minutes
 
 function getCopilotTokenExpiryMs(expiresAt: unknown): number {
-  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
-    return expiresAt < 1e12 ? expiresAt * 1000 : expiresAt;
-  }
-  if (typeof expiresAt === "string" && expiresAt.trim()) {
-    const parsed = new Date(expiresAt).getTime();
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-  return 0;
+  return parseTokenExpiryMs(expiresAt);
 }
 
 // Providers whose OAuth flow yields only a GitHub-style access token (no

--- a/tests/unit/token-expiry-numeric-epoch.test.ts
+++ b/tests/unit/token-expiry-numeric-epoch.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// We import the exported helper directly. The module auto-starts the
+// health-check timer on import, so we stop it immediately.
+import { parseTokenExpiryMs, stopTokenHealthCheck } from "../../src/lib/tokenHealthCheck.ts";
+
+stopTokenHealthCheck();
+
+/**
+ * Regression guard: `provider_connections.expires_at` is a TEXT column, so an
+ * epoch timestamp always reads back as a string. `new Date("1789012345678")`
+ * is an Invalid Date, and an epoch-seconds *number* parsed as milliseconds
+ * lands in 1970 — both break the expiry-driven refresh in checkConnection():
+ *
+ *   - NaN  -> getEffectiveTokenExpiryMs() returns 0 -> hasKnownExpiry false.
+ *     For a ROTATING_REFRESH_PROVIDERS entry (codex, claude, kiro, openai, …)
+ *     shouldRefreshByInterval is false too, so the connection is never
+ *     refreshed at all.
+ *   - 1970 -> isAboutToExpire is permanently true, so every sweep refreshes
+ *     the connection, burning refresh-token rotations.
+ *
+ * The sibling Copilot helper already handled both shapes; this asserts the
+ * single shared parser does the same for every connection.
+ */
+describe("parseTokenExpiryMs", () => {
+  const MS = Date.parse("2026-09-12T12:00:00.000Z");
+  const SECONDS = Math.floor(MS / 1000);
+
+  it("parses epoch milliseconds as a number", () => {
+    assert.equal(parseTokenExpiryMs(MS), MS);
+  });
+
+  it("parses epoch seconds as a number", () => {
+    assert.equal(parseTokenExpiryMs(SECONDS), SECONDS * 1000);
+  });
+
+  it("parses epoch milliseconds given as a string", () => {
+    assert.equal(parseTokenExpiryMs(String(MS)), MS);
+  });
+
+  it("parses epoch seconds given as a string", () => {
+    assert.equal(parseTokenExpiryMs(String(SECONDS)), SECONDS * 1000);
+  });
+
+  it("parses an ISO 8601 string", () => {
+    assert.equal(parseTokenExpiryMs("2026-09-12T12:00:00.000Z"), MS);
+  });
+
+  it("returns 0 for values that carry no usable time", () => {
+    assert.equal(parseTokenExpiryMs(null), 0);
+    assert.equal(parseTokenExpiryMs(undefined), 0);
+    assert.equal(parseTokenExpiryMs(""), 0);
+    assert.equal(parseTokenExpiryMs("   "), 0);
+    assert.equal(parseTokenExpiryMs("not-a-date"), 0);
+    assert.equal(parseTokenExpiryMs(0), 0);
+    assert.equal(parseTokenExpiryMs(Number.NaN), 0);
+    assert.equal(parseTokenExpiryMs({}), 0);
+  });
+});


### PR DESCRIPTION
⚠️ base-red inherited: #12732

## Summary

`provider_connections.expires_at` / `token_expires_at` are **TEXT** columns, so an epoch timestamp always reads back as a *string*. `getEffectiveTokenExpiryMs()` went straight to `new Date()`:

```ts
new Date("1789012345678").getTime()  // NaN
new Date(1789012345).getTime()       // 1970-01-21 — seconds read as milliseconds
```

The sibling helper immediately below it, `getCopilotTokenExpiryMs()`, already handled both numeric shapes (`expiresAt < 1e12 ? expiresAt * 1000 : expiresAt`) — the main connection path just never got the same treatment.

### Two ways this breaks `checkConnection()`

**1. Numeric string → the connection is never refreshed.**
`NaN` → `Number.isFinite` false → `getEffectiveTokenExpiryMs()` returns `0` → `hasKnownExpiry` false → `isAboutToExpire` false. For a `ROTATING_REFRESH_PROVIDERS` entry (`codex`, `claude`, `kiro`, `openai`, `cline`, `kimi-coding`, `amazon-q`, `gitlab-duo`, `openference`) `shouldRefreshByInterval` is also false, so:

```ts
if (!isAboutToExpire && !shouldRefreshByInterval) return;   // src/lib/tokenHealthCheck.ts
```

returns early **every sweep**. The expiry-driven refresh that the surrounding comment says it prefers is silently off, and the token is only ever discovered dead by a failing request.

**2. Epoch seconds as a number → a refresh loop.** Parsed as milliseconds it lands in 1970, so `isAboutToExpire` is permanently true and *every* sweep refreshes the connection — burning single-use refresh-token rotations, exactly the thing the `ROTATING_REFRESH_PROVIDERS` comment warns about ("can trigger Auth0's token family revocation").

## Fix

Extract the numeric/string handling `getCopilotTokenExpiryMs()` already had into one exported `parseTokenExpiryMs()`, and route both call sites through it, so every connection is parsed the same way:

- `number` → seconds/ms heuristic (`< 1e12` → seconds), `0` for non-finite/non-positive
- numeric string → same heuristic after `Number()`
- anything else → `new Date()` (ISO 8601 and friends), `0` when unparseable

No behavior change for the ISO strings written by the OAuth flows today.

## Related Issues

- Related to #12732 (base red at branch time — not caused by this PR)

## Validation

TDD per Hard Rule #18 — failing test first, then the fix.

```
# new test, before the fix (parseTokenExpiryMs did not exist)
$ node --import tsx/esm --test tests/unit/token-expiry-numeric-epoch.test.ts
  # pass 0
  # fail 1

# after the fix
$ node --import tsx/esm --test tests/unit/token-expiry-numeric-epoch.test.ts
  # pass 6
  # fail 0
```

Every existing test file that imports `src/lib/tokenHealthCheck.ts` — all green:

| file | pass | fail |
| :-- | --: | --: |
| `tests/unit/token-health-check.test.ts` | 11 | 0 |
| `tests/unit/token-health-check-sweep.test.ts` | 3 | 0 |
| `tests/unit/tokenHealthCheck-transient.test.ts` | 12 | 0 |
| `tests/unit/tokenHealthCheck-batchSize.test.ts` | 1 | 0 |
| `tests/unit/token-health-check-kimi.test.ts` | 4 | 0 |
| `tests/unit/token-health-check-webcookie.test.ts` | 10 | 0 |
| `tests/unit/oauth-connection-tokenexpiresat-5326.test.ts` | 3 | 0 |
| `tests/unit/token-health-no-refresh-token-expired-5326.test.ts` | 7 | 0 |

Gates:

```
$ npm run typecheck:core     # clean
$ npx eslint src/lib/tokenHealthCheck.ts tests/unit/token-expiry-numeric-epoch.test.ts   # clean
$ npx prettier --check ...   # unchanged
```

The commit was made with the Husky pre-commit gate active (no `--no-verify`): `lint-staged`, `check-docs-sync`, `check:any-budget:t11` and `check:tracked-artifacts` all passed.

- [x] Change type: **DB / provider credentials**
- [x] Focused tests and category gates from the golden path
- [x] `npm run lint`
- [x] Reconciled with the current active release base (`release/v3.8.51`)
- [x] Production-code changes include a new automated test in this PR

## Tests Added Or Updated

- `tests/unit/token-expiry-numeric-epoch.test.ts` (new, 6 cases)

## Coverage Notes

The change is one new exported helper in `src/lib/tokenHealthCheck.ts` plus two call sites collapsing into it. The new test covers every branch of `parseTokenExpiryMs()` — number ms, number seconds, string ms, string seconds, ISO, and the eight no-usable-time inputs. Net coverage of the touched file goes up: the numeric-string and non-finite paths had no test before.

## Reviewer Notes

- `getCopilotTokenExpiryMs()` is now a thin alias. It is kept rather than inlined so the Copilot call site at line ~694 keeps reading as intent-revealing; happy to inline it if you prefer.
- The seconds/ms cutover stays at `1e12` — the exact value the Copilot helper already used — so no existing value changes classification.
