### PR TITLE
fix(tests): relax GLM arity assertion to accept trailing buffer-size args (#13319)

### DIFF
--- a/tests/unit/glm-sse-transform-arity.test.ts
+++ b/tests/unit/glm-sse-transform-arity.test.ts
@@ -47,5 +47,6 @@ test("GLM translateSseResponse does not pass a 16th positional to the stream hel
   assert.ok(callAt >= 0);
   const call = extractParens(body, callAt + "createSSETransformStreamWithLogger".length);
   assert.equal(/65536/.test(call), false, `dead 16th arg still present:\n${call}`);
-  assert.match(call, /suppressThinkClose\s*\)\s*$/);
+  // #13319: #12925 added trailing buffer-size arguments after suppressThinkClose
+  assert.match(call, /suppressThinkClose/);
 });


### PR DESCRIPTION
## Summary

The GLM SSE transform arity test (`tests/unit/glm-sse-transform-arity.test.ts`) fails on the current `release/v3.8.51` base because commit `af49d4972` (`#12925`) added trailing buffer-size arguments after `suppressThinkClose`, but the test assertion still expects the call to end immediately with `suppressThinkClose )`.

## Root Cause

`#12770` added the arity guard with:
```ts
assert.match(call, /suppressThinkClose\s*\)\s*$/);
```

`#12925` then added three trailing positional arguments:
```ts
suppressThinkClose,
undefined,
undefined,
GLM_STREAM_BUFFER_BYTES
)
```

The product change is correct; only the test assertion is stale.

## Fix

Relax the second assertion to check for the presence of `suppressThinkClose` anywhere in the call, rather than requiring it to be the last argument before the closing paren.

## Verification

```
✔ createSSETransformStreamWithLogger has no highWaterMark slot
✔ GLM translateSseResponse does not pass a 16th positional to the stream helper
ℹ tests 2  ℹ pass 2  ℹ fail 0
```

Closes #13319