### PR TITLE
fix(eval): add dotAll flag to regex grading for multiline answers

### DIFF
--- a/src/lib/evals/evalRunner.ts
+++ b/src/lib/evals/evalRunner.ts
@@ -155,8 +155,11 @@ export function evaluateCase(evalCase: any, actualOutput: string) {
         }
         const regex =
           expectedValue instanceof RegExp
-            ? new RegExp(expectedValue.source, expectedValue.flags.replace(/[gy]/g, ""))
-            : new RegExp(expectedValue);
+            ? new RegExp(
+                expectedValue.source,
+                (expectedValue.flags.replace(/[gy]/g, "") + "s").split("").sort().join("")
+              )
+            : new RegExp(expectedValue, "s");
         if (regex.source.length > 512) {
           passed = false;
           details.error = "Regex pattern too large for safe evaluation.";

--- a/tests/unit/combo-silent-stop-gaps.test.ts
+++ b/tests/unit/combo-silent-stop-gaps.test.ts
@@ -254,6 +254,30 @@ test("G7: benign regex still evaluates normally", () => {
   assert.equal(result.passed, true);
 });
 
+
+test("G7: regex with dotAll matches multiline answers", () => {
+  const result = evaluateCase(
+    {
+      id: "dotall-test",
+      name: "dotall-test",
+      expected: { strategy: "regex", value: "hello.*world" },
+    },
+    "hello\nworld"
+  );
+  assert.equal(result.passed, true, "dotAll regex should match across newlines");
+});
+
+test("G7: RegExp object with dotAll flag works correctly", () => {
+  const result = evaluateCase(
+    {
+      id: "dotall-regex-obj",
+      name: "dotall-regex-obj",
+      expected: { strategy: "regex", value: /hello.*world/ },
+    },
+    "hello\nworld"
+  );
+  assert.equal(result.passed, true, "RegExp with dotAll should match across newlines");
+});
 // ── G8: autoRefreshDaemon logs network errors per provider ──────────────────
 test("G8: autoRefreshDaemon logs network errors instead of swallowing them", async () => {
   const { autoRefreshDaemon } = await import("../../open-sse/services/autoRefreshDaemon.ts");


### PR DESCRIPTION
Fixes #13138

## Changes
- Added `s` (dotAll) flag to regex compilation in `evaluateCase()` so `.` matches newlines
- Applied to both the RegExp object branch and the string branch
- Added two test cases verifying multiline matching works correctly

## Root Cause
Eval regex grading compiled string patterns with no flags, leaving `dotAll` off. Since LLM answers are routinely multi-line, the `.` metacharacter failed to match newlines, causing correct answers to be marked wrong.