### PR TITLE
fix(opencode-plugin): surface cache age in disk fallback log and escalate level

### DIFF
--- a/@omniroute/opencode-plugin/src/index.ts
+++ b/@omniroute/opencode-plugin/src/index.ts
@@ -5518,9 +5518,20 @@ export function createOmniRouteConfigHook(
         if (modelsFetchThrew && wantDiskCache && !warmSnapshot) {
           const snapshot = await diskSnapshotReader(resolved.providerId, snapshotFingerprint);
           if (snapshot && snapshot.rawModels.length > 0) {
+            // #13390: include cache age in log message so staleness is self-diagnosing.
+            // A few minutes stale is routine; days stale warrants investigation.
+            const cacheAgeMs = typeof snapshot.writtenAt === "number" ? Date.now() - snapshot.writtenAt : 0;
+            const cacheAgeHuman = cacheAgeMs > 0
+              ? cacheAgeMs < 3_600_000
+                ? `${Math.round(cacheAgeMs / 60_000)}m`
+                : cacheAgeMs < 86_400_000
+                  ? `${Math.round(cacheAgeMs / 3_600_000)}h`
+                  : `${Math.round(cacheAgeMs / 86_400_000)}d`
+              : "age unknown";
+            const logLevel = cacheAgeMs > 86_400_000 ? "error" : "warn";
             logAt(
-              "warn",
-              `config shim: /v1/models unreachable; using stale disk cache (${snapshot.rawModels.length} models)`
+              logLevel,
+              `config shim: /v1/models unreachable; using stale disk cache from ${new Date(snapshot.writtenAt ?? 0).toISOString().slice(0, 10)} (${cacheAgeHuman} old, ${snapshot.rawModels.length} models)`
             );
             localRawModels = snapshot.rawModels;
             localRawCombos = snapshot.rawCombos;


### PR DESCRIPTION
Closes diegosouzapw/OmniRoute#13390

## Problem

When `/v1/models` is unreachable, the opencode-plugin falls back to its on-disk catalog cache. The old log message only reported model count:

```
[omniroute-plugin] config shim: /v1/models unreachable; using stale disk cache (1325 models)
```

This made it impossible to distinguish a 5-minute-old cache from a week-old one. A community member spent hours diagnosing what turned out to be a week-stale catalog.

## Fix

1. **Return `writtenAt` from `defaultDiskSnapshotReader`** — the field was already written to the JSON snapshot but discarded by the reader. Now surfaced so the fallback code can compute age.

2. **Include cache date and human-readable age in the log message:**
```
[omniroute-plugin] config shim: /v1/models unreachable; using stale disk cache from 2026-09-05 (7d old, 1325 models)
```

3. **Escalate log level with staleness:**
   - `<1d` stale → `warn` (routine, e.g. offline laptop)
   - `>1d` stale → `error` (warrants investigation)

## Why this is safe

- Pure observability change — no behavioral change to the fallback path itself
- The `writtenAt` field was already persisted; the reader just didn't return it
- Log level escalation only affects logging, not fallback behavior
- Existing noop reader returns `undefined` which is compatible with the updated type

## Tests

Added `tests/13390-disk-snapshot-written-at.test.ts` (3 test cases):
- Reader returns `writtenAt` matching write timestamp
- Corrupt file returns `undefined` (no crash)
- Missing file returns `undefined`

Note: opencode-plugin tests require `@opencode-ai/plugin` which isn't available in the monorepo dev environment. The fix is verified by the type-safe reader change and follows the exact pattern of the existing `disk-snapshot-perms.test.ts`.

---

*Test plan: verified code compiles — `@opencode-ai/plugin` dependency required for full test run*