### PR TITLE
fix: run caveman user preservePatterns before built-in patterns

### DIFF
--- a/open-sse/services/compression/preservation.ts
+++ b/open-sse/services/compression/preservation.ts
@@ -125,7 +125,13 @@ export function extractPreservedBlocks(
     },
   ];
 
-  for (const { pattern, kind } of [...builtIns, ...compileUserPatterns(options.preservePatterns)]) {
+  // #13457: User patterns MUST run before built-ins.  Built-ins replace content
+  // with sentinels; if they run first, a user pattern whose match spans a
+  // sentinel-bearing region hits the `includes(SENTINEL_PREFIX)` guard and is
+  // silently skipped -- the operator's preservation rule is ignored with no
+  // warning.  Running user patterns first lets them claim the full region,
+  // and built-ins then skip the sentinel placeholders harmlessly.
+  for (const { pattern, kind } of [...compileUserPatterns(options.preservePatterns), ...builtIns]) {
     result = replacePattern(result, ensureGlobal(pattern), kind, addBlock);
   }
 


### PR DESCRIPTION
Closes diegosouzapw/OmniRoute#13457

## Problem

When `cavemanConfig.preservePatterns` included a regex whose match region overlapped with a built-in pattern (inline code span, heading, URL, etc.), the user pattern was silently skipped.

### Root cause

In `preservation.ts`, built-in patterns ran first and replaced sub-regions with sentinel placeholders. When user patterns then matched the same region, the `includes(SENTINEL_PREFIX)` guard in `replacePattern` detected the sentinel and returned the match unchanged — the operator's preservation rule was ignored with no warning.

### Evidence

The concrete example from the issue:
```ts
const PAT = /<system-reminder>[\s\S]*?<\/system-reminder>/.source;
```
Input: `<system-reminder>\nThe backup files \`.app-prev-*\` must never be deleted.\n</system-reminder>`

Before: Built-in `inline_code` matched \`.app-prev-*\` first → user pattern's full match now contains sentinel → silently skipped → rule never preserved.

## Fix

Reversed the pattern execution order in `extractPreservedBlocks`:
- **Before**: `[...builtIns, ...compileUserPatterns(...)]`
- **After**: `[...compileUserPatterns(...), ...builtIns]`

User patterns now claim the full region first. Built-ins then skip the sentinel placeholders harmlessly. No behavioral change when no user patterns are configured.

## Tests

Added `tests/unit/13457-caveman-user-patterns-before-builtins.test.ts` (4 test cases):
- User pattern protects region containing inline code span
- User pattern protects region containing markdown heading
- User pattern protects region containing URL
- Baseline: no user patterns → built-ins still work as before

All 25 existing caveman preservation/engine tests remain green.

---

*Test plan: verified locally — `node --import tsx/esm --test`*