### PR TITLE
fix(auth): model-scoped lockout on passthrough provider credit exhaustion

### DIFF
--- a/open-sse/services/accountFallback.ts
+++ b/open-sse/services/accountFallback.ts
@@ -1956,18 +1956,16 @@ export function checkFallbackError(
       }
     }
 
-    // T10 (sub2api #1169) + #8247: credits/quota exhausted; *-compatible-* nicknames stay model-scoped
+    // T10 (sub2api #1169) + #8247: credits/quota exhausted; per-model-quota providers stay model-scoped
     // unless the body is an account-level Open Platform empty wallet.
-    if (
-      shouldUseQuotaSignal &&
-      isCreditsExhausted(errorStr) &&
-      (!isCompatibleProvider(provider) || isMoonshotAccountBalanceExhausted(errorStr))
-    ) {
+    if (shouldUseQuotaSignal && isCreditsExhausted(errorStr)) {
       return {
         shouldFallback: true,
         cooldownMs: COOLDOWN_MS.paymentRequired ?? 3600 * 1000, // 1h cooldown
         reason: RateLimitReason.QUOTA_EXHAUSTED,
-        creditsExhausted: true,
+        ...(!hasPerModelQuota(provider, _model) || isMoonshotAccountBalanceExhausted(errorStr)
+          ? { creditsExhausted: true }
+          : {}),
       };
     }
 

--- a/src/sse/services/auth.ts
+++ b/src/sse/services/auth.ts
@@ -2965,17 +2965,27 @@ export async function markAccountUnavailable(
       );
       return { shouldFallback: true, cooldownMs: lockout.cooldownMs };
     }
