### PR TITLE
fix(guardrails): skip data: URI base64 payloads in CredentialMasker to prevent false-positive redaction (#13462)

### DIFF
--- a/src/lib/guardrails/credentialMasker.ts
+++ b/src/lib/guardrails/credentialMasker.ts
@@ -23,17 +23,38 @@ export interface CredentialRedactionResult {
 
 export function redactCredentials(text: string): CredentialRedactionResult {
   if (typeof text !== "string" || !text) return { text, detections: [], modified: false };
-  let result = text;
+
+  // #13462: data: URIs carry base64-encoded binary (images, audio, etc.) whose
+  // encoding can randomly collide with credential regex patterns — e.g. the
+  // Google AIza pattern matching inside a PNG's base64 stream.  Temporarily
+  // replace the base64 payload with a placeholder, redact the remaining text,
+  // then restore the original payload.
+  const DATA_URI_RE = /((?:data:[^;]+;base64,)[A-Za-z0-9+/=%]+)/g;
+  const dataUriBodies: string[] = [];
+  let prepared = text.replace(DATA_URI_RE, (_match, _body: string, offset: number) => {
+    // capture the full match including the data:…;base64, prefix
+    const full = text.slice(offset, offset + _match.length);
+    const idx = dataUriBodies.length;
+    dataUriBodies.push(full);
+    return `__DATA_URI_${idx}__`;
+  });
+
   const detections: Array<{ type: string; count: number }> = [];
   for (const p of CREDENTIAL_PATTERNS) {
     p.regex.lastIndex = 0;
-    const matches = result.match(p.regex);
+    const matches = prepared.match(p.regex);
     if (matches && matches.length > 0) {
-      result = result.replace(p.regex, p.replacement);
+      prepared = prepared.replace(p.regex, p.replacement);
       detections.push({ type: p.name, count: matches.length });
     }
   }
-  return { text: result, detections, modified: result !== text };
+
+  // Restore original data: URI payloads (unmodified)
+  if (dataUriBodies.length > 0) {
+    prepared = prepared.replace(/__DATA_URI_(\d+)__/g, (_m, idx: string) => dataUriBodies[Number(idx)]);
+  }
+
+  return { text: prepared, detections, modified: prepared !== text };
 }
 
 type JsonRecord = Record<string, unknown>;

--- a/tests/unit/13462-credential-masker-data-uri.test.tsx
+++ b/tests/unit/13462-credential-masker-data-uri.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { redactCredentials } from "../../src/lib/guardrails/credentialMasker";
+
+/**
+ * #13462 — CredentialMasker must not corrupt valid base64 image data by
+ * accidentally matching credential regex patterns inside the encoded payload.
+ */
+
+describe("redactCredentials — data URI false-positive guard (#13462)", () => {
+  /**
+   * A synthetic data URI whose base64 payload deliberately contains the
+   * Google API key prefix "AIza" followed by 35 alphanumeric chars.
+   * This mirrors the real collision observed with a PNG screenshot.
+   */
+  const DATA_URI_WITH_COLLISION =
+    "data:image/png;base64,AAAIzaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABB==";
+
+  it("does NOT redact base64 payload inside a data URI", () => {
+    const input = `Here is an image: ${DATA_URI_WITH_COLLISION}`;
+    const result = redactCredentials(input);
+    // The data URI must pass through intact
+    expect(result.text).toContain(DATA_URI_WITH_COLLISION);
+    expect(result.text).not.toContain("__DATA_URI_");
+  });
+
+  it("still redacts real Google API keys in non-data-URI text", () => {
+    const input = "My Google key is AIzaSyA1234567890abcdefghijklmnopqrstuv";
+    const result = redactCredentials(input);
+    expect(result.text).toContain("[REDACTED:google]");
+    expect(result.modified).toBe(true);
+  });
+
+  it("redacts real keys while preserving data URIs in the same string", () => {
+    const input = `Key: AIzaSyA1234567890abcdefghijklmnopqrstuv\nImage: ${DATA_URI_WITH_COLLISION}`;
+    const result = redactCredentials(input);
+    expect(result.text).toContain("[REDACTED:google]");
+    expect(result.text).toContain(DATA_URI_WITH_COLLISION);
+  });
+
+  it("handles multiple data URIs in one string", () => {
+    const uri1 = "data:image/png;base64,ABCDEF==";
+    const uri2 = "data:image/jpeg;base64,GHIJKL==";
+    const input = `${uri1} and ${uri2}`;
+    const result = redactCredentials(input);
+    expect(result.text).toContain(uri1);
+    expect(result.text).toContain(uri2);
+  });
+
+  it("returns unmodified text when no credentials or data URIs present", () => {
+    const input = "Hello, this is a normal message.";
+    const result = redactCredentials(input);
+    expect(result.text).toBe(input);
+    expect(result.modified).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

When `credentialRedactionEnabled=true`, `CredentialMaskerGuardrail` recursively scans all string values for well-known credential patterns. However, it does not account for `data:` URIs carrying base64-encoded binary (images, audio, etc.). The base64 encoding can randomly collide with credential regex patterns — for example, the Google `AIza` pattern matching inside a PNG's base64 stream.

This corrupts the image payload, causing the upstream provider to reject the request with HTTP 400.

## Fix

Temporarily replace `data:...;base64,...` URI payloads with placeholders before applying credential regex patterns, then restore the originals afterward. This ensures base64 content is never scanned for credentials.

### Changes
- `src/lib/guardrails/credentialMasker.ts`: Added data URI detection and placeholder logic in `redactCredentials()`
- `tests/unit/13462-credential-masker-data-uri.test.tsx`: 5 test cases covering:
  - Data URI with base64 collision passes through intact
  - Real credentials in non-data-URI text are still redacted
  - Mixed data URI + real credential in same string
  - Multiple data URIs in one string
  - No-op for plain text with no credentials

## Test Results
All 5 tests pass: `✓ tests/unit/13462-credential-masker-data-uri.test.tsx (5 tests)`

Closes #13462