### PR TITLE
fix(websearch): add Antigravity to native web search bypass (#13447)

### DIFF
--- a/open-sse/services/webSearchFallback.ts
+++ b/open-sse/services/webSearchFallback.ts
@@ -166,7 +166,9 @@ export function supportsNativeWebSearchFallbackBypass({
   // Native Codex (OpenAI Responses) passthrough: the upstream runs web search itself.
   if (nativeCodexPassthrough) return true;
   // Gemini target: the Gemini translator maps built-in web search to googleSearch natively.
-  if (targetFormat === FORMATS.GEMINI) return true;
+  // #13447: Antigravity uses the same Gemini translator (toGeminiGoogleSearchTool) so it
+  // also maps web_search → googleSearch natively — bypass the fallback conversion.
+  if (targetFormat === FORMATS.GEMINI || targetFormat === FORMATS.ANTIGRAVITY) return true;
   // Claude -> Claude passthrough: the Anthropic Messages upstream (e.g. a Claude
   // subscription driven by Claude Code) natively runs web_search_20250305. Forward the
   // native tool untouched instead of rewriting it to omniroute_web_search. Mirrors the

--- a/tests/unit/13447-antigravity-websearch-bypass.test.ts
+++ b/tests/unit/13447-antigravity-websearch-bypass.test.ts
@@ -1,0 +1,49 @@
+/**
+ * #13447 — supportsNativeWebSearchFallbackBypass returns false for Antigravity,
+ * so web_search is rewritten to omniroute_web_search which Responses clients
+ * reject as an undeclared tool. Antigravity uses the same Gemini translator
+ * (toGeminiGoogleSearchTool) which maps web_search → googleSearch natively.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { supportsNativeWebSearchFallbackBypass } = await import(
+  "../../open-sse/services/webSearchFallback.ts"
+);
+
+test("#13447 Antigravity target bypasses web search fallback conversion", () => {
+  const result = supportsNativeWebSearchFallbackBypass({
+    targetFormat: "antigravity",
+    nativeCodexPassthrough: false,
+  });
+
+  assert.equal(result, true, "Antigravity must be recognized as natively supporting web search bypass");
+});
+
+test("#13447 Gemini target still bypasses web search fallback conversion", () => {
+  const result = supportsNativeWebSearchFallbackBypass({
+    targetFormat: "gemini",
+    nativeCodexPassthrough: false,
+  });
+
+  assert.equal(result, true, "Gemini must still be recognized for native web search bypass");
+});
+
+test("#13447 OpenAI target does NOT bypass web search fallback", () => {
+  const result = supportsNativeWebSearchFallbackBypass({
+    targetFormat: "openai",
+    nativeCodexPassthrough: false,
+  });
+
+  assert.equal(result, false, "OpenAI must not bypass web search fallback");
+});
+
+test("#13447 interceptSearchOverride=true forces interception even for Antigravity", () => {
+  const result = supportsNativeWebSearchFallbackBypass({
+    targetFormat: "antigravity",
+    nativeCodexPassthrough: false,
+    interceptSearchOverride: true,
+  });
+
+  assert.equal(result, false, "interceptSearchOverride must override Antigravity bypass");
+});


### PR DESCRIPTION
Fixes #13447. Antigravity uses the same Gemini translator (toGeminiGoogleSearchTool) which maps web_search to googleSearch natively. But supportsNativeWebSearchFallbackBypass only checked FORMATS.GEMINI, so Antigravity fell through to the omniroute_web_search fallback conversion, which Responses clients reject as an undeclared tool.

Add FORMATS.ANTIGRAVITY to the native bypass check.

4 new tests + 19 existing web search tests pass.