### PR TITLE
fix(memory): merge memory into top-level system field when present

### DIFF
--- a/src/lib/memory/injection.ts
+++ b/src/lib/memory/injection.ts
@@ -165,6 +165,14 @@ function injectSystemFirst(
   count: number
 ): ChatRequest {
   log.info("memory.injection.injected", { count, strategy: "system-first", model: request.model });
+
+  // #13425: When the body carries a top-level `system` field (Anthropic-shaped
+  // requests), merge memory text into it instead of unshifting a role:"system"
+  // message at messages[0] — Anthropic rejects a system role at index 0.
+  if (typeof request.system === "string" && request.system.length > 0) {
+    return { ...request, system: `${memoryText}\n${request.system}` };
+  }
+
   const first = messages[0];
   if (first && first.role === "system") {
     const merged: ChatMessage = { ...first, content: `${memoryText}\n${first.content}` };


### PR DESCRIPTION
Fixes #13425

## Problem

When memory injection is enabled and the body has a top-level `system` field (Anthropic-shaped requests), `injectSystemFirst()` unshifted a new `{role:'system'}` at `messages[0]`. Anthropic rejects this with 400: `use the top-level 'system' parameter for the initial system prompt`.

## Fix

Check `request.system` before inspecting `messages[0]`. When a top-level `system` field is present (string), merge memory text into it. Fall back to the existing messages-based strategy otherwise.

## Changes

- `src/lib/memory/injection.ts`: Added top-level `system` field check in `injectSystemFirst()`