### PR TITLE
fix(auth): skip /v1/models auth when no management credentials exist

### DIFF
--- a/src/app/api/v1/models/catalogRequest.ts
+++ b/src/app/api/v1/models/catalogRequest.ts
@@ -18,6 +18,21 @@ export async function getModelCatalogAuthRejection(
   if (!authRequired) return null;
   if (settings.requireAuthForModels === false) return null;
 
+  // Keyless local-first guard (#13354): when no management auth is configured
+  // (no password, no OIDC, no INITIAL_PASSWORD, and no API keys in the DB),
+  // skip auth for /v1/models. This preserves the pre-#9320 posture for
+  // installs that deliberately chose not to set up any auth, while still
+  // requiring auth when management credentials exist.
+  const hasPassword =
+    typeof settings.password === "string" && settings.password.length > 0;
+  const hasOidc = settings.oidcEnabled === true;
+  const hasInitialPassword = !!process.env.INITIAL_PASSWORD;
+  if (!hasPassword && !hasOidc && !hasInitialPassword) {
+    const { getApiKeys } = await import("@/lib/db/apiKeys");
+    const keys = await getApiKeys(1);
+    if (keys.length === 0) return null;
+  }
+
   const apiKey = extractApiKey(request);
   if (apiKey) {
     if (await validateCatalogApiKey(apiKey)) return null;


### PR DESCRIPTION
Fixes #13354

## Changes
- Added keyless local-first guard in `getModelCatalogAuthRejection`
- When no management auth is configured (no password, no OIDC, no INITIAL_PASSWORD, no API keys in DB), auth is skipped for `/v1/models`
- Preserves the pre-#9320 posture for installs that deliberately chose not to set up auth
- Still requires auth when management credentials exist (password, OIDC, API keys)

## Root Cause
After #9320, `getModelCatalogAuthRejection` was changed from opt-in (`requireAuthForModels === true`) to opt-out (`requireAuthForModels === false`). For keyless installs where `setupComplete === true` but no password is configured, `isAuthRequired()` returns true, causing 401 on every `/v1/models` request.

## Testing
- Keyless install (no password, no API keys): `GET /v1/models` now returns 200
- Install with password configured: `GET /v1/models` still requires auth
- Install with API keys: `GET /v1/models` still requires auth