### PR TITLE
fix(gemini): strip JSON-Schema 2020-12 prefixItems/additionalItems from tool schemas

### DIFF
--- a/open-sse/translator/helpers/geminiHelper.ts
+++ b/open-sse/translator/helpers/geminiHelper.ts
@@ -33,6 +33,11 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYS = new Set([
   // upstream 400s and wrong-tool semantics (decolua/9router#1368).
   "minItems",
   "maxItems",
+  // JSON-Schema 2020-12 tuple-array keywords not recognized by Gemini's
+  // OpenAPI 3.0-style function_declarations.  Leaving them in triggers a
+  // hard 400 ("Unknown name \"prefixItems\"").  See #13464.
+  "prefixItems",
+  "additionalItems",
   "format",
   // Claude rejects these in VALIDATED mode
   "default",

--- a/tests/unit/13464-gemini-prefix-items-stripping.test.ts
+++ b/tests/unit/13464-gemini-prefix-items-stripping.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Issue #13464: Gemini tool-call requests fail 400 with "Unknown name prefixItems"
+ *
+ * OpenAI/Claude tool schemas use JSON-Schema 2020-12 keywords like `prefixItems`
+ * and `additionalItems` for tuple arrays. Gemini's function_declarations only
+ * accept draft-07-style schemas and reject these with HTTP 400.
+ *
+ * The fix adds `prefixItems` and `additionalItems` to the set of unsupported
+ * schema keys that get stripped by `cleanJSONSchemaForAntigravity` before the
+ * schema is forwarded to the Gemini API.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  cleanJSONSchemaForAntigravity,
+  GEMINI_UNSUPPORTED_SCHEMA_KEYS,
+} from "../../open-sse/translator/helpers/geminiHelper.ts";
+
+describe("Issue #13464 — Gemini prefixItems / additionalItems stripping", () => {
+  it("prefixItems is in the unsupported set", () => {
+    assert.ok(
+      GEMINI_UNSUPPORTED_SCHEMA_KEYS.has("prefixItems"),
+      "prefixItems must be stripped before sending to Gemini"
+    );
+  });
+
+  it("additionalItems is in the unsupported set", () => {
+    assert.ok(
+      GEMINI_UNSUPPORTED_SCHEMA_KEYS.has("additionalItems"),
+      "additionalItems must be stripped before sending to Gemini"
+    );
+  });
+
+  it("cleanJSONSchemaForAntigravity strips prefixItems from nested tool parameters", () => {
+    // Simulates a typical OpenAI tool schema with a tuple-array parameter.
+    const schema = {
+      type: "object",
+      properties: {
+        coordinates: {
+          type: "array",
+          prefixItems: [
+            { type: "number", description: "latitude" },
+            { type: "number", description: "longitude" },
+          ],
+          minItems: 2,
+          maxItems: 2,
+        },
+      },
+      required: ["coordinates"],
+    };
+
+    const cleaned = cleanJSONSchemaForAntigravity(schema) as Record<string, unknown>;
+    const coords = cleaned.properties as Record<string, Record<string, unknown>>;
+    const coordinates = coords.coordinates;
+
+    // prefixItems must be removed
+    assert.equal(
+      coordinates.prefixItems,
+      undefined,
+      "prefixItems should be stripped from nested property schema"
+    );
+
+    // minItems / maxItems must also be removed (already in the unsupported set)
+    assert.equal(coordinates.minItems, undefined, "minItems should be stripped");
+    assert.equal(coordinates.maxItems, undefined, "maxItems should be stripped");
+
+    // The top-level type:"array" must survive
+    assert.equal(coordinates.type, "array", "type:array should be preserved");
+  });
+
+  it("cleanJSONSchemaForAntigravity strips additionalItems from nested schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          additionalItems: { type: "number" },
+        },
+      },
+    };
+
+    const cleaned = cleanJSONSchemaForAntigravity(schema) as Record<string, unknown>;
+    const props = cleaned.properties as Record<string, Record<string, unknown>>;
+    const tags = props.tags;
+
+    assert.equal(tags.additionalItems, undefined, "additionalItems should be stripped");
+    // items must survive — it's a supported keyword
+    assert.deepEqual(
+      tags.items,
+      { type: "string" },
+      "items should be preserved alongside stripped additionalItems"
+    );
+  });
+
+  it("Gemini function-declaration-style tool with prefixItems is cleaned", () => {
+    // Simulates the full tool object as it flows through buildGeminiTools.
+    const geminiTool = {
+      functionDeclarations: [
+        {
+          name: "get_coordinates",
+          description: "Get GPS coordinates",
+          parameters: {
+            type: "object",
+            properties: {
+              location: {
+                type: "array",
+                prefixItems: [
+                  { type: "number" },
+                  { type: "number" },
+                ],
+                minItems: 2,
+              },
+            },
+            required: ["location"],
+          },
+        },
+      ],
+    };
+
+    const cleaned = cleanJSONSchemaForAntigravity(
+      geminiTool.functionDeclarations[0].parameters
+    ) as Record<string, unknown>;
+    const props = cleaned.properties as Record<string, Record<string, unknown>>;
+    const location = props.location;
+
+    assert.equal(location.prefixItems, undefined, "prefixItems must be stripped");
+    assert.equal(location.minItems, undefined, "minItems must be stripped");
+    assert.equal(location.type, "array", "type:array must survive");
+
+    // The function declaration structure is intact
+    assert.equal(cleaned.type, "object", "root type:object must survive");
+  });
+});


### PR DESCRIPTION
Fixes #13464

## Problem

Every tool-calling request routed to a Gemini model fails with HTTP 400:

```
Invalid JSON payload received. Unknown name "prefixItems"
at 'tools[0].function_declarations[...].parameters.properties[...].value.items':
Cannot find field.
```

OpenAI and Claude tool schemas use JSON-Schema 2020-12 keywords like `prefixItems` and `additionalItems` for tuple arrays. Gemini's `function_declarations` only accept draft-07-style schemas and reject these keywords outright. This makes Gemini completely unusable for any tool-using client (~450 errors/day per machine per the reporter).

## Fix

Add `prefixItems` and `additionalItems` to `GEMINI_UNSUPPORTED_SCHEMA_KEYS` so they get stripped by the existing recursive `removeUnsupportedKeywords` pass in `cleanJSONSchemaForAntigravity` before the schema reaches the Gemini API.

This follows the exact same pattern used for 30+ other unsupported keywords already in the set (e.g. `minItems`, `maxItems`, `patternProperties`).

## Files changed

- `open-sse/translator/helpers/geminiHelper.ts` — added 2 keywords to unsupported set
- `tests/unit/13464-gemini-prefix-items-stripping.test.ts` — 5 tests confirming stripping works

## Testing

- All 5 new tests pass on the fix branch
- All 5 new tests fail on unpatched main (confirming the test detects the issue)
- 20/20 existing Gemini-related tests pass (no regressions)