+    const isModelLevelQuotaOrRateLimit =
+      !fallbackResult.permanent &&
+      (fallbackResult.reason === RateLimitReason.QUOTA_EXHAUSTED ||
+        Boolean(fallbackResult.creditsExhausted) ||
+        fallbackResult.reason === RateLimitReason.RATE_LIMIT_EXCEEDED);
     if (
       isPerModelQuotaProvider &&
       provider &&
       provider !== "codex" &&
       model &&
-      (status === 404 || isNvidiaModelGone || status === 429 || status >= 500)
+      (status === 404 ||
+        isNvidiaModelGone ||
+        status === 429 ||
+        status >= 500 ||
+        isModelLevelQuotaOrRateLimit)
     ) {
       const reason =
         status === 404 || isNvidiaModelGone
           ? "not_found"
-          : status === 429 && fallbackResult.reason === RateLimitReason.QUOTA_EXHAUSTED
+          : fallbackResult.reason === RateLimitReason.QUOTA_EXHAUSTED ||
+              fallbackResult.creditsExhausted
             ? "quota_exhausted"
             : status === 429
               ? "rate_limited"

--- a/tests/unit/auth-passthrough-credit-lockout.test.ts
+++ b/tests/unit/auth-passthrough-credit-lockout.test.ts
@@ -1,0 +1,151 @@
+// Test for per-model credit exhaustion on passthrough providers (e.g. b.ai, aggregators).
+// When a specific model fails with HTTP 400 "credit insufficient balance: balance=0"
+// or quota exhaustion, it must lock out ONLY that model, keeping the connection active
+// so other models (e.g. free models like qwen3.8-flash) on the same key remain usable.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "omniroute-bai-credit-"));
+process.env.DATA_DIR = TEST_DATA_DIR;
+
+const core = await import("../../src/lib/db/core.ts");
+const providersDb = await import("../../src/lib/db/providers.ts");
+const auth = await import("../../src/sse/services/auth.ts");
+const accountFallback = await import("../../open-sse/services/accountFallback.ts");
+
+const BAI_INSUFFICIENT_BALANCE_400 =
+  "[400]: credit insufficient balance: balance=0 required=6792 (request id: 20260913093939137112807c955d5685unboZPV)";
+
+async function resetStorage() {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(TEST_DATA_DIR, { recursive: true });
+}
+
+interface SeededConn {
+  id: string;
+}
+
+async function seedConnection(
+  provider: string,
+  extra: Record<string, unknown> = {}
+): Promise<SeededConn> {
+  const conn = await providersDb.createProviderConnection({
+    provider,
+    authType: "apikey",
+    apiKey: "test-key",
+    isActive: true,
+    testStatus: "active",
+    ...extra,
+  });
+  return conn as unknown as SeededConn;
+}
+
+test.after(() => {
+  core.resetDbInstance();
+  fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+});
+
+test("b.ai HTTP 400 credit insufficient balance locks only the requested model, connection stays active", async () => {
+  await resetStorage();
+  accountFallback.clearAllModelLockouts();
+
+  const conn = await seedConnection("bai", {
+    name: "ggdayup",
+  });
+
+  const result = await auth.markAccountUnavailable(
+    conn.id,
+    400,
+    BAI_INSUFFICIENT_BALANCE_400,
+    "bai",
+    "glm-5.3-flash"
+  );
+
+  assert.equal(result.shouldFallback, true);
+  assert.ok(result.cooldownMs > 0);
+
+  // Connection must NOT be terminated or rate-limited connection-wide
+  const after = await providersDb.getProviderConnectionById(conn.id);
+  assert.equal(after?.testStatus, "active", "connection testStatus must remain active");
+  assert.ok(!after?.rateLimitedUntil, "connection rateLimitedUntil must not be set");
+  assert.equal(after?.lastErrorType, "quota_exhausted");
+  assert.equal(Number(after?.errorCode), 400);
+
+  // The paid/exhausted model is locked out for this connection
+  const glmLockout = accountFallback.getModelLockoutInfo("bai", conn.id, "glm-5.3-flash");
+  assert.ok(glmLockout, "glm-5.3-flash must be locked out");
+  assert.equal(glmLockout?.reason, "quota_exhausted");
+
+  // Other models on b.ai (e.g. free model qwen3.8-flash) remain eligible
+  const qwenLockout = accountFallback.getModelLockoutInfo("bai", conn.id, "qwen3.8-flash");
+  assert.equal(qwenLockout, null, "qwen3.8-flash must not be locked out");
+});
+
+test("compatible provider HTTP 400 insufficient balance locks only the model", async () => {
+  await resetStorage();
+  accountFallback.clearAllModelLockouts();
+
+  const conn = await seedConnection("openai-compatible-chat-123", {
+    name: "aggregator",
+    providerSpecificData: { passthroughModels: true },
+  });
+
+  const result = await auth.markAccountUnavailable(
+    conn.id,
+    400,
+    "insufficient balance for model claude-3-opus",
+    "openai-compatible-chat-123",
+    "claude-3-opus"
+  );
+
+  assert.equal(result.shouldFallback, true);
+
+  const after = await providersDb.getProviderConnectionById(conn.id);
+  assert.equal(after?.testStatus, "active");
+  assert.ok(!after?.rateLimitedUntil);
+
+  const opusLockout = accountFallback.getModelLockoutInfo(
+    "openai-compatible-chat-123",
+    conn.id,
+    "claude-3-opus"
+  );
+  assert.ok(opusLockout);
+  assert.equal(opusLockout?.reason, "quota_exhausted");
+
+  const freeLockout = accountFallback.getModelLockoutInfo(
+    "openai-compatible-chat-123",
+    conn.id,
+    "free-llama-3"
+  );
+  assert.equal(freeLockout, null);
+});
+
+test("single-model non-passthrough provider (openai) still terminates connection on credit exhaustion", async () => {
+  await resetStorage();
+  accountFallback.clearAllModelLockouts();
+
+  const conn = await seedConnection("openai", {
+    name: "openai-account",
+  });
+
+  const result = await auth.markAccountUnavailable(
+    conn.id,
+    400,
+    "insufficient balance",
+    "openai",
+    "gpt-4o"
+  );
+
+  assert.equal(result.shouldFallback, true);
+
+  const after = await providersDb.getProviderConnectionById(conn.id);
+  assert.equal(
+    after?.testStatus,
+    "credits_exhausted",
+    "single-model provider must be marked credits_exhausted"
+  );
+});


### PR DESCRIPTION
## Summary
When a provider with passthrough models (e.g., `bai` / `thebai`, third-party aggregators, or multi-model nodes) returns HTTP 400 with `credit insufficient balance` or quota exhaustion on a specific paid model, OmniRoute previously marked the entire connection as terminal `credits_exhausted` with `rateLimitedUntil = null`.

This disabled all free or available models on the same connection (e.g., `bai/qwen3.8-flash`) until a manual "Retest" was triggered or the 30-minute background reprobe timer elapsed.

This PR ensures credit exhaustion on per-model-quota providers is properly scoped as a model-level lockout (`reason: "quota_exhausted"`) rather than a whole-connection terminal failure.

## Root Cause
1. **`checkFallbackError()` in `open-sse/services/accountFallback.ts`**:
   PR #8247 added `!isCompatibleProvider(provider)` to prevent compatible providers from emitting `creditsExhausted: true`. However, `isCompatibleProvider` only matches `openai-compatible-` / `anthropic-compatible-` prefixes, omitting built-in passthrough providers like `bai`.
2. **`markAccountUnavailable()` in `src/sse/services/auth.ts`**:
   The model-lockout conditional check was restricted to `(status === 404 || isNvidiaModelGone || status === 429 || status >= 500)`. When an upstream passthrough provider returns HTTP 400 with `credit insufficient balance`, status 400 did not match this condition, falling through to `resolveTerminalConnectionStatus()` and terminating the entire account connection.

## Key Changes
1. **Scope Quota Signal to Per-Model Providers** (`open-sse/services/accountFallback.ts`):
   Replaced `!isCompatibleProvider(provider)` with `!hasPerModelQuota(provider, _model)` when returning `creditsExhausted: true`. Built-in passthrough providers, compatible providers, and multi-model configurations now avoid emitting connection-wide `creditsExhausted`. Account-level balance exhaustion (e.g. Moonshot empty wallet) continues to terminate the whole connection as expected.
2. **Handle Model Quota Exhaustion in `markAccountUnavailable`** (`src/sse/services/auth.ts`):
   Added `isModelLevelQuotaOrRateLimit` check so that non-permanent quota/credit exhaustion (`RateLimitReason.QUOTA_EXHAUSTED` or `creditsExhausted`) triggers model-only lockout with `reason: "quota_exhausted"`. Sibling models on the same connection remain active and eligible.
3. **Unit Tests** (`tests/unit/auth-passthrough-credit-lockout.test.ts`):
   - Verified `b.ai` HTTP 400 credit insufficient balance locks only the requested model (`glm-5.3-flash`), connection remains `active`, and free model (`qwen3.8-flash`) remains unlocked.
   - Verified compatible providers continue to lock only the model.
   - Verified single-model providers (e.g. `openai`) still terminate the connection with `credits_exhausted`.

## Testing
- Ran unit tests:
  ```bash
  node --import tsx/esm --test tests/unit/auth-passthrough-credit-lockout.test.ts tests/unit/auth-ollama-cloud-per-model-403-3027.test.ts tests/unit/account-fallback.test.ts tests/unit/auth-account-fallback.test.ts
  ```
  All passed cleanly.
- ESLint and Prettier checks passed with 0 errors.