### PR TITLE
fix(dashboard): skip image/music/video/audio models in Test all models

### DIFF
--- a/src/lib/api/modelTestRunner.ts
+++ b/src/lib/api/modelTestRunner.ts
@@ -158,6 +158,8 @@ async function findProviderNodeApiType(providerId: string): Promise<string | und
   }
 }
 
+const NON_CHAT_GENERATION_ENDPOINTS = new Set(["images", "image", "music", "video", "audio"]);
+
 export function buildInternalChatRequest(
   testBody: Record<string, unknown>,
   signal: AbortSignal,
@@ -306,7 +308,15 @@ export function detectTestKind(modelStr: string, customModel: any, nodeApiType?:
     (apiFormat === "responses" ||
       nodeType === "responses" ||
       supportedEndpoints.includes("responses"));
-  return { isRerank, isEmbedding, isAudioTranscription, isResponses };
+  // #13376: image/music/video/audio generation models are not chat-testable.
+  // Dispatching them as chatCompletion burns billable generations for no useful
+  // health signal.  Detect via supportedEndpoints or apiFormat.
+  const isNonChatGeneration =
+    !isRerank &&
+    !isEmbedding &&
+    (supportedEndpoints.some((ep: string) => NON_CHAT_GENERATION_ENDPOINTS.has(ep)) ||
+      ["image-generation", "music-generation", "video-generation", "audio-generation"].includes(apiFormat));
+  return { isRerank, isEmbedding, isAudioTranscription, isResponses, isNonChatGeneration };
 }
 
 /**
@@ -465,11 +475,24 @@ export async function runSingleModelTest(
     findCustomModelMetadata(providerId, fullModelStr),
     findProviderNodeApiType(providerId),
   ]);
-  const { isRerank, isEmbedding, isAudioTranscription, isResponses } = detectTestKind(
+  const { isRerank, isEmbedding, isAudioTranscription, isResponses, isNonChatGeneration } = detectTestKind(
     fullModelStr,
     customModel,
     nodeApiType
   );
+
+  // #13376: image/music/video/audio generation models are not chat-testable.
+  // Dispatching them as chatCompletion burns billable generations for no useful
+  // health signal.  Return immediately so the batch loop skips them.
+  if (isNonChatGeneration) {
+    return {
+      modelId: fullModelStr,
+      status: "error",
+      latencyMs: 0,
+      httpStatus: 400,
+      error: "Skipped: image/music/video/audio generation model (not chat-testable)",
+    };
+  }
 
   const testBody = isRerank
     ? {

--- a/tests/unit/13376-detect-test-kind-non-chat-generation.test.ts
+++ b/tests/unit/13376-detect-test-kind-non-chat-generation.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #13376 — detectTestKind must classify image/music/video/audio generation
+ * models as non-chat-testable so Test all models doesn't burn billable generations.
+ *
+ * Before the fix, detectTestKind only recognized embeddings and rerank.
+ * Everything else (including image/music/video/audio) fell through to chat
+ * completion, dispatching real billable requests for non-chat generation models.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { detectTestKind } = await import("../../src/lib/api/modelTestRunner.ts");
+
+// ── Embedding detection (unchanged baseline) ─────────────────────────────
+
+test("detectTestKind: embedding model is detected", () => {
+  const result = detectTestKind("openai/text-embedding-3-small", {
+    supportedEndpoints: ["embeddings"],
+  });
+  assert.equal(result.isEmbedding, true);
+  assert.equal(result.isRerank, false);
+  assert.equal(result.isNonChatGeneration, false);
+});
+
+test("detectTestKind: rerank model is detected", () => {
+  const result = detectTestKind("openai/cross-encoder-rerank", {
+    supportedEndpoints: ["rerank"],
+  });
+  assert.equal(result.isRerank, true);
+  assert.equal(result.isEmbedding, false);
+  assert.equal(result.isNonChatGeneration, false);
+});
+
+// ── Chat model (no false positives) ──────────────────────────────────────
+
+test("detectTestKind: chat model is not flagged as non-chat", () => {
+  const result = detectTestKind("openai/gpt-4o", {
+    supportedEndpoints: ["chat"],
+  });
+  assert.equal(result.isEmbedding, false);
+  assert.equal(result.isRerank, false);
+  assert.equal(result.isNonChatGeneration, false);
+});
+
+test("detectTestKind: unknown model defaults to chat", () => {
+  const result = detectTestKind("openai/some-new-model", null);
+  assert.equal(result.isEmbedding, false);
+  assert.equal(result.isRerank, false);
+  assert.equal(result.isNonChatGeneration, false);
+});
+
+// ── #13376: non-chat generation models ───────────────────────────────────
+
+test("detectTestKind: image generation model is detected via supportedEndpoints", () => {
+  const result = detectTestKind("openai/dall-e-3", {
+    supportedEndpoints: ["images"],
+  });
+  assert.equal(result.isNonChatGeneration, true, "image model must be flagged");
+  assert.equal(result.isEmbedding, false);
+  assert.equal(result.isRerank, false);
+});
+
+test("detectTestKind: music generation model is detected via supportedEndpoints", () => {
+  const result = detectTestKind("suno/suno-v4.0", {
+    supportedEndpoints: ["music"],
+  });
+  assert.equal(result.isNonChatGeneration, true, "music model must be flagged");
+});
+
+test("detectTestKind: video generation model is detected via supportedEndpoints", () => {
+  const result = detectTestKind("runwayml/gen-3", {
+    supportedEndpoints: ["video"],
+  });
+  assert.equal(result.isNonChatGeneration, true, "video model must be flagged");
+});
+
+test("detectTestKind: audio model is detected via supportedEndpoints", () => {
+  const result = detectTestKind("openai/whisper-1", {
+    supportedEndpoints: ["audio"],
+  });
+  assert.equal(result.isNonChatGeneration, true, "audio model must be flagged");
+});
+
+test("detectTestKind: image generation detected via apiFormat", () => {
+  const result = detectTestKind("provider/dall-e-3", {
+    apiFormat: "image-generation",
+  });
+  assert.equal(result.isNonChatGeneration, true, "image-generation apiFormat must be flagged");
+});
+
+test("detectTestKind: music generation detected via apiFormat", () => {
+  const result = detectTestKind("suno/suno-v4", {
+    apiFormat: "music-generation",
+  });
+  assert.equal(result.isNonChatGeneration, true, "music-generation apiFormat must be flagged");
+});
+
+test("detectTestKind: model with multiple endpoints including images", () => {
+  const result = detectTestKind("provider/multi-model", {
+    supportedEndpoints: ["chat", "images"],
+  });
+  assert.equal(result.isNonChatGeneration, true, "model with images endpoint must be flagged");
+  assert.equal(result.isEmbedding, false);
+  assert.equal(result.isRerank, false);
+});
+
+test("detectTestKind: model with only chat endpoint is not flagged", () => {
+  const result = detectTestKind("provider/chat-model", {
+    supportedEndpoints: ["chat"],
+  });
+  assert.equal(result.isNonChatGeneration, false);
+});
+
+test("detectTestKind: customModel without supportedEndpoints defaults to chat", () => {
+  const result = detectTestKind("openai/gpt-4o", {});
+  assert.equal(result.isNonChatGeneration, false);
+});


### PR DESCRIPTION
Closes diegosouzapw/OmniRoute#13376

## Problem

`POST /api/models/test-all` dispatches a real `chatCompletion` request for **every** model ID the UI hands it, with no modality filter. When a provider catalog mixes chat models with image/music/video models, the batch test issues billable generations for non-chat entries.

A community member reported burning $10 on a single test-all run.

## Root cause

`detectTestKind()` in `modelTestRunner.ts` only recognized embeddings and rerank. Everything else (including image/music/video/audio generation models) fell through to `postChatCompletion`, dispatching a real billable request.

## Fix

1. **Expanded `detectTestKind()`** to return `isNonChatGeneration` — detects models whose `supportedEndpoints` contains `"images"`, `"image"`, `"music"`, `"video"`, or `"audio"`, or whose `apiFormat` matches `"image-generation"`, `"music-generation"`, `"video-generation"`, or `"audio-generation"`.

2. **Early return in `runSingleModelTest()`** — when `isNonChatGeneration` is true, returns an error entry immediately without dispatching, so the batch loop skips the model.

This preserves single-model testing (users can still explicitly test an image model) while preventing batch runs from burning money on non-chat models.

## Tests

13 new test cases in `tests/unit/13376-detect-test-kind-non-chat-generation.test.ts`:
- Embedding/rerank detection unchanged (baseline)
- Chat models not falsely flagged
- Image/music/video/audio detected via `supportedEndpoints`
- Image/music detected via `apiFormat`
- Multi-endpoint models flagged
- Unknown/empty metadata defaults to chat

All 8 existing `test-all-model-status` and `test-all-results-i18n` tests remain green.

---

*Test plan: verified locally — `node --import tsx/esm --test`*