### PR TITLE
fix(compression): preserve polarity words and newlines in ultra heuristic (#13454)

### DIFF
--- a/open-sse/services/compression/ultraHeuristic.ts
+++ b/open-sse/services/compression/ultraHeuristic.ts
@@ -19,18 +19,12 @@ export const STOPWORDS = new Set([
   "have",
   "has",
   "had",
-  "do",
-  "does",
-  "did",
   "will",
   "would",
   "could",
-  "should",
   "may",
   "might",
   "shall",
-  "can",
-  "need",
   "dare",
   "ought",
   "used",
@@ -59,7 +53,6 @@ export const STOPWORDS = new Set([
   "and",
   "but",
   "or",
-  "nor",
   "for",
   "yet",
   "so",
@@ -88,8 +81,6 @@ export const STOPWORDS = new Set([
   "even",
   "still",
   "already",
-  "always",
-  "never",
   "often",
   "usually",
   "sometimes",
@@ -97,8 +88,26 @@ export const STOPWORDS = new Set([
   "there",
 ]);
 
+// #13454: Polarity / modality words that carry the constraint of an instruction.
+// Dropping them inverts meaning ("never delete" → "delete"), which is worse
+// than not compressing at all.  Scored 1.0 like FORCE_PRESERVE_RE tokens.
+export const POLARITY_WORDS = new Set([
+  "never", "always", "no", "not", "nor",
+  "do", "does", "did", "don't", "doesn't", "didn't",
+  "should", "shouldn't",
+  "can", "cannot", "can't",
+  "must", "mustn't",
+  "need", "needs", "needed",
+  "shall", "shallnot",
+  "won't", "wouldn't", "couldn't", "maynot", "mightnot",
+]);
+
 /** Regex for tokens that must never be pruned */
 export const FORCE_PRESERVE_RE = /\d|https?:\/\/|[._\/\\]|Error:|Exception:|```/i;
+
+// #13454: Combined polarity + force-preserve check.  Called before the STOPWORDS
+// lookup so polarity words always score 1.0 regardless of length.
+const POLARITY_RE = /^(?:never|always|no|not|nor|do(?:es(?:n't)?|n't)?|did(?:n't)?|should(?:n't)?|can(?:not|'t)?|must(?:n't)?|ne(?:ed(?:s|ed)?|n't)|shall(?:not)?|won't|wouldn't|couldn't|shouldn't|didn't|doesn't|don't|can't|mustn't|needn't|isn't|aren't|wasn't|weren't|hasn't|haven't|hadn't)$/i;
 
 /**
  * Score a single token (word/symbol) for information value.
@@ -106,6 +115,9 @@ export const FORCE_PRESERVE_RE = /\d|https?:\/\/|[._\/\\]|Error:|Exception:|```/
  */
 export function scoreToken(token: string): number {
   if (FORCE_PRESERVE_RE.test(token)) return 1.0;
+  // #13454: polarity / modality words must never be pruned — dropping them
+  // inverts the instruction ("never delete" → "delete").
+  if (POLARITY_RE.test(token)) return 1.0;
   const lower = token.toLowerCase();
   if (STOPWORDS.has(lower)) return 0.1;
   if (token.length <= 2) return 0.2;
@@ -152,6 +164,8 @@ export function pruneByScore(text: string, keepRate = 0.5, minScore = 0.3): stri
       return keep ? t : "";
     })
     .join("")
-    .replace(/\s{2,}/g, " ")
+    .replace(/[ \t]{2,}/g, " ")
+    .replace(/ \n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/tests/unit/13454-ultra-heuristic-negation-preservation.test.ts
+++ b/tests/unit/13454-ultra-heuristic-negation-preservation.test.ts
@@ -1,0 +1,72 @@
+/**
+ * #13454 — Ultra heuristic prunes negations/absolutes and collapses newlines,
+ * inverting instructions. Before the fix, polarity words (never, always, no,
+ * do, should, etc.) were in STOPWORDS (score 0.1) or short-token bucket (0.2),
+ * both below the default 0.3 threshold. Also, pruneByScore collapsed all
+ * whitespace including newlines via /\s{2,}/g.
+ *
+ * The fix removes polarity words from STOPWORDS, adds POLARITY_RE (score 1.0),
+ * and changes the whitespace collapse to only compress spaces/tabs, not newlines.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { scoreToken, pruneByScore, STOPWORDS, POLARITY_WORDS } = await import(
+  "../../open-sse/services/compression/ultraHeuristic.ts"
+);
+
+test("#13454 polarity words are not in STOPWORDS", () => {
+  for (const word of ["never", "always", "no", "do", "does", "did", "should", "can", "need", "nor"]) {
+    assert.ok(!STOPWORDS.has(word), `"${word}" must not be in STOPWORDS (polarity word)`);
+  }
+});
+
+test("#13454 polarity words score 1.0 (must never be pruned)", () => {
+  for (const word of ["never", "always", "no", "not", "nor", "do", "does", "did",
+    "should", "can", "must", "need", "don't", "doesn't", "can't", "mustn't", "won't"]) {
+    const score = scoreToken(word);
+    assert.equal(score, 1.0, `"${word}" must score 1.0, got ${score}`);
+  }
+});
+
+test("#13454 pruneByScore keeps all negation words in the sample", () => {
+  const block = `- NEVER run \`rm -rf\` on the target host. Always ask first.
+- Do not push to \`main\` directly; open a PR.
+- The backup files \`.app-prev-*\` must never be deleted.
+- Never store the SSH password on disk.
+- Always run \`npm test\` before \`npm run build\`.
+- Do NOT edit files under \`/etc\` by hand.`;
+
+  const result = pruneByScore(block, 0.5, 0.3);
+
+  // All polarity words must survive
+  for (const word of ["NEVER", "Always", "never", "Never", "Always", "NOT"]) {
+    assert.ok(
+      result.includes(word),
+      `polarity word "${word}" must survive pruning, got: ${result.slice(0, 200)}`
+    );
+  }
+});
+
+test("#13454 pruneByScore preserves newlines (bullet lists stay as lines)", () => {
+  const block = `- NEVER run \`rm -rf\` on the target host.
+- Do not push to \`main\` directly.
+- Always run \`npm test\` before \`npm run build\`.`;
+
+  const result = pruneByScore(block, 0.5, 0.3);
+
+  // Must contain at least 2 newlines (3 lines → at least 2 separators)
+  const newlineCount = (result.match(/\n/g) || []).length;
+  assert.ok(
+    newlineCount >= 2,
+    `expected at least 2 newlines in result, got ${newlineCount}: ${result.slice(0, 200)}`
+  );
+});
+
+test("#13454 basic stopwords still score low (pruning still works for filler)", () => {
+  // Common filler words should still be prunable
+  assert.equal(scoreToken("the"), 0.1);
+  assert.equal(scoreToken("a"), 0.1);
+  assert.equal(scoreToken("is"), 0.1);
+  assert.equal(scoreToken("are"), 0.1);
+});


### PR DESCRIPTION
Fixes #13454. The ultra heuristic STOPWORDS set contained polarity/modality words (never, always, no, do, should, can, need, nor) scored at 0.1, below the 0.3 threshold. This inverted instructions: 'must never be deleted' became 'must deleted'. Also pruneByScore collapsed all whitespace including newlines.

Remove polarity words from STOPWORDS, add POLARITY_RE scored 1.0, and change whitespace collapse to only compress spaces/tabs.

5 new tests + 40 existing ultra tests pass.