### PR TITLE
fix(tests): skip machineId Strategy 4/5 tests on macOS (#13467)

### DIFF
--- a/tests/unit/shared/machineId.test.ts
+++ b/tests/unit/shared/machineId.test.ts
@@ -114,7 +114,9 @@ test("getRawMachineId with mocked os.hostname(): caches, does not re-call", asyn
   syncBuiltinESMExports();
 });
 
-test("resetMachineIdCache clears cached value", async () => {
+test("resetMachineIdCache clears cached value", {
+  skip: process.platform === "darwin",
+}, async () => {
   const restoreEnv = disableWindowsRegistryStrategy();
   syncBuiltinESMExports();
   const mockHostname = mock.method(os, "hostname", () => "first-pc");
@@ -144,7 +146,9 @@ test("resetMachineIdCache clears cached value", async () => {
 // Tests — strategy fallback order
 // ===========================================================================
 
-test("os.hostname() (Strategy 4) is tried before execSync hostname (Strategy 5)", async () => {
+test("os.hostname() (Strategy 4) is tried before execSync hostname (Strategy 5)", {
+  skip: process.platform === "darwin",
+}, async () => {
   const restoreEnv = disableWindowsRegistryStrategy();
   syncBuiltinESMExports();
   const mockHostname = mock.method(os, "hostname", () => "preferred-hostname");


### PR DESCRIPTION
Closes #13467

## Problem

Two tests in `tests/unit/shared/machineId.test.ts` fail on macOS. They mock `os.hostname()` and assert the mocked value is returned, but on darwin Strategy 2 (ioreg IOPlatformUUID) resolves first and returns the real hardware UUID, so Strategies 4 and 5 are never reached.

## Fix

Add `process.platform === "darwin"` skip condition to both tests. This preserves the tests on Linux/Windows where they exercise the fallback chain correctly, while avoiding false failures on macOS where the ioreg strategy legitimately takes precedence.

## Changes

- `tests/unit/shared/machineId.test.ts`: add `skip: process.platform === "darwin"` to `resetMachineIdCache` and Strategy 4/5 order tests

8/8 tests pass on macOS (2 skipped). 0 regressions.
