### PR TITLE
fix(memory): merge memory context into top-level system field for claude-shaped bodies

### DIFF
--- a/changelog.d/fixes/memory-top-level-system.md
+++ b/changelog.d/fixes/memory-top-level-system.md
@@ -1,0 +1,1 @@
+- fix(memory): merge injected memory context into the top-level `system` field instead of unshifting a synthetic `role: "system"` message at `messages[0]`, fixing a 400 on Anthropic-shaped (claude-family / strict-provider) request bodies (#13425)

--- a/src/lib/memory/injection.ts
+++ b/src/lib/memory/injection.ts
@@ -28,7 +28,7 @@ export interface ChatMessage {
 export interface ChatRequest {
   model: string;
   messages: ChatMessage[];
-  system?: string;
+  system?: string | unknown[];
   temperature?: number;
   max_tokens?: number;
   stream?: boolean;
@@ -154,9 +154,39 @@ export interface InjectMemoryOptions {
 }
 
 /**
+ * #13425: merge memory text into the request's TOP-LEVEL `system` field instead of
+ * unshifting a `role: "system"` entry into `messages[]`. An Anthropic-shaped body
+ * carries its system prompt in this field — `messages[]` may only contain `user`/
+ * `assistant` turns — so adding a system-role message there lands invalid alongside
+ * an existing `system` field. Mirrors the existing merge pattern for a top-level
+ * `system` array (open-sse/translator/request/openai-to-claude.ts:489-505,
+ * `[...body.system, systemBlock]`): string fields get the memory text prepended,
+ * block-array fields get a new text block appended so any leading `cache_control`
+ * breakpoint on the first block stays first. Returns null when there is no
+ * top-level `system` field, so the caller falls back to its existing
+ * messages[]-based placement.
+ */
+function mergeIntoTopLevelSystem(
+  request: ChatRequest,
+  messages: ChatMessage[],
+  memoryText: string
+): ChatRequest | null {
+  const { system } = request;
+  if (typeof system === "string") {
+    const merged = system.length > 0 ? `${memoryText}\n${system}` : memoryText;
+    return { ...request, messages, system: merged };
+  }
+  if (Array.isArray(system)) {
+    return { ...request, messages, system: [...system, { type: "text", text: memoryText }] };
+  }
+  return null;
+}
+
+/**
  * #6135: place the memory as a leading system message for providers that reject
  * a non-first system role — merging into an existing index-0 system message when
- * present, else prepending. Split out of injectMemory to keep it flat.
+ * present, else merging into a top-level `system` field (#13425), else prepending
+ * a new system message. Split out of injectMemory to keep it flat.
  */
 function injectSystemFirst(
   request: ChatRequest,
@@ -164,12 +194,22 @@ function injectSystemFirst(
   memoryText: string,
   count: number
 ): ChatRequest {
-  log.info("memory.injection.injected", { count, strategy: "system-first", model: request.model });
   const first = messages[0];
   if (first && first.role === "system") {
+    log.info("memory.injection.injected", { count, strategy: "system-first", model: request.model });
     const merged: ChatMessage = { ...first, content: `${memoryText}\n${first.content}` };
     return { ...request, messages: [merged, ...messages.slice(1)] };
   }
+  const mergedTopLevel = mergeIntoTopLevelSystem(request, messages, memoryText);
+  if (mergedTopLevel) {
+    log.info("memory.injection.injected", {
+      count,
+      strategy: "system-first-top-level",
+      model: request.model,
+    });
+    return mergedTopLevel;
+  }
+  log.info("memory.injection.injected", { count, strategy: "system-first", model: request.model });
   const memorySystemMessage: ChatMessage = { role: "system", content: memoryText };
   return { ...request, messages: [memorySystemMessage, ...messages] };
 }
@@ -213,8 +253,10 @@ function endsWithServerToolResult(message: ChatMessage | undefined): boolean {
 
 /**
  * Place a memory message at the #3890 cache-safe anchor (just before the last
- * user turn) when one exists, else prepend it. Shared by the system and user
- * injection strategies to keep injectMemory flat.
+ * user turn) when one exists, else merge into a top-level `system` field when
+ * present (#13425), else prepend it. Shared by the system and user injection
+ * strategies to keep injectMemory flat. The top-level-system guard only applies
+ * to the system-role strategy — GLM's user-role fallback never touches `system`.
  */
 function placeMessage(
   request: ChatRequest,
@@ -226,6 +268,10 @@ function placeMessage(
     const next = [...messages];
     next.splice(cacheSafeIndex, 0, msg);
     return { ...request, messages: next };
+  }
+  if (msg.role === "system") {
+    const mergedTopLevel = mergeIntoTopLevelSystem(request, messages, msg.content);
+    if (mergedTopLevel) return mergedTopLevel;
   }
   return { ...request, messages: [msg, ...messages] };
 }

--- a/tests/unit/memory-cache-safe-injection.test.ts
+++ b/tests/unit/memory-cache-safe-injection.test.ts
@@ -180,3 +180,61 @@ describe("injectMemory cache-safe positioning — Claude-family server-tool-resu
     assert.equal(out.messages[4].content, "turn 2 question");
   });
 });
+
+/**
+ * #13425: an Anthropic-shaped body carries its system prompt in the top-level `system`
+ * field, never as a `messages[]` entry — `messages[]` may only contain `user`/`assistant`
+ * turns. Unshifting a `role: "system"` message at index 0 on such a body is rejected by
+ * Anthropic with HTTP 400. These tests pin the fix: memory merges into the top-level
+ * `system` field when one exists, leaving `messages[]` untouched.
+ */
+describe("injectMemory top-level system field placement (#13425)", () => {
+  it("merges memory into a string top-level `system` field instead of unshifting messages[0]", () => {
+    const req: ChatRequest = {
+      model: "anthropic/claude-sonnet-4-6",
+      system: "TOP LEVEL SYS",
+      messages: [{ role: "user", content: "turn 1 question" }],
+    };
+    const out = injectMemory(req, [mem("dark mode")], "anthropic");
+
+    assert.equal(out.system, "Memory context: dark mode\nTOP LEVEL SYS");
+    assert.equal(out.messages.length, 1);
+    assert.equal(out.messages[0].role, "user");
+    assert.equal(out.messages[0].content, "turn 1 question");
+  });
+
+  it("appends a text block onto an array-shaped top-level `system` field", () => {
+    const req: ChatRequest = {
+      model: "anthropic/claude-sonnet-4-6",
+      system: [{ type: "text", text: "TOP LEVEL SYS BLOCK" }],
+      messages: [{ role: "user", content: "turn 1 question" }],
+    };
+    const out = injectMemory(req, [mem("dark mode")], "anthropic");
+
+    assert.deepEqual(out.system, [
+      { type: "text", text: "TOP LEVEL SYS BLOCK" },
+      { type: "text", text: "Memory context: dark mode" },
+    ]);
+    assert.equal(out.messages.length, 1);
+    assert.equal(out.messages[0].role, "user");
+  });
+
+  it("merges into the top-level `system` field via the #11290 Claude-family cache-safe fallback", () => {
+    const req: ChatRequest = {
+      model: "anthropic/claude-opus-5",
+      system: "TOP LEVEL SYS",
+      messages: [
+        { role: "user", content: "turn 1 question" },
+        { role: "assistant", content: "turn 1 answer" },
+        { role: "user", content: "turn 2 question" },
+      ],
+    };
+    const out = injectMemory(req, [mem("dark mode")], "anthropic", { cacheSafe: true });
+
+    // No messages[]-splice: falls back through injectSystemFirst into the top-level field.
+    assert.equal(out.messages.length, 3);
+    assert.equal(out.system, "Memory context: dark mode\nTOP LEVEL SYS");
+    assert.equal(out.messages[0].role, "user");
+    assert.equal(out.messages[0].content, "turn 1 question");
+  });
+});

--- a/tests/unit/memory-glm-injection.test.ts
+++ b/tests/unit/memory-glm-injection.test.ts
@@ -117,6 +117,17 @@ describe("injectMemory — GLM providers use user role (#1701)", () => {
     injectMemory(baseRequest, testMemories, "glm");
     assert.equal(baseRequest.messages.length, original.messages.length);
   });
+
+  it("should never populate a top-level system field for GLM even when one exists (#13425)", () => {
+    const reqWithSystem: ChatRequest = {
+      ...baseRequest,
+      system: "Existing GLM system text",
+    };
+    const result = injectMemory(reqWithSystem, testMemories, "glm");
+    assert.equal(result.system, "Existing GLM system text");
+    assert.equal(result.messages[0].role, "user");
+    assert.ok(result.messages[0].content.includes("Memory context:"));
+  });
 });
 
 // ── normalizeSystemRole — GLM model names ──────────────────────────────────────

