### PR TITLE
fix(logging): use per-attempt traceId as call log id to prevent UNIQUE collision (#13481)

### DIFF
--- a/open-sse/handlers/chatCore/attemptLogging.ts
+++ b/open-sse/handlers/chatCore/attemptLogging.ts
@@ -458,8 +458,13 @@ export function persistAttemptLogs(args: PersistAttemptLogsArgs, ctx: PersistAtt
     }
   }
 
+  // #13481: Each combo attempt must get its own log id. Previously all attempts
+  // shared `pendingRequestId`, so the successful member's insert hit the UNIQUE
+  // constraint and was silently dropped — only failed steps appeared in the dashboard.
+  // `traceId` is unique per attempt (emitted in `request.started`) and pairs with
+  // the lifecycle events; `pendingRequestId` stays in `correlationId` for grouping.
   saveCallLog({
-    id: pendingRequestId,
+    id: traceId,
     method: "POST",
     path: clientRawRequest?.endpoint || "/v1/chat/completions",
     status,

--- a/tests/unit/13481-combo-calllog-unique-collision.test.ts
+++ b/tests/unit/13481-combo-calllog-unique-collision.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #13481 — Combo failover: successful attempt's call log dropped because all
+ * attempts shared `pendingRequestId` as the log id, triggering UNIQUE constraint
+ * collisions. The fix uses the per-attempt `traceId` as the id (unique per attempt)
+ * while keeping `pendingRequestId` in `correlationId` for grouping.
+ *
+ * Verifies: two `saveCallLog` calls under the same correlationId but different
+ * trace ids must both be persisted and readable.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-13481-calllog-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const { saveCallLog, getCallLogById } = await import("../../src/lib/usageDb.ts");
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+test("#13481 two attempts with different trace ids under same correlation both persist", async () => {
+  const pendingRequestId = "req-test-13481-shared";
+  const traceId1 = "trace-attempt-1-failed";
+  const traceId2 = "trace-attempt-2-success";
+
+  // Attempt 1: failed member (400)
+  await saveCallLog({
+    id: traceId1,
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 400,
+    model: "test-model",
+    requestedModel: "test-model",
+    provider: "test-provider",
+    duration: 2000,
+    tokens: {},
+    error: "Model unavailable",
+    correlationId: pendingRequestId,
+  });
+
+  // Attempt 2: successful member (200) — this was silently dropped before the fix
+  // because it shared the same id as attempt 1.
+  await saveCallLog({
+    id: traceId2,
+    method: "POST",
+    path: "/v1/chat/completions",
+    status: 200,
+    model: "test-model",
+    requestedModel: "test-model",
+    provider: "test-provider",
+    duration: 5000,
+    tokens: { prompt_tokens: 100, completion_tokens: 50 },
+    correlationId: pendingRequestId,
+  });
+
+  // Both logs must be readable
+  const log1 = await getCallLogById(traceId1);
+  const log2 = await getCallLogById(traceId2);
+
+  assert.ok(log1, "attempt 1 (400) must be persisted");
+  assert.equal(log1!.status, 400, "attempt 1 status must be 400");
+  assert.equal(log1!.correlationId, pendingRequestId, "attempt 1 correlationId must match");
+
+  assert.ok(log2, "attempt 2 (200) must be persisted — not silently dropped");
+  assert.equal(log2!.status, 200, "attempt 2 status must be 200");
+  assert.equal(log2!.correlationId, pendingRequestId, "attempt 2 correlationId must match");
+});


### PR DESCRIPTION
## Summary

Fixes #13481. All combo failover attempts shared  as the . The first attempt (failed member) inserts the row; the successful member's insert then hits the UNIQUE constraint and is silently dropped. Only failed steps appear in the dashboard while clients are being served normally.

## Fix

Use  (unique per attempt, emitted in ) as the log id.  stays in  for cross-attempt grouping.

## Changes

- **`open-sse/handlers/chatCore/attemptLogging.ts`**: Changed `saveCallLog({ id: pendingRequestId })` to `saveCallLog({ id: traceId })` in `persistAttemptLogs`
- **`tests/unit/13481-combo-calllog-unique-collision.test.ts`**: Test verifying two attempts under the same correlationId with different trace ids both persist

## Test results

1/1 test passes:
- ✔ two attempts with different trace ids under same correlation both persist

Existing calllogs tests pass (26/26).