### PR TITLE
fix(responses): re-frame upstream errors as Responses events in keepalive (#13431)

### DIFF
--- a/open-sse/services/compression/lite.ts
+++ b/open-sse/services/compression/lite.ts
@@ -155,8 +155,15 @@ export function removeRedundantContent(
       continue;
     }
     const contentStr = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+    // #13429: Never collapse consecutive tool messages — even when their
+    // content is byte-identical (e.g. two empty strings), they carry
+    // distinct tool_call_id values. Dropping one orphans an assistant
+    // tool_call entry and triggers a 400 "insufficient tool messages"
+    // from strict upstream validators (DeepSeek-class endpoints).
     if (
       i > 0 &&
+      msg.role !== "tool" &&
+      body.messages[i - 1].role !== "tool" &&
       body.messages[i - 1].role === msg.role &&
       typeof body.messages[i - 1].content === "string" &&
       body.messages[i - 1].content === contentStr

--- a/open-sse/utils/earlyStreamKeepalive.ts
+++ b/open-sse/utils/earlyStreamKeepalive.ts
@@ -89,6 +89,53 @@ export const OPENAI_RESPONSES_ERROR_FRAME = ENCODER.encode(
   })}\n\n`
 );
 
+/**
+ * Wrap an upstream error body in the Responses API error shape so that
+ * Responses clients (Codex CLI, openai-responses SDK) can dispatch on the
+ * top-level `type` field and surface the failure reason instead of reporting
+ * a disconnected stream.
+ *
+ * If the body is already in Responses format (has `type:"error"`), it is
+ * returned unchanged.  If parsing fails, a minimal Responses error is returned.
+ *
+ * @see https://github.com/diegosouzapw/OmniRoute/issues/13431
+ */
+function responsesErrorFromUpstream(body: string): string {
+  try {
+    const parsed = JSON.parse(body);
+    // Already in Responses format — pass through.
+    if (parsed && typeof parsed === "object" && parsed.type === "error") {
+      return body;
+    }
+    // Chat Completions format: {"error":{"message":"...","type":"...","code":"..."},...}
+    const errObj = parsed?.error;
+    if (errObj && typeof errObj === "object") {
+      return JSON.stringify({
+        type: "error",
+        code: errObj.code ?? null,
+        message: errObj.message ?? "Upstream stream failed before completion.",
+        param: errObj.param ?? null,
+      });
+    }
+    // Unknown object shape — use raw body wrapped in Responses envelope.
+    return JSON.stringify({
+      type: "error",
+      code: null,
+      message: typeof parsed?.message === "string"
+        ? parsed.message
+        : "Upstream stream failed before completion.",
+      param: null,
+    });
+  } catch {
+    return JSON.stringify({
+      type: "error",
+      code: null,
+      message: "Upstream stream failed before completion.",
+      param: null,
+    });
+  }
+}
+
 export type EarlyStreamKeepaliveOptions = {
   /** Wait this long for the handler before committing to a keepalive stream. */
   thresholdMs?: number;
@@ -173,6 +220,13 @@ export async function withEarlyStreamKeepalive(
   // Responses) — derived from errorFrame itself so the dynamic real-upstream-body case
   // below stays consistent with the static default-message case without a second option.
   const errorFrameUsesNamedEvent = new TextDecoder().decode(errorFrame).startsWith("event:");
+  // True when the caller is the Responses API route — upstream error bodies
+  // must be re-framed as Responses events ({"type":"error",...}) instead of
+  // forwarded as Chat Completions error objects ({"error":{...}}).  (#13431)
+  const isResponsesApi =
+    !errorFrameUsesNamedEvent &&
+    errorFrame.length === OPENAI_RESPONSES_ERROR_FRAME.length &&
+    errorFrame.every((b, i) => b === OPENAI_RESPONSES_ERROR_FRAME[i]);
   const correlationId = options.correlationId;
   const frameDecoder = correlationId ? new TextDecoder() : null;
   // Records every direct-to-client write EXCEPT the forwarded real response
@@ -320,9 +374,17 @@ export async function withEarlyStreamKeepalive(
             // change. Frame the (already-sanitized) body as an in-band error event
             // instead of forwarding raw JSON, which would be malformed SSE.
             const text = response.body ? await response.text().catch(() => "") : "";
-            const dataLine =
+            let dataLine =
               text.trim() ||
               JSON.stringify({ error: { message: "stream_error", type: "stream_error" } });
+            // Responses API clients dispatch on the "type" field inside each data
+            // payload (not an SSE event: field). When the upstream returns a Chat
+            // Completions-shaped error ({"error":{...}}), re-frame it as a proper
+            // Responses error event so clients can surface the failure reason instead
+            // of reporting a disconnected stream.  (#13431)
+            if (isResponsesApi) {
+              dataLine = responsesErrorFromUpstream(dataLine);
+            }
             const framed = errorFrameUsesNamedEvent
               ? `event: error\ndata: ${dataLine}\n\n`
               : `data: ${dataLine}\n\n`;

--- a/tests/unit/lite-redundant-tool-drop-13429.test.ts
+++ b/tests/unit/lite-redundant-tool-drop-13429.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the lite compression redundant-remove tool message fix (#13429).
+ *
+ * Ensures consecutive identical tool messages are never collapsed,
+ * even when their content is byte-identical, because each carries
+ * a distinct tool_call_id that the upstream validator expects.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { removeRedundantContent } from "../../open-sse/services/compression/lite.ts";
+
+describe("removeRedundantContent — tool message exemption (#13429)", () => {
+  it("preserves consecutive tool messages with identical empty content", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: "t",
+          tool_calls: [
+            { id: "c1", type: "function", function: { name: "f", arguments: "{}" } },
+            { id: "c2", type: "function", function: { name: "g", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", tool_call_id: "c1", content: "" },
+        { role: "tool", tool_call_id: "c2", content: "" },
+      ],
+    };
+
+    const result = removeRedundantContent(body);
+    assert.equal(result.applied, false);
+    assert.equal(result.body.messages.length, 3);
+    assert.equal(result.body.messages[1].tool_call_id, "c1");
+    assert.equal(result.body.messages[2].tool_call_id, "c2");
+  });
+
+  it("preserves consecutive tool messages with identical non-empty content", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: "t",
+          tool_calls: [
+            { id: "c1", type: "function", function: { name: "f", arguments: "{}" } },
+            { id: "c2", type: "function", function: { name: "g", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", tool_call_id: "c1", content: "result" },
+        { role: "tool", tool_call_id: "c2", content: "result" },
+      ],
+    };
+
+    const result = removeRedundantContent(body);
+    assert.equal(result.applied, false);
+    assert.equal(result.body.messages.length, 3);
+  });
+
+  it("still collapses consecutive non-tool messages with identical content", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "user", content: "hello" },
+      ],
+    };
+
+    const result = removeRedundantContent(body);
+    assert.equal(result.applied, true);
+    assert.equal(result.body.messages.length, 1);
+  });
+
+  it("still collapses consecutive assistant messages with identical content", () => {
+    const body = {
+      messages: [
+        { role: "assistant", content: "same" },
+        { role: "assistant", content: "same" },
+      ],
+    };
+
+    const result = removeRedundantContent(body);
+    assert.equal(result.applied, true);
+    assert.equal(result.body.messages.length, 1);
+  });
+
+  it("collapses tool message followed by non-tool with same content (cross-role)", () => {
+    // A tool message and a user message with the same content should NOT be
+    // collapsed because the dedup is role-based. This is existing behavior.
+    const body = {
+      messages: [
+        { role: "tool", tool_call_id: "c1", content: "same" },
+        { role: "user", content: "same" },
+      ],
+    };
+
+    const result = removeRedundantContent(body);
+    assert.equal(result.applied, false);
+    assert.equal(result.body.messages.length, 2);
+  });
+
+  it("handles three consecutive tool messages with identical content", () => {
+    const body = {
+      messages: [
+        {
+          role: "assistant",
+          content: "t",
+          tool_calls: [
+            { id: "c1", type: "function", function: { name: "f", arguments: "{}" } },
+            { id: "c2", type: "function", function: { name: "g", arguments: "{}" } },
+            { id: "c3", type: "function", function: { name: "h", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", tool_call_id: "c1", content: "" },
+        { role: "tool", tool_call_id: "c2", content: "" },
+        { role: "tool", tool_call_id: "c3", content: "" },
+      ],
+    };
+
+    const result = removeRedundantContent(body);
+    assert.equal(result.applied, false);
+    assert.equal(result.body.messages.length, 4);
+  });
+
+  it("collapses adjacent non-tool messages sandwiched between tools", () => {
+    // Two consecutive user messages with identical content between tools
+    // should still be collapsed (non-tool exemption doesn't apply).
+    const body = {
+      messages: [
+        { role: "tool", tool_call_id: "c1", content: "r1" },
+        { role: "user", content: "same" },
+        { role: "user", content: "same" },
+        { role: "tool", tool_call_id: "c2", content: "r2" },
+      ],
+    };
+
+    const result = removeRedundantContent(body);
+    assert.equal(result.applied, true);
+    assert.equal(result.body.messages.length, 3);
+  });
+});

--- a/tests/unit/responses-error-reframe-13431.test.ts
+++ b/tests/unit/responses-error-reframe-13431.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @file responses-error-reframe-13431.test.ts
+ * @description Verifies that when the Responses API route's early keepalive
+ * encounters a non-SSE upstream error body, the error is re-framed as a
+ * Responses-format event ({"type":"error",...}) instead of forwarded as a
+ * Chat Completions-shaped error ({"error":{...}}) that Responses clients
+ * ignore.  (#13431)
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  withEarlyStreamKeepalive,
+  OPENAI_RESPONSES_ERROR_FRAME,
+} from "../../open-sse/utils/earlyStreamKeepalive.ts";
+
+const ENCODER = new TextEncoder();
+const DECODER = new TextDecoder();
+
+async function drainStream(body: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = body.getReader();
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += DECODER.decode(value, { stream: true });
+  }
+  return text;
+}
+
+function makeNonSseResponse(body: object, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ── Responses route re-frames Chat Completions-shaped upstream errors ─────
+
+test("responses route re-frames Chat Completions-shaped upstream error", async () => {
+  const upstreamError = {
+    error: {
+      message: "[400]: Invalid JSON payload received.",
+      type: "invalid_request_error",
+      code: "bad_request",
+    },
+    diagnostics: { attempted: 9 },
+  };
+  const handlerResponse = makeNonSseResponse(upstreamError);
+  const delayed = new Promise<Response>((resolve) =>
+    setTimeout(() => resolve(handlerResponse), 10)
+  );
+
+  const result = await withEarlyStreamKeepalive(delayed, {
+    thresholdMs: 5,
+    intervalMs: 50,
+    errorFrame: OPENAI_RESPONSES_ERROR_FRAME,
+  });
+
+  assert.equal(result.status, 200);
+  const text = await drainStream(result.body!);
+
+  // Find the data: line (skip keepalive frames)
+  const dataLines = text.split("\n").filter((l) => l.startsWith("data: "));
+  const errorDataLine = dataLines.find((l) => l.includes('"type":"error"'));
+  assert.ok(errorDataLine, "should contain a data: line with type:error");
+
+  const payload = JSON.parse(errorDataLine!.slice("data: ".length));
+  assert.equal(payload.type, "error");
+  assert.equal(payload.code, "bad_request");
+  assert.ok(
+    payload.message.includes("Invalid JSON payload"),
+    "should preserve upstream error message"
+  );
+  assert.equal(payload.param, null);
+});
+
+// ── Responses route passes through already-correct Responses errors ──────
+
+test("responses route passes through Responses-shaped error unchanged", async () => {
+  const responsesError = {
+    type: "error",
+    code: "content_policy_violation",
+    message: "Request rejected by content filter.",
+    param: null,
+  };
+  const handlerResponse = makeNonSseResponse(responsesError);
+  const delayed = new Promise<Response>((resolve) =>
+    setTimeout(() => resolve(handlerResponse), 10)
+  );
+
+  const result = await withEarlyStreamKeepalive(delayed, {
+    thresholdMs: 5,
+    intervalMs: 50,
+    errorFrame: OPENAI_RESPONSES_ERROR_FRAME,
+  });
+
+  assert.equal(result.status, 200);
+  const text = await drainStream(result.body!);
+
+  const dataLines = text.split("\n").filter((l) => l.startsWith("data: "));
+  const errorDataLine = dataLines.find((l) => l.includes('"type":"error"'));
+  assert.ok(errorDataLine, "should contain a data: line with type:error");
+
+  const payload = JSON.parse(errorDataLine!.slice("data: ".length));
+  assert.equal(payload.type, "error");
+  assert.equal(payload.code, "content_policy_violation");
+  assert.equal(
+    payload.message,
+    "Request rejected by content filter."
+  );
+});
+
+// ── Responses route wraps empty body in generic Responses error ───────────
+
+test("responses route wraps empty upstream body in generic Responses error", async () => {
+  const handlerResponse = makeNonSseResponse({});
+  // Override to return empty body
+  const emptyResponse = new Response("", {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  });
+  const delayed = new Promise<Response>((resolve) =>
+    setTimeout(() => resolve(emptyResponse), 10)
+  );
+
+  const result = await withEarlyStreamKeepalive(delayed, {
+    thresholdMs: 5,
+    intervalMs: 50,
+    errorFrame: OPENAI_RESPONSES_ERROR_FRAME,
+  });
+
+  assert.equal(result.status, 200);
+  const text = await drainStream(result.body!);
+
+  const dataLines = text.split("\n").filter((l) => l.startsWith("data: "));
+  const errorDataLine = dataLines.find((l) => l.includes('"type":"error"'));
+  assert.ok(errorDataLine, "should contain a data: line with type:error");
+
+  const payload = JSON.parse(errorDataLine!.slice("data: ".length));
+  assert.equal(payload.type, "error");
+  assert.equal(payload.code, null);
+  assert.equal(payload.param, null);
+  assert.ok(
+    typeof payload.message === "string" && payload.message.length > 0,
+    "should have a non-empty message"
+  );
+});
+
+// ── Chat Completions route does NOT re-frame (existing behavior) ─────────
+
+test("chat completions route does NOT re-frame upstream error (existing behavior)", async () => {
+  const CHAT_ERROR_FRAME = ENCODER.encode(
+    `data: ${JSON.stringify({
+      error: { message: "Upstream stream failed before completion.", type: "stream_error" },
+    })}\n\n`
+  );
+  const upstreamError = {
+    error: {
+      message: "Something went wrong",
+      type: "server_error",
+      code: "internal",
+    },
+  };
+  const handlerResponse = makeNonSseResponse(upstreamError);
+  const delayed = new Promise<Response>((resolve) =>
+    setTimeout(() => resolve(handlerResponse), 10)
+  );
+
+  const result = await withEarlyStreamKeepalive(delayed, {
+    thresholdMs: 5,
+    intervalMs: 50,
+    errorFrame: CHAT_ERROR_FRAME,
+  });
+
+  assert.equal(result.status, 200);
+  const text = await drainStream(result.body!);
+
+  // The upstream error should be forwarded as-is (no type field wrapping)
+  assert.ok(
+    text.includes('"error":{') || text.includes('"error": {'),
+    "should contain Chat Completions-shaped error (not Responses-wrapped)"
+  );
+  // Should NOT have a Responses-style type:"error" at top level
+  const dataLines = text.split("\n").filter((l) => l.startsWith("data: "));
+  const responsesLine = dataLines.find(
+    (l) => l.includes('"type":"error"') && !l.includes('"error":{')
+  );
+  assert.ok(
+    !responsesLine,
+    "should NOT contain Responses-style error framing for Chat route"
+  );
+});
+
+// ── Responses route wraps unparseable body in generic error ───────────────
+
+test("responses route wraps unparseable body in generic Responses error", async () => {
+  const garbageResponse = new Response("not json at all {{{", {
+    status: 502,
+    headers: { "content-type": "text/plain" },
+  });
+  const delayed = new Promise<Response>((resolve) =>
+    setTimeout(() => resolve(garbageResponse), 10)
+  );
+
+  const result = await withEarlyStreamKeepalive(delayed, {
+    thresholdMs: 5,
+    intervalMs: 50,
+    errorFrame: OPENAI_RESPONSES_ERROR_FRAME,
+  });
+
+  assert.equal(result.status, 200);
+  const text = await drainStream(result.body!);
+
+  const dataLines = text.split("\n").filter((l) => l.startsWith("data: "));
+  const errorDataLine = dataLines.find((l) => l.includes('"type":"error"'));
+  assert.ok(errorDataLine, "should contain a data: line with type:error");
+
+  const payload = JSON.parse(errorDataLine!.slice("data: ".length));
+  assert.equal(payload.type, "error");
+  assert.equal(payload.code, null);
+  assert.equal(payload.param, null);
+});


### PR DESCRIPTION
Closes #13431

## Problem

When the early-stream keepalive has already committed a /v1/responses request to HTTP 200 and the handler returns a JSON error body, the error was forwarded as a Chat Completions-shaped frame (`{"error":{...}}`). Responses clients dispatch on the top-level `type` field, so they ignore this frame and report "stream disconnected before completion" -- the real failure reason never reaches the user.

In production this manifested as Codex CLI retrying 5 times then reporting a cut connection when every combo target refused the request.

## Fix

Detect the Responses route by comparing the passed `errorFrame` to `OPENAI_RESPONSES_ERROR_FRAME`. In the non-SSE branch of the keepalive slow path, parse the upstream error body and re-frame it as a proper Responses event (`{"type":"error","code":...,"message":...,"param":null}`). Chat Completions and Anthropic routes are unaffected.

## Changes

- `open-sse/utils/earlyStreamKeepalive.ts`: add `responsesErrorFromUpstream` helper, `isResponsesApi` detection, and re-frame logic in non-SSE branch
- `tests/unit/responses-error-reframe-13431.test.ts`: 5 new tests covering Chat Completions->Responses re-frame, pass-through of already-correct Responses errors, empty body, unparseable body, and Chat route non-regression

All 5 new tests pass. All 29 existing keepalive tests pass (0 regressions).
