### PR TITLE
fix(mistral): strip GLM thinking params

### DIFF
--- a/open-sse/translator/paramSupport.ts
+++ b/open-sse/translator/paramSupport.ts
@@ -50,6 +50,8 @@ const STRIP_RULES: StripRule[] = [
   // (format:"openai") does not accept the Claude-style `thinking` body field
   // and returns 400 "Unsupported parameter(s): thinking". Upstream #2268.
   { provider: "nvidia", match: /minimax-m2\.7/i, drop: ["thinking"] },
+  // Mistral GLM 5.2 rejects Claude-style thinking payloads.
+  { provider: "mistral", match: /(?:^|\/)zai-glm-5(?:[.-])2\b/i, drop: ["thinking", "reasoning"] },
   // NVIDIA NIM: OpenAI-compatible wrapper 400s on `prompt_cache_key` (Codex CLI
   // injects it natively for its own prompt caching). NIM has no documented
   // support for this field (providerSupportsCaching already treats nvidia as

--- a/tests/unit/executors-strip-unsupported-params.test.ts
+++ b/tests/unit/executors-strip-unsupported-params.test.ts
@@ -129,6 +129,16 @@ test("stripUnsupportedParams: drops reasoning for nvidia z-ai/glm-5.2", () => {
   assert.equal(body.model, "z-ai/glm-5.2", "model must not be touched");
 });
 
+test("stripUnsupportedParams: drops thinking for mistral zai-glm-5-2", () => {
+  const body: Record<string, unknown> = {
+    thinking: { type: "enabled", budget_tokens: 10240 },
+    reasoning: { effort: "high" },
+  };
+  stripUnsupportedParams("mistral", "zai-glm-5-2", body);
+  assert.equal(body.thinking, undefined);
+  assert.equal(body.reasoning, undefined);
+});
+
 test("stripUnsupportedParams: nvidia z-ai/glm-5.1 keeps reasoning (rule is 5.2-only)", () => {
   const body: Record<string, unknown> = {
     model: "z-ai/glm-5.1",


### PR DESCRIPTION
Mistral GLM 5.2 is exposed under model ID `zai-glm-5-2`, while existing matching only covered dotted `zai-glm-5.2`.

This caused Claude-style `thinking` and `reasoning` fields to reach Mistral and produce HTTP 422 `extra_forbidden`.

Changes:
- Match both dotted and hyphenated model IDs.
- Add regression coverage for `mistral/zai-glm-5-2`.

Validation:
- Docker image builds successfully.
- Container health check passes.
- Hermes smoke request returns HTTP 200.