### PR TITLE
fix(guardrails): preserve image base64 during credential masking

### DIFF
--- a/changelog.d/fixes/13468-credential-masker-image-integrity.md
+++ b/changelog.d/fixes/13468-credential-masker-image-integrity.md
@@ -1,0 +1,1 @@
+- **fix(guardrails):** Preserve valid base64 image transport bytes during credential masking without exempting neighboring text or authorization fields, preventing continued image-bearing sessions from failing upstream validation ([#13468](https://github.com/diegosouzapw/OmniRoute/pull/13468)) — thanks @marcelokarval

--- a/docs/security/GUARDRAILS.md
+++ b/docs/security/GUARDRAILS.md
@@ -667,10 +667,22 @@ to the upstream provider or back to the client.
   disabled unless `settings.credentialRedactionEnabled === true` **or**
   `CREDENTIAL_REDACTION_ENABLED=true`. With it off, the guardrail is a no-op —
   it never blocks and never rewrites.
-- `redactCredentials()` walks the full payload/response tree (`walkValue()`,
+- The guardrail walks the payload/response tree (`walkValue()`,
   prototype-pollution-safe, cycle-safe via `WeakSet`) and replaces matches with
   a `[REDACTED:<type>]` placeholder, cloning only the branches that actually
   changed.
+- Recognized image transport fields preserve valid base64 byte-for-byte: Chat
+  `image_url.url`, Responses `input_image.image_url`, Claude base64 image
+  `source.data`, and Gemini `inlineData.data` / `inline_data.data` with image MIME
+  types. This is transport recognition, not image decoding or secret detection
+  inside images. Neighboring text, structured authorization fields, remote URLs,
+  malformed encodings, and generic fields remain scanned. The standalone
+  `redactCredentials()` text helper has no media exemption.
+- Disabling `credentialRedactionEnabled` globally can temporarily unblock an
+  affected session, provided the environment flag is not forcing it on, but also
+  disables credential masking for unrelated requests and responses. It is not
+  the recommended permanent remedy; prefer the image-integrity fix and restore
+  protection after validating the corrected deployment.
 - `CREDENTIAL_PATTERNS` covers LLM provider keys (OpenAI, OpenAI-proj,
   Anthropic, Google, Hugging Face, Replicate), VCS/SaaS tokens (GitHub, Slack,
   Linear, Notion, npm, Postman, Discord), payment keys (Stripe, Square), cloud
@@ -683,7 +695,8 @@ to the upstream provider or back to the client.
 - The guardrail never blocks; it only rewrites (`modifiedPayload` /
   `modifiedResponse`) and annotates (`meta.credentialsRedacted`, `meta.count`).
 
-Regression guard: `tests/unit/credential-masker-guardrail.test.ts`.
+Regression guards: `tests/unit/credential-masker-guardrail.test.ts` and
+`tests/unit/credential-masker-image-integrity.test.ts`.
 
 ## Base Contract (`base.ts`)
 

--- a/src/lib/guardrails/credentialImageFields.ts
+++ b/src/lib/guardrails/credentialImageFields.ts
@@ -1,0 +1,50 @@
+/** Transport recognition only: encoded image bytes are not credential-bearing text. */
+function isBase64(value: unknown): value is string {
+  if (typeof value !== "string" || !value.length || value.length % 4 !== 0) return false;
+  const padding = value.indexOf("=");
+  const body = padding < 0 ? value : value.slice(0, padding);
+  const suffix = padding < 0 ? "" : value.slice(padding);
+  return body.length > 0 && !/[^A-Za-z0-9+/]/.test(body) && ["", "=", "=="].includes(suffix);
+}
+
+function isImageMime(value: unknown): boolean {
+  return (
+    typeof value === "string" && /^image\/[a-z0-9][a-z0-9.+-]{0,63}$/i.exec(value)?.[0] === value
+  );
+}
+
+function isImageDataUrl(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const comma = value.indexOf(",");
+  const header = value.slice(0, comma);
+  return (
+    /^data:image\/[a-z0-9][a-z0-9.+-]{0,63};base64$/i.exec(header)?.[0] === header &&
+    isBase64(value.slice(comma + 1))
+  );
+}
+
+/** Exempt only the exact binary field of a recognized image part, never its siblings. */
+export function credentialImageField(
+  record: Record<string, unknown>,
+  parentKey?: string,
+  parentType?: unknown
+): string | undefined {
+  if (record.type === "input_image" && isImageDataUrl(record.image_url)) return "image_url";
+  if (parentKey === "image_url" && parentType === "image_url" && isImageDataUrl(record.url))
+    return "url";
+  if (
+    parentKey === "source" &&
+    parentType === "image" &&
+    record.type === "base64" &&
+    isImageMime(record.media_type) &&
+    isBase64(record.data)
+  )
+    return "data";
+  if (
+    ((parentKey === "inlineData" && isImageMime(record.mimeType)) ||
+      (parentKey === "inline_data" && isImageMime(record.mime_type))) &&
+    isBase64(record.data)
+  )
+    return "data";
+  return undefined;
+}

--- a/src/lib/guardrails/credentialImageFields.ts
+++ b/src/lib/guardrails/credentialImageFields.ts
@@ -23,6 +23,14 @@ function isImageDataUrl(value: unknown): boolean {
   );
 }
 
+function isInlineImageData(record: Record<string, unknown>, parentKey?: string): boolean {
+  return (
+    ((parentKey === "inlineData" && isImageMime(record.mimeType)) ||
+      (parentKey === "inline_data" && isImageMime(record.mime_type))) &&
+    isBase64(record.data)
+  );
+}
+
 /** Exempt only the exact binary field of a recognized image part, never its siblings. */
 export function credentialImageField(
   record: Record<string, unknown>,
@@ -40,11 +48,6 @@ export function credentialImageField(
     isBase64(record.data)
   )
     return "data";
-  if (
-    ((parentKey === "inlineData" && isImageMime(record.mimeType)) ||
-      (parentKey === "inline_data" && isImageMime(record.mime_type))) &&
-    isBase64(record.data)
-  )
-    return "data";
+  if (isInlineImageData(record, parentKey)) return "data";
   return undefined;
 }

--- a/src/lib/guardrails/credentialMasker.ts
+++ b/src/lib/guardrails/credentialMasker.ts
@@ -1,6 +1,7 @@
 import { CREDENTIAL_PATTERNS } from "@omniroute/open-sse/utils/credentialPatterns.ts";
 import { getSettings } from "@/lib/db/settings";
 import { BaseGuardrail, type GuardrailContext, type GuardrailResult } from "./base";
+import { credentialImageField } from "./credentialImageFields";
 
 export { CREDENTIAL_PATTERNS };
 export type { CredentialPattern } from "@omniroute/open-sse/utils/credentialPatterns.ts";
@@ -51,7 +52,9 @@ function redactHeaderValue(value: string): string {
 function walkValue(
   value: unknown,
   detections: Array<{ type: string; count: number }>,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
+  parentKey?: string,
+  parentType?: unknown
 ): { modified: boolean; value: unknown } {
   if (typeof value === "string") {
     const r = redactCredentials(value);
@@ -76,6 +79,8 @@ function walkValue(
     if (prototype !== null && prototype !== Object.prototype) return { modified: false, value };
     seen.add(value);
     const entries = Object.entries(value as JsonRecord);
+    const record = value as JsonRecord;
+    const imageField = credentialImageField(record, parentKey, parentType);
     let next: JsonRecord | null = null;
     for (let index = 0; index < entries.length; index++) {
       const [key, entryValue] = entries[index];
@@ -83,7 +88,9 @@ function walkValue(
       const redactedHeader = structuredHeader ? redactHeaderValue(entryValue) : null;
       const r = structuredHeader
         ? { modified: redactedHeader !== entryValue, value: redactedHeader }
-        : walkValue(entryValue, detections, seen);
+        : key === imageField
+          ? { modified: false, value: entryValue }
+          : walkValue(entryValue, detections, seen, key, record.type);
       if (structuredHeader && r.modified) detections.push({ type: "auth_header", count: 1 });
       if (r.modified && !next) {
         next = Object.create(prototype) as JsonRecord;

--- a/tests/unit/credential-masker-image-integrity.test.ts
+++ b/tests/unit/credential-masker-image-integrity.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { after } from "node:test";
+import { deflateSync, inflateSync } from "node:zlib";
+
+const previousDataDir = process.env.DATA_DIR;
+const previousEnabled = process.env.CREDENTIAL_REDACTION_ENABLED;
+const dataDir = mkdtempSync(join(tmpdir(), "omniroute-13462-"));
+process.env.DATA_DIR = dataDir;
+process.env.CREDENTIAL_REDACTION_ENABLED = "true";
+const { CredentialMaskerGuardrail, redactCredentials } =
+  await import("../../src/lib/guardrails/credentialMasker.ts");
+const { resetDbInstance } = await import("../../src/lib/db/core.ts");
+after(() => {
+  resetDbInstance();
+  rmSync(dataDir, { recursive: true, force: true });
+  if (previousDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = previousDataDir;
+  if (previousEnabled === undefined) delete process.env.CREDENTIAL_REDACTION_ENABLED;
+  else process.env.CREDENTIAL_REDACTION_ENABLED = previousEnabled;
+});
+
+// Not a credential: these bytes deliberately create a regex collision in base64.
+const marker = ["AI", "za"].join("") + "A".repeat(36);
+const secret = "sk-proj-" + "x".repeat(24);
+function crc32(bytes: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+function chunk(name: string, data: Buffer): Buffer {
+  const type = Buffer.from(name);
+  const size = Buffer.alloc(4);
+  size.writeUInt32BE(data.length);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([type, data])));
+  return Buffer.concat([size, type, data, crc]);
+}
+const ihdr = Buffer.alloc(13);
+ihdr.writeUInt32BE(1, 0);
+ihdr.writeUInt32BE(1, 4);
+ihdr[8] = 8;
+ihdr[9] = 6;
+const pixels = Buffer.from([0, 255, 0, 0, 255]);
+const png = Buffer.concat([
+  Buffer.from("89504e470d0a1a0a", "hex"),
+  chunk("IHDR", ihdr),
+  chunk("raNd", Buffer.concat([Buffer.alloc(1), Buffer.from(marker, "base64")])),
+  chunk("IDAT", deflateSync(pixels)),
+  chunk("IEND", Buffer.alloc(0)),
+]);
+const encoded = png.toString("base64");
+const url = "data:image/png;base64," + encoded;
+const guardrail = new CredentialMaskerGuardrail();
+
+test("13462: fixture has valid PNG chunks, pixels, and a synthetic credential collision", () => {
+  assert.equal(png.length, 113);
+  assert.ok(encoded.includes(marker));
+  for (let offset = 8; offset < png.length;) {
+    const size = png.readUInt32BE(offset);
+    const typeAndData = png.subarray(offset + 4, offset + 8 + size);
+    assert.equal(png.readUInt32BE(offset + 8 + size), crc32(typeAndData));
+    if (typeAndData.subarray(0, 4).toString() === "IDAT") {
+      assert.deepEqual(inflateSync(typeAndData.subarray(4)), pixels);
+    }
+    offset += size + 12;
+  }
+  // The text helper must continue to redact token-like text, including this string.
+  assert.equal(redactCredentials(url).modified, true);
+});
+
+const cases = [
+  {
+    name: "Chat",
+    image: { type: "image_url", image_url: { url, detail: secret } },
+    expected: { type: "image_url", image_url: { url, detail: "[REDACTED:openai]" } },
+  },
+  {
+    name: "Responses",
+    image: { type: "input_image", image_url: url },
+    expected: { type: "input_image", image_url: url },
+  },
+  {
+    name: "Claude",
+    image: {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: encoded, note: secret },
+    },
+    expected: {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: encoded, note: "[REDACTED:openai]" },
+    },
+  },
+  {
+    name: "Gemini",
+    image: { inlineData: { mimeType: "image/png", data: encoded, note: secret } },
+    expected: { inlineData: { mimeType: "image/png", data: encoded, note: "[REDACTED:openai]" } },
+  },
+  {
+    name: "Gemini snake case",
+    image: { inline_data: { mime_type: "image/png", data: encoded } },
+    expected: { inline_data: { mime_type: "image/png", data: encoded } },
+  },
+];
+for (const entry of cases) {
+  for (const stage of ["preCall", "postCall"] as const) {
+    test(`13462: ${stage} preserves ${entry.name} image bytes and masks neighboring text`, async () => {
+      const payload = {
+        content: [entry.image],
+        text: secret,
+        headers: { Authorization: "Bearer short" },
+      };
+      const snapshot = structuredClone(payload);
+      const result = await guardrail[stage](payload, {});
+      const actual = stage === "preCall" ? result?.modifiedPayload : result?.modifiedResponse;
+      assert.deepEqual(actual, {
+        content: [entry.expected],
+        text: "[REDACTED:openai]",
+        headers: { Authorization: "Bearer [REDACTED:auth_header]" },
+      });
+      assert.deepEqual(payload, snapshot, "caller-owned payload is not mutated");
+    });
+  }
+}
+
+test("13462: a mock strict upstream receives the same PNG after the guardrail", async () => {
+  const input = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: secret },
+          { type: "image_url", image_url: { url } },
+        ],
+      },
+    ],
+  };
+  const result = await guardrail.preCall(input, {});
+  const outgoing = (result?.modifiedPayload ?? input) as typeof input;
+  const serialized = JSON.stringify(outgoing);
+  const upstream = JSON.parse(serialized) as typeof input;
+  const image = upstream.messages[0].content[1].image_url!.url;
+  const data = image.slice(image.indexOf(",") + 1);
+  assert.match(data, /^[A-Za-z0-9+/]*={0,2}$/);
+  assert.deepEqual(Buffer.from(data, "base64"), png);
+  assert.equal(upstream.messages[0].content[0].text, "[REDACTED:openai]");
+});
+
+test("13462: generic fields, remote URLs, malformed media and text remain scanned", async () => {
+  const payload = {
+    data: encoded,
+    url,
+    image_url: url,
+    text: url,
+    blocks: [
+      { type: "text", image_url: url },
+      { type: "input_image", image_url: "https://example.com/" + marker },
+      { type: "input_image", image_url: url + "!" },
+      { type: "image_url", image_url: { url: "data:text/plain;base64," + encoded } },
+      { source: { type: "base64", media_type: "image/png", data: encoded } },
+      { type: "image", source: { type: "text", media_type: "image/png", data: encoded } },
+      { inlineData: { mimeType: "text/plain", data: encoded } },
+      { inlineData: { mimeType: "image/png", data: encoded + "!" } },
+      { inlineData: { mimeType: "image/png\n", data: encoded } },
+      { type: "input_image", image_url: "data:image/png;base64\n," + encoded },
+      { inlineData: { mimeType: "image/png", data: encoded + "====" } },
+    ],
+  };
+  const result = await guardrail.preCall(payload, {});
+  assert.ok(result?.modifiedPayload);
+  assert.ok(!JSON.stringify(result.modifiedPayload).includes(marker));
+});
+
+test("13462: shared image objects do not grant exemptions to generic references", async () => {
+  const shared = { url };
+  const payload = { image: { type: "image_url", image_url: shared }, generic: shared };
+  const result = await guardrail.preCall(payload, {});
+  const actual = result?.modifiedPayload as typeof payload;
+  assert.equal(actual.image.image_url.url, url);
+  assert.ok(!actual.generic.url.includes(marker));
+  assert.equal(shared.url, url);
+});
+
+test("13462: image-only payload is unchanged without unnecessary cloning", async () => {
+  const result = await guardrail.preCall({ input: [{ type: "input_image", image_url: url }] }, {});
+  assert.equal(result?.modifiedPayload, undefined);
+});
+
+test("13462: disabled guardrail preserves images and text", async () => {
+  process.env.CREDENTIAL_REDACTION_ENABLED = "false";
+  try {
+    const payload = { input: [{ type: "input_image", image_url: url }], text: secret };
+    assert.equal((await guardrail.preCall(payload, {}))?.modifiedPayload, undefined);
+    assert.equal((await guardrail.postCall(payload, {}))?.modifiedResponse, undefined);
+    assert.equal(payload.text, secret);
+  } finally {
+    process.env.CREDENTIAL_REDACTION_ENABLED = "true";
+  }
+});


### PR DESCRIPTION
## CI reconciliation update

The PR-owned complexity regression is corrected in `1727c18ff`. Fresh local checks pass (32 focused tests, core typecheck, complexity ratchets, changed-file lint and hooks). The previous CI run contains inherited failures: 50 of its 51 failing unit tests were reproduced on the exact clean base; the remaining timing failure is unresolved. New CI and maintainer review remain pending. See the [detailed attribution and reproduction commands](https://github.com/diegosouzapw/OmniRoute/pull/13468#issuecomment-5648134842).

## Summary

- Preserve base64 image transport bytes in CredentialMaskerGuardrail instead of applying credential regular expressions to encoded media.
- Recognize only the exact binary field in Chat Completions, Responses, Claude and Gemini image parts. Continue masking neighboring text, tool content, structured authorization values, generic fields, remote URLs and malformed encodings.
- Apply the same behavior to preCall and postCall without changing the standalone text redactor, credential patterns, opt-in settings, priorities, or routing.
- Document the temporary global-disable workaround and its security cost.

## Related Issues

Closes #13462.
Related to #7683 (credential masker introduction); error-message sanitization is a separate concern from outgoing payload integrity.

**Target: release/v3.8.51 only**, based on `152d95108c9c3d557562311ffed63240a511eb31`. Version 3.8.50 is the affected closed release, not a contribution target. No backport, release deployment, service restart, or local runtime/configuration change is part of this PR.

⚠️ base-red inherited: #12732

Requested triage labels: `bug`, `backend` (maintainer permissions required).

## Failure and fix

A valid image's base64 can coincidentally match a provider-token pattern. The recursive string walker replaced that match with a redaction placeholder, making the image invalid. A strict Responses upstream then rejected the historical attachment, so retries and subsequent turns remained blocked by the same image.

The regression fixture generates a valid 1×1 PNG with a private ancillary chunk whose base64 deliberately contains a synthetic Google-pattern collision. CRCs and inflated pixels are checked. No real credentials, private images, customer paths or session identifiers are included.

A small transport-recognition helper identifies the binary leaf; the walker carries only its immediate parent key/type. It does not skip entire objects. Shared references are visited in their own context, so an image reference does not grant a generic reference an exemption. Recognition is not image decoding, OCR, malware inspection, or secret detection inside media.

## Validation

- [x] Change type: other — guardrail/security payload integrity.
- [x] TDD: new image-preservation assertions failed on the unmodified masker with the synthetic redaction placeholder in the image. They passed after the fix.
- [x] Focused tests: **32 passed, 0 failed** across the three files below.
- [x] `npm run typecheck:core`.
- [x] `check:complexity-ratchets -- --base-ref 152d95108c9c3d557562311ffed63240a511eb31`: zero new complexity/cognitive-complexity violations after the scoped refactor.
- [x] Staged-file ESLint, formatting and all commit hooks.
- [x] `check:changelog-integrity`, `check:docs-sync`, `check:docs-frontmatter`, and `git diff --check`.
- [ ] Full `npm run lint`: not green — four inherited errors, reproduced on the clean base (details below). Changed-file ESLint passed.
- [x] Production-code changes include automated regression tests.
- [x] Active release base rechecked against upstream; no release freeze found.
- [ ] CI's full unit suite, coverage, build and broader gates: pending.

Focused command:

```sh
DISABLE_SQLITE_AUTO_BACKUP=true node --import tsx/esm \
  --import ./tests/_setup/isolateDataDir.ts --test \
  tests/unit/credential-masker-guardrail.test.ts \
  tests/unit/credential-masker-image-integrity.test.ts \
  tests/unit/error-sensitive-redaction.test.ts
```

Tests use disposable isolated data directories, not the running gateway's database.

### Inherited checks, reproduced on a clean detached base

- Full `npm run lint` reports four errors in untouched tests: unused `ResourcePressureRuntime` at `tests/unit/resource-pressure-self-restart.test.ts:14`, and explicit `any` at `tests/unit/volcengine-plan-binding-upsert.test.ts:70`, `:96`, `:120`. Targeted lint of these same files on the clean base reproduces all four errors. The full run also reports stale suppressions; this PR does not prune or weaken the shared suppression baseline.

- `npm run check:docs-all` stops at `check:docs-counts`: seven existing strict provider-count drifts in the provider reference and SVGs. Documentation version sync and frontmatter pass.
- `npm run check:file-size`: existing `open-sse/utils/stream.ts` has 3115 lines against its frozen 3098 limit. New test-file size check passes.
- Neither unrelated source nor quality baselines are changed to hide these failures.

## Tests Added Or Updated

Added `tests/unit/credential-masker-image-integrity.test.ts`:

- Valid PNG construction, chunk CRC and inflated-pixel proof.
- Byte preservation on preCall/postCall for Chat, Responses, Claude and both Gemini naming conventions.
- Adjacent credential and authorization masking; original payload immutability.
- Mock strict-upstream serialization/byte-equality boundary.
- Negative controls for generic fields, remote URLs, wrong media types, malformed base64/padding and newline-tainted media headers.
- Context-sensitive shared references, no unnecessary image-only cloning, and disabled mode.

Existing `credential-masker-guardrail.test.ts` and `error-sensitive-redaction.test.ts` were rerun unchanged.

## Coverage Notes

The new tests exercise both public guardrail stages and the image-leaf recognition branches. The standalone credential pattern catalog and public error sanitization remain covered by the existing regression tests. The mock boundary is not a real HTTP/provider end-to-end test. Full coverage ratchets remain CI-owned; no coverage increase or full harness qualification is claimed.

## Reviewer Notes

The affected operator temporarily disabled `credentialRedactionEnabled` globally through the supported settings API and reported the original session resumed. This also removes credential masking from unrelated request/response text when no environment override forces it on. It is an emergency mitigation, not the proposed permanent fix.

This PR does **not** re-enable that running deployment's setting. After the corrected version is released/deployed, re-enable protection and validate both image continuity and text credential masking before declaring operational recovery complete.

No schema migration, new dependency, model catalog change, broad `data`/`url` exemption, or credential-pattern weakening. Independent maintainer review and CI are still required; local diff review is not presented as independent approval.

Changelog: `changelog.d/fixes/13468-credential-masker-image-integrity.md`. Final tested head: `1727c18ff930f10e862f5dd8f7cc27b4fba89e4e`.

