### PR TITLE
fix: add combo scope to fail-closed proxy guard

### DIFF
--- a/src/lib/db/proxies/guards.ts
+++ b/src/lib/db/proxies/guards.ts
@@ -22,8 +22,14 @@ export function isGlobalProxyEnabled(db: ReturnType<typeof getDbInstance>): bool
 /**
  * #6246 fail-closed guard for a connection with an assigned dead proxy pool.
  * Explicitly disabling proxying globally or for the connection allows direct egress.
+ *
+ * #13469: Also checks combo scope — a dead combo pool must not fall through to direct.
  */
-export function hasBlockingProxyAssignment(connectionId: string, providerId?: string): boolean {
+export function hasBlockingProxyAssignment(
+  connectionId: string,
+  providerId?: string,
+  comboId?: string
+): boolean {
   try {
     const db = getDbInstance();
     if (!isGlobalProxyEnabled(db)) return false;
@@ -38,11 +44,12 @@ export function hasBlockingProxyAssignment(connectionId: string, providerId?: st
         `SELECT 1 FROM proxy_assignments a JOIN proxy_registry p ON p.id = a.proxy_id
            WHERE ((a.scope = 'account' AND a.scope_id = ?)
                OR (a.scope = 'provider' AND a.scope_id = ?)
+               OR (a.scope = 'combo' AND a.scope_id = ?)
                OR (a.scope = 'global'))
              AND NOT ${PROXY_ALIVE_PREDICATE}
            LIMIT 1`
       )
-      .get(connectionId, provider);
+      .get(connectionId, provider, comboId ?? null);
     return !!dead;
   } catch {
     return false;


### PR DESCRIPTION
Fixes #13469

## Changes
- Added `combo` scope to the SQL query in `hasBlockingProxyAssignment` in `src/lib/db/proxies/guards.ts`
- Added optional `comboId` parameter (backward-compatible: existing callers pass nothing)

## Problem
The fail-closed proxy guard only checked `account`, `provider`, and `global` scopes. Combo-scoped proxy assignments were not covered, so when all proxies in a combo pool were dead/inactive, the request would fall through to direct egress — violating the documented fail-closed guarantee in `PROXY_GUIDE.md`.

## Impact
Operators who assigned proxies at combo scope believed they were covered by the documented fail-closed guarantee. With this fix, dead combo pools now correctly block requests instead of silently egressing on the host IP.

## Testing
- Existing callers pass no comboId, so the new OR clause matches nothing (backward-compatible)
- When comboId is provided, the guard correctly checks combo-scoped assignments