### PR TITLE
fix: increase requestQueue.maxWaitMs default from 15s to 30s

### DIFF
--- a/src/lib/resilience/settings.ts
+++ b/src/lib/resilience/settings.ts
@@ -43,8 +43,8 @@ export type {
 } from "./settings/types";
 
 export const DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS = (() => {
-  const parsed = Number(process.env.RATE_LIMIT_MAX_WAIT_MS || "15000");
-  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 15000;
+  const parsed = Number(process.env.RATE_LIMIT_MAX_WAIT_MS || "30000");
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 30000;
 })();
 
 // Limiter-managed execution backstop (Bottleneck `expiration`). Deliberately

--- a/tests/unit/ratelimit-admission-control-6593.test.ts
+++ b/tests/unit/ratelimit-admission-control-6593.test.ts
@@ -177,10 +177,10 @@ test("#6593 withRateLimit: default maxQueueDepth=0 preserves unbounded-queue beh
 
 // --- Default maxWaitMs ----------------------------------------------------
 
-test("#6593 DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS is 15s absent RATE_LIMIT_MAX_WAIT_MS", () => {
+test("#6593 DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS is 30s absent RATE_LIMIT_MAX_WAIT_MS", () => {
   assert.equal(process.env.RATE_LIMIT_MAX_WAIT_MS, undefined);
-  assert.equal(resilienceSettings.DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS, 15000);
-  assert.equal(resilienceSettings.DEFAULT_RESILIENCE_SETTINGS.requestQueue.maxWaitMs, 15000);
+  assert.equal(resilienceSettings.DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS, 30000);
+  assert.equal(resilienceSettings.DEFAULT_RESILIENCE_SETTINGS.requestQueue.maxWaitMs, 30000);
 });
 
 test("requestQueue.executionMaxWaitMs defaults to a 10-minute backstop, separate from maxWaitMs", () => {


### PR DESCRIPTION
Fixes #13504

## Changes
- Increased `DEFAULT_REQUEST_QUEUE_MAX_WAIT_MS` from 15000ms to 30000ms in `src/lib/resilience/settings.ts`
- The override via `RATE_LIMIT_MAX_WAIT_MS` env var continues to work as before

## Problem
The previous 15-second default caused premature 504 Gateway Timeout errors on slow providers (BAI, TokenRouter, Nvidia) that routinely exceed 15s for first-token on large context models like Claude Opus, GLM-5.3-free, and DeepSeek. 137 daily timeout errors were reported.

## Testing
- Verified the env var override still works for operators who need a different value
- Default change is backward-compatible: models that respond quickly are unaffected
- The downside is only that truly failed requests take longer to timeout (30s vs 15s), but retries will succeed more often