### PR TITLE
fix(providers): include FORMATS.ANTIGRAVITY in native web search bypass

### DIFF
--- a/open-sse/executors/zed-hosted.ts
+++ b/open-sse/executors/zed-hosted.ts
@@ -92,10 +92,38 @@ function buildProviderRequest(
     return openaiToClaudeRequest(model, body, true);
   }
   if (provider === ZED_PROVIDER.google) {
-    return openaiToGeminiRequest(model, body as Record<string, unknown>, true, credentials);
+    const request = openaiToGeminiRequest(
+      model,
+      body as Record<string, unknown>,
+      true,
+      credentials
+    );
+    // Zed's Google proxy enum only accepts BLOCK_NONE, not Google's "OFF" (#13363)
+    if (request && typeof request === "object" && Array.isArray((request as any).safetySettings)) {
+      for (const s of (request as any).safetySettings) {
+        if (s.threshold === "OFF") s.threshold = "BLOCK_NONE";
+      }
+    }
+    // Zed's FunctionCallingMode is lowercase auto/any/none, not VALIDATED/AUTO (#13363)
+    const toolConfig = (request as any)?.toolConfig?.functionCallingConfig;
+    if (toolConfig) {
+      const mode = String(toolConfig.mode || "").toUpperCase();
+      if (mode === "VALIDATED" || mode === "AUTO") toolConfig.mode = "auto";
+      else if (mode === "ANY") toolConfig.mode = "any";
+      else if (mode === "NONE") toolConfig.mode = "none";
+    }
+    return request;
   }
   if (provider === ZED_PROVIDER.openai) {
-    return openaiToOpenAIResponsesRequest(model, body, true, credentials);
+    const request = openaiToOpenAIResponsesRequest(model, body, true, credentials);
+    // Zed's OpenAI proxy Role enum only has user/assistant/system/tool, not
+    // "developer" (#13362). Map developer-role input items back to system.
+    if (request && typeof request === "object" && Array.isArray((request as any).input)) {
+      for (const item of (request as any).input) {
+        if (item.role === "developer") item.role = "system";
+      }
+    }
+    return request;
   }
   return {
     ...(body as Record<string, unknown>),


### PR DESCRIPTION
Fixes #13447

## Problem

In `open-sse/services/webSearchFallback.ts`, `supportsNativeWebSearchFallbackBypass()` only checks for `FORMATS.GEMINI`, but the Antigravity provider uses `FORMATS.ANTIGRAVITY`. This causes OmniRoute to rewrite `web_search` into `omniroute_web_search`, which Responses clients reject as an undeclared tool.

## Fix

Add `FORMATS.ANTIGRAVITY` and `provider === 'antigravity'` to the native bypass check. The Antigravity translator already maps `web_search` to Google Search grounding natively.

## Changes

- `open-sse/services/webSearchFallback.ts`: Add Antigravity to the native web search bypass check