--- a/tests/unit/memory-system-first-6135.test.ts
+++ b/tests/unit/memory-system-first-6135.test.ts
@@ -109,6 +109,21 @@ describe("injectMemory system-must-be-first (#6135)", () => {
     );
   });
 
+  // #13425: a body carrying BOTH a leading system message and a top-level
+  // `system` field must receive memory exactly once. The leading system message
+  // wins; the top-level field is left untouched (no double injection).
+  it("injects only once when a leading system message and a top-level system field coexist", () => {
+    const req = { ...multiTurn(), system: "TOP LEVEL SYSTEM" } as ChatRequest & { system: string };
+    const out = injectMemory(req, [mem("dark mode")], "xiaomi-mimo", {
+      cacheSafe: true,
+    }) as ChatRequest & { system: string };
+    assert.equal(out.messages[0].role, "system");
+    assert.ok(out.messages[0].content.includes("Memory context"));
+    assert.ok(out.messages[0].content.includes("SYSTEM PROMPT"));
+    assert.equal(out.system, "TOP LEVEL SYSTEM");
+    assert.equal(out.messages.filter((m) => m.role === "system").length, 1);
+  });
+
   it("regression: a NON-flagged provider keeps the existing cache-safe placement", () => {
     const req = multiTurn();
     // #11290/#11303 added a Claude-family-specific reroute to injectSystemFirst()


### PR DESCRIPTION
## Summary
- Memory injection now merges into the top-level `system` field (string or block-array) instead of unshifting a synthetic `system` role message at `messages[0]`.
- Fixes the Anthropic 400 error hit when a claude-shaped request body already carries a top-level `system` field alongside injected memory context.
- Placement fix only — memory feature behavior/flags unchanged, still enabled by default per existing config.

## Test plan
- [x] Regression test pins single injection when a leading system message and top-level system field coexist
- [x] `npm run test:unit` / targeted test file for memory injection path

Fixes #13425

⚠️ base-red inherited: #12